### PR TITLE
avoid lock contention in page cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +258,12 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hdrhistogram"
@@ -398,6 +417,7 @@ dependencies = [
  "bitvec",
  "blake3",
  "crossbeam-channel",
+ "dashmap",
  "fxhash",
  "nomt-core",
  "parking_lot",
@@ -431,6 +451,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -20,3 +20,4 @@ threadpool = "1.8.1"
 bitvec = { version = "1" }
 blake3 = "1.5.1"
 fxhash = "0.2.1"
+dashmap = "5.5.3"

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -222,7 +222,7 @@ impl Nomt {
         let mut terminals = terminals.into_inner();
 
         let mut tx = self.store.new_tx();
-        let mut cursor = PageCacheCursor::at_root(prev_root, page_cache);
+        let mut cursor = page_cache.new_write_cursor(prev_root);
 
         let mut ops = vec![];
         let mut witness_builder = WitnessBuilder::default();
@@ -253,7 +253,7 @@ impl Nomt {
         cursor.rewind();
         self.shared.lock().root = cursor.node();
 
-        self.page_cache.commit(&mut tx);
+        self.page_cache.commit(cursor, &mut tx);
         self.store.commit(tx)?;
         Ok(witness)
     }
@@ -305,7 +305,7 @@ impl Session {
         let terminals = self.terminals.clone();
         let root = self.prev_root;
         let f = move || {
-            let mut cur = PageCacheCursor::at_root(root, page_cache);
+            let mut cur = page_cache.new_read_cursor(root);
             cur.seek(path);
             let (_, depth) = cur.position();
             let node = cur.node();


### PR DESCRIPTION
by leveraging rw-pass-cell for bulk locking for pages and
using a concurrent analog of HashMap.

This also localizes the dirty map in the cursor and makes
it local to the commit thread.