### PR TITLE
page_id: error handling in child_page_id

### DIFF
--- a/core/src/page.rs
+++ b/core/src/page.rs
@@ -223,7 +223,9 @@ impl<'a, P: PageSet + 'a> PageSetCursor<'a, P> {
                 CursorLocation::Root => ROOT_PAGE_ID,
                 CursorLocation::Page(p) => {
                     let child_page_idx = last_page_path(&self.path, self.depth).load_be::<u8>();
-                    child_page_id(*p.id(), child_page_idx)
+                    child_page_id(*p.id(), child_page_idx).expect(
+                        "Child index is 6 bits and Pages do not go deeper than the maximum layer, 42"
+                    )
                 }
             };
 

--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -28,14 +28,67 @@ pub type PageId = [u8; 32];
 /// It has an ID consisting of all zeros.
 pub const ROOT_PAGE_ID: [u8; 32] = [0; 32];
 
+/// The PageId of the leftmost page of the last layer of the page tree.
+/// It is the lowest PageId beyond which all pages with a PageId equal to
+/// or higher overflow if a child is attempted to be accessed
+pub const LOWEST_42: [u8; 32] = [
+    0, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65,
+    4, 16, 65, 4, 16, 65,
+];
+
 const MAX_CHILD_INDEX: u8 = (1 << DEPTH) - 1;
 
 /// Construct the Child PageId given the previous PageId and the child index.
 ///
 /// Child index must be a 6 bit integer, two most significant bits must be zero.
-pub fn child_page_id(mut page_id: PageId, child_index: u8) -> PageId {
-    // TODO: proper error handling
-    assert!(child_index <= MAX_CHILD_INDEX);
+/// Passed PageId must be a valid PageId and be located in a layer below 42 otherwise
+/// `PageIdOverflow` will be returned.
+pub fn child_page_id(mut page_id: PageId, child_index: u8) -> Result<PageId, ChildPageIdError> {
+    if child_index > MAX_CHILD_INDEX {
+        return Err(ChildPageIdError::InvalidChildIndex);
+    }
+
+    // RootPageId is at layer zero, the second layer has index one
+    // and so on. There are 43 layers.
+    //
+    // For each layer between 1 and 42 the lowest id for layer I is:
+    //
+    // L(I) = sum_i(2^(6 * i)) where i goes from 0 to I - 1
+    //
+    // while the highest id for each layer is:
+    //
+    // H(I) = L(I) + 2^(6 * I) - 1 = sum_i(2^(6 * i)) where i goes from 1 to I
+    //
+    // So for each layer bigger than 0 the range of PageIds are:
+    //
+    // [L(I)..=H(I)]
+    //
+    // And L(I) = H(I - 1) + 1
+    //
+    // Any PageId larger than or equal to L(42) will overflow.
+    // L(42) and H(41) have the same most significant bit
+    // set to one at position 246, resulting in 9 leading zeros.
+    // If the PageId passed as an argument has fewer than 9 leading zeros,
+    // it will definitely overflow. If it has exactly 9 leading zeros,
+    // it needs to be compared to L(42). If it is higher than L(42),
+    // it will overflow.
+    let leading_zeros = page_id.view_bits::<Msb0>().leading_zeros();
+    if leading_zeros < 9 {
+        return Err(ChildPageIdError::PageIdOverflow);
+    } else if leading_zeros == 9 {
+        let mut lower = false;
+
+        for (byte, byte_lowest) in page_id.iter().zip(LOWEST_42.iter()) {
+            if byte < byte_lowest {
+                lower = true;
+                break;
+            }
+        }
+
+        if !lower {
+            return Err(ChildPageIdError::PageIdOverflow);
+        }
+    }
 
     let page_id_bits = page_id.view_bits_mut::<Msb0>();
 
@@ -63,7 +116,7 @@ pub fn child_page_id(mut page_id: PageId, child_index: u8) -> PageId {
         page_id_bits[256 - DEPTH..256]
             .copy_from_bitslice(&(child_index + 1).view_bits::<Msb0>()[2..]);
     };
-    page_id
+    Ok(page_id)
 }
 
 /// Extract the Parent PageId given a PageId.
@@ -84,6 +137,16 @@ pub fn parent_page_id(mut page_id: PageId) -> PageId {
 
     page_id_bits.shift_right(DEPTH);
     page_id
+}
+
+/// Errors related to the construction of a Child PageId
+#[derive(Debug, PartialEq)]
+pub enum ChildPageIdError {
+    /// Child index must be made by only the first 6 bits in a byte
+    InvalidChildIndex,
+    /// PageId was at the last layer of the page tree
+    /// or it was too big to represent a valid page
+    PageIdOverflow,
 }
 
 /// Iterator of PageIds over a KeyPath,
@@ -113,7 +176,9 @@ impl<'a> Iterator for PageIdsIterator<'a> {
             Some(prev_page_id) => {
                 // If sextets are finished, then there are no more pages to load
                 let child_index = self.sextets.next()?.load_be::<u8>();
-                Some(child_page_id(prev_page_id, child_index))
+                Some(child_page_id(prev_page_id, child_index).expect(
+                    "Child index is 6 bits and Pages do not go deeper than the maximum layer, 42",
+                ))
             }
         };
         self.page_id = new_page_id;
@@ -133,25 +198,26 @@ mod tests {
         let mut page_id_1 = [0u8; 32]; // child index 6
         page_id_1[31] = 0b00000111;
 
-        assert_eq!(page_id_1, child_page_id(page_id_0, 6));
+        assert_eq!(Ok(page_id_1), child_page_id(page_id_0, 6));
         assert_eq!(page_id_0, parent_page_id(page_id_1));
 
         let mut page_id_2 = page_id_0; // child index 4
         page_id_2[31] = 0b11000101;
         page_id_2[30] = 0b00000001;
 
-        assert_eq!(page_id_2, child_page_id(page_id_1, 4));
+        assert_eq!(Ok(page_id_2), child_page_id(page_id_1, 4));
         assert_eq!(page_id_1, parent_page_id(page_id_2));
 
         let mut page_id_3 = page_id_0; // child index 63
         page_id_3[31] = 0b10000000;
         page_id_3[30] = 0b01110001;
 
-        assert_eq!(page_id_3, child_page_id(page_id_2, MAX_CHILD_INDEX));
+        assert_eq!(Ok(page_id_3), child_page_id(page_id_2, MAX_CHILD_INDEX));
         assert_eq!(page_id_2, parent_page_id(page_id_3));
     }
+
     #[test]
-    fn test_get_page_ids() {
+    fn test_page_ids_iterator() {
         // key_path = 0b000001|000010|0...
         let mut key_path = [0u8; 32];
         key_path[0] = 0b00000100;
@@ -184,5 +250,66 @@ mod tests {
         assert_eq!(page_ids.next(), Some(page_id_0));
         assert_eq!(page_ids.next(), Some(page_id_1));
         assert_eq!(page_ids.next(), Some(page_id_2));
+    }
+
+    #[test]
+    fn invalid_child_index() {
+        assert_eq!(
+            Err(ChildPageIdError::InvalidChildIndex),
+            child_page_id(ROOT_PAGE_ID, 0b01010000)
+        );
+
+        assert_eq!(
+            Err(ChildPageIdError::InvalidChildIndex),
+            child_page_id(ROOT_PAGE_ID, 0b10000100)
+        );
+
+        assert_eq!(
+            Err(ChildPageIdError::InvalidChildIndex),
+            child_page_id(ROOT_PAGE_ID, 0b11000101)
+        );
+    }
+
+    #[test]
+    fn test_page_id_overflow() {
+        let first_page_last_layer = PageIdsIterator::new(&[0u8; 32]).last().unwrap();
+        let last_page_last_layer = PageIdsIterator::new(&[255; 32]).last().unwrap();
+        assert_eq!(
+            Err(ChildPageIdError::PageIdOverflow),
+            child_page_id(first_page_last_layer, 0)
+        );
+        assert_eq!(
+            Err(ChildPageIdError::PageIdOverflow),
+            child_page_id(last_page_last_layer, 0)
+        );
+
+        // position 255
+        let mut page_id = ROOT_PAGE_ID;
+        page_id[0] = 128;
+        assert_eq!(
+            Err(ChildPageIdError::PageIdOverflow),
+            child_page_id(page_id, 0)
+        );
+
+        // any PageId bigger than LOWEST_42 must overflow
+        page_id = LOWEST_42;
+        page_id[31] = 255;
+        assert_eq!(
+            Err(ChildPageIdError::PageIdOverflow),
+            child_page_id(page_id, 0)
+        );
+
+        // position 245
+        page_id = ROOT_PAGE_ID;
+        page_id[1] = 32;
+        assert!(child_page_id(page_id, 0).is_ok());
+
+        // neither of those two have to panic if called at most 41 times
+        let mut low = ROOT_PAGE_ID;
+        let mut high = ROOT_PAGE_ID;
+        for _ in 0..42 {
+            low = child_page_id(low, 0).unwrap();
+            high = child_page_id(high, MAX_CHILD_INDEX).unwrap();
+        }
     }
 }


### PR DESCRIPTION
Inside `traverse_children`, I used `unwrap` for one main logical reason: the operation of traversing the tree operated by the Cursor must be infallible given the information of the KeyPath. A KeyPath is an arbitrary string of 256 bits, so there should be no way to pass a wrong KeyPath that could lead to a wrong construction of the child index pased to `child_page_id`. 

Despite that, I still think it's valuable to return an error on `child_page_id`, mostly to detect possible bugs introduced during development. 

What do you think? Do you think instead it should be handled and `traverse_children` should return a more general error like `TraverseError`, not only covering `MissingPage` but also `ChildPageIdError`?
