### PR TITLE
page_id: use ruint to handle 256-bits integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ name = "nomt-core"
 version = "0.1.0"
 dependencies = [
  "bitvec",
+ "ruint",
 ]
 
 [[package]]
@@ -397,6 +398,21 @@ dependencies = [
  "libc",
  "librocksdb-sys",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f308135fef9fc398342da5472ce7c484529df23743fb7c734e0f3d472971e62"
+dependencies = [
+ "ruint-macro",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86854cf50259291520509879a5c294c3c9a4c334e9ff65071c51e42ef1e2343"
 
 [[package]]
 name = "rustc-hash"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
+ruint = { version = "1.12.1", default-features = false }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
PageId is kept as `[u8; 32]` and the conversion to
`Uint<256, 4>` is only made where PageId needs to be
treated as a 256-bits integer