### PR TITLE
page_id: move logic into struct PageId using Uint

### DIFF
--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -158,13 +158,13 @@ impl PageCache {
         // Nope, then we need to fetch the page from the store.
         let inflight = InflightFetch::new();
         let promise = inflight.promise();
-        shared.inflight.insert(page_id, inflight);
+        shared.inflight.insert(page_id.clone(), inflight);
         let task = {
             let store = self.store.clone();
             let shared = self.shared.clone();
             move || {
                 let entry = store
-                    .load_page(page_id)
+                    .load_page(page_id.clone())
                     .map(Arc::new)
                     .map_or(Page::Nil, Page::Exists);
                 let mut shared = shared.lock();
@@ -186,7 +186,7 @@ impl PageCache {
     pub fn commit(&self, tx: &mut Transaction) {
         let mut shared = self.shared.lock();
         for (page_id, page) in mem::take(&mut shared.dirty) {
-            shared.pristine.insert(page_id, page.clone());
+            shared.pristine.insert(page_id.clone(), page.clone());
             let page_data = match page {
                 Page::Nil => None,
                 Page::Exists(data) => Some(data),

--- a/nomt/src/store.rs
+++ b/nomt/src/store.rs
@@ -66,7 +66,7 @@ impl Store {
     /// Loads the given page.
     pub fn load_page(&self, page_id: PageId) -> anyhow::Result<Vec<u8>> {
         let cf = self.shared.db.cf_handle(PAGES_CF).unwrap();
-        let value = self.shared.db.get_cf(&cf, page_id.as_ref())?;
+        let value = self.shared.db.get_cf(&cf, page_id.to_bytes().as_ref())?;
         Ok(value.unwrap())
     }
 
@@ -110,8 +110,8 @@ impl Transaction {
     pub fn write_page<V: AsRef<[u8]>>(&mut self, page_id: PageId, value: Option<V>) {
         let cf = self.shared.db.cf_handle(PAGES_CF).unwrap();
         match value {
-            None => self.batch.delete_cf(&cf, page_id.as_ref()),
-            Some(value) => self.batch.put_cf(&cf, page_id.as_ref(), value),
+            None => self.batch.delete_cf(&cf, page_id.to_bytes().as_ref()),
+            Some(value) => self.batch.put_cf(&cf, page_id.to_bytes().as_ref(), value),
         }
     }
 }


### PR DESCRIPTION
Struct `PageId` now wraps `Uint<256,4>` to enable bounds checking at creation
and to allow for ordering of that struct.
This could simplifies future page caching mechanisms.