### PR TITLE
feat: write root in commit

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -251,7 +251,9 @@ impl Nomt {
 
         nomt_core::update::update::<Blake3Hasher>(&mut cursor, &ops, &visited_leaves);
         cursor.rewind();
+        let new_root = cursor.node();
         self.shared.lock().root = cursor.node();
+        tx.write_root(new_root);
 
         self.page_cache.commit(cursor, &mut tx);
         self.store.commit(tx)?;

--- a/nomt/src/store.rs
+++ b/nomt/src/store.rs
@@ -156,4 +156,10 @@ impl Transaction {
             Some(value) => self.batch.put_cf(&cf, page_id.to_bytes().as_ref(), value),
         }
     }
+
+    /// Write the root to metadata.
+    pub fn write_root(&mut self, root: Node) {
+        let cf = self.shared.db.cf_handle(METADATA_CF).unwrap();
+        self.batch.put_cf(&cf, b"root", &root[..]);
+    }
 }


### PR DESCRIPTION
We read the root in `Nomt::open` but never wrote it, which lead us to assume an empty DB when opening an existing one.