### PR TITLE
refactor: enable 'static pageset

### DIFF
--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -1,6 +1,6 @@
 //! Proving and verifying inclusion, non-inclusion, and updates to the trie.
 
-use crate::page::{MissingPage, PageSet, PageSetCursor};
+use crate::page::{MissingPage, PageSet, PageSetCursor, RawPage};
 use crate::trie::{InternalData, KeyPath, LeafData, Node, NodeHasher, NodeHasherExt, TERMINATOR};
 
 use alloc::vec::Vec;
@@ -167,9 +167,9 @@ impl VerifiedPathProof {
 ///
 /// This returns the sibling nodes and the terminal node encountered when looking up
 /// a key. This is always either a terminator or leaf.
-pub fn record_path(
+pub fn record_path<P: core::borrow::Borrow<RawPage>>(
     root: Node,
-    pages: &PageSet,
+    pages: &PageSet<P>,
     key: &KeyPath,
 ) -> Result<(Node, Siblings), MissingPage> {
     let mut cursor = PageSetCursor::new(root, pages);


### PR DESCRIPTION
This addresses review on #29 that the `Page<'a>` struct having a lifetime is too unwieldy.

There are 4 approaches I considered to working around this:
  1. Change `Page` to own the data. This is a non-starter as it inhibits any kind of intelligent arena allocation.
  2. Change `PageSet` to be generic over a `Page: Borrow<RawPage>`. This introduces a generic which is somewhat unwieldy but also allows high flexibility. This approach is taken in this PR.
  3. Make `PageSet` a trait rather than a struct. I actually quite like this approach, as it pushes indexing and managing tree relationships between pages up the stack while limiting the amount of generics: just write `impl PageSet` in most places and you're good to go. I may revisit and do this instead later. (https://github.com/thrumdev/nomt/pull/33)
  4. Make `Page` a concrete type that references into an arena directly, with ref-counted mechanics. I didn't like this approach as the page arena is a backend responsibility.