### PR TITLE
return new root from commit_and_prove

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -197,8 +197,8 @@ impl Nomt {
         }
     }
 
-    /// Commit the transaction and create a proof for the given session.
-    pub fn commit_and_prove(&self, session: Session) -> anyhow::Result<Witness> {
+    /// Commit the transaction and create a proof for the given session. Also, returns the new root.
+    pub fn commit_and_prove(&self, session: Session) -> anyhow::Result<(Node, Witness)> {
         let prev = self
             .session_cnt
             .swap(0, std::sync::atomic::Ordering::Relaxed);
@@ -257,7 +257,7 @@ impl Nomt {
 
         self.page_cache.commit(cursor, &mut tx);
         self.store.commit(tx)?;
-        Ok(witness)
+        Ok((new_root, witness))
     }
 }
 


### PR DESCRIPTION
returns the newly computed root from `commit_and_prove`.

This is less racy and is more aligned with the API shape we 
had in mind originally.
