### PR TITLE
refactor: cursor API in prep for blocking on I/O and multi-update

### DIFF
--- a/core/src/cursor.rs
+++ b/core/src/cursor.rs
@@ -1,0 +1,39 @@
+//! A generic cursor through a binary merkle trie.
+//!
+//! This is not intended so much for abstraction as it is for dependency injection and testability
+//! and should not be considered stable.
+
+use crate::trie::{KeyPath, Node};
+
+/// Generic cursor over binary trie storage.
+///
+/// This is not required to give results that make sense; higher level code is required to ensure
+/// that the nodes actually hash up to a common root.
+///
+/// The API here allows moving out-of-bounds, that is, to a node whose parent is a terminal node.
+/// The behavior is implementation-defined in such cases.
+pub trait Cursor {
+    /// The current position of the cursor, expressed as a bit-path and length. Bits after the
+    /// length are irrelevant.
+    fn position(&self) -> (KeyPath, u8);
+    /// The current node.
+    fn node(&self) -> &Node;
+    /// Peek at the sibling node of the current position. At the root, gives the terminator.
+    fn peek_sibling(&self) -> &Node;
+
+    /// Rewind to the root.
+    fn rewind(&mut self);
+    /// Jump to the node at the given path. Only the first `depth` bits are relevant.
+    /// It is possible to jump out of bounds, that is, to a node whose parent is a terminal.
+    fn jump(&mut self, path: KeyPath, depth: u8);
+    /// Seek to the terminal of the given path. Returns the terminal node and its depth.
+    fn seek(&mut self, path: KeyPath) -> Option<(Node, u8)>;
+
+    /// Traverse to the sibling node of the current position. No-op at the root.
+    fn sibling(&mut self);
+    /// Traverse to a child of the current position. Provide a bit that indicates whether
+    /// the left or right child should be taken.
+    fn down(&mut self, bit: bool);
+    /// Traverse upwards by d bits. No-op if d is greater than the current position length.
+    fn up(&mut self, d: u8);
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,7 @@
 
 extern crate alloc;
 
+pub mod cursor;
 pub mod page;
 pub mod page_id;
 pub mod proof;

--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -38,7 +38,7 @@ use core::ops::{AddAssign, ShlAssign, ShrAssign, SubAssign};
 use ruint::Uint;
 
 /// A unique ID for a page.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PageId(Uint<256, 4>);
 
 /// The root page is the one containing the sub-trie directly descending from the root node.


### PR DESCRIPTION
Gets rid of a bunch of code that was unnecessary for the dummy (test) cursor implementation.

Should not be considered final, just roughly what I mapped out as needing for the update, plus the skeleton in #42 