### PR TITLE
page_id: make PageIdsIterator own the KeyPath

### DIFF
--- a/core/src/page.rs
+++ b/core/src/page.rs
@@ -218,7 +218,7 @@ impl<'a> crate::cursor::Cursor for PageSetCursor<'a> {
         }
 
         let n_pages = self.depth as usize / DEPTH;
-        let page_id = crate::page_id::PageIdsIterator::new(&self.path)
+        let page_id = crate::page_id::PageIdsIterator::new(self.path)
             .nth(n_pages)
             .expect("all keys with <= 256 bits have pages; qed");
 

--- a/nomt/src/cursor.rs
+++ b/nomt/src/cursor.rs
@@ -62,7 +62,7 @@ impl PageCacheCursor {
         }
 
         let n_pages = self.depth as usize / DEPTH;
-        let page_id = PageIdsIterator::new(&self.path)
+        let page_id = PageIdsIterator::new(self.path)
             .nth(n_pages)
             .expect("all keys with <= 256 bits have pages; qed");
 
@@ -301,7 +301,7 @@ impl PagePrefetcher {
         let rev_page_ids = {
             // Chop the destination key path into the corresponding page IDs and reverse them so
             // that we can `pop`.
-            let mut x = PageIdsIterator::new(&dest).collect::<Vec<_>>();
+            let mut x = PageIdsIterator::new(dest).collect::<Vec<_>>();
             x.reverse();
             x
         };


### PR DESCRIPTION
Probably less efficient than storing an iterator over chunks,
because now BitSlice needs to be constructed each time.
But useful to avoid propagating the requirements of dealing
with lifetimes in all structs that will store the iterator