### PR TITLE
fuzz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,10 +221,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "flate2"
@@ -322,6 +358,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +404,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -431,6 +484,16 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "ruint",
+]
+
+[[package]]
+name = "nomt-fuzz"
+version = "0.0.0"
+dependencies = [
+ "arbitrary",
+ "libfuzzer-sys",
+ "nomt",
+ "tempfile",
 ]
 
 [[package]]
@@ -626,6 +689,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.38.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +737,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +774,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "benchtop",
-    "core",
-    "nomt",
-]
+members = ["benchtop", "core", "nomt", "fuzz"]
 
 [workspace.package]
 authors = ["thrum"]

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nomt-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1.3.1", features = ["derive"] }
+tempfile = "3.10.1"
+
+[dependencies.nomt]
+path = "../nomt"
+
+[[bin]]
+name = "api_surface"
+path = "fuzz_targets/api_surface.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/api_surface.rs
+++ b/fuzz/fuzz_targets/api_surface.rs
@@ -1,0 +1,249 @@
+#![no_main]
+
+use std::collections::{HashMap, HashSet};
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use nomt::{KeyPath, KeyReadWrite, Nomt, Options, Value};
+
+fuzz_target!(|run: Run| {
+    let db = open_db(run.traversal_concurrency, run.fetch_concurrency);
+
+    for call in run.calls.calls {
+        match call {
+            NomtCall::BeginSession { session_calls } => {
+                let mut session = db.begin_session();
+                for session_call in session_calls {
+                    match session_call {
+                        SessionCall::TentativeRead {
+                            key_path,
+                            expected_value,
+                        } => {
+                            let actual_value = session.tentative_read_slot(key_path).unwrap();
+                            assert_eq!(actual_value, expected_value);
+                        }
+                        SessionCall::TentativeWrite { key_path } => {
+                            session.tentative_write_slot(key_path);
+                        }
+                        SessionCall::CommitAndProve { keys } => {
+                            let _ = db.commit_and_prove(session, keys);
+                            break;
+                        }
+                        SessionCall::Drop => {
+                            drop(session);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+});
+
+struct Context {
+    /// All the key paths that have been created, irregardless of whether they have been committed
+    /// or not.
+    key_paths: HashSet<KeyPath>,
+    /// The key value pairs that have been committed into the store.
+    ///
+    /// The u32 is the index of the key path in `key_paths`.
+    committed: HashMap<KeyPath, Value>,
+}
+
+impl Context {
+    fn new_key_path(
+        &mut self,
+        input: &mut arbitrary::Unstructured<'_>,
+    ) -> arbitrary::Result<Option<KeyPath>> {
+        let mut attempts = 0;
+        loop {
+            let mut key_path: [u8; 32] = [0; 32];
+            input.fill_buffer(&mut key_path)?;
+            if self.key_paths.insert(key_path) {
+                return Ok(Some(key_path));
+            }
+            attempts += 1;
+            if attempts > 10 {
+                return Ok(None);
+            }
+        }
+    }
+
+    fn new_value(
+        &mut self,
+        input: &mut arbitrary::Unstructured<'_>,
+    ) -> arbitrary::Result<Option<Value>> {
+        if input.arbitrary()? {
+            let mut size = *input.choose(&[0, 4096])?;
+            if input.arbitrary()? {
+                size += 1;
+            }
+            let mut buf = vec![0; size];
+            input.fill_buffer(&mut buf)?;
+            Ok(Some(buf.into()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Run {
+    traversal_concurrency: usize,
+    fetch_concurrency: usize,
+    calls: NomtCalls,
+}
+
+impl<'a> Arbitrary<'a> for Run {
+    fn arbitrary(input: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let run = Run {
+            traversal_concurrency: input.int_in_range(1..=4)?,
+            fetch_concurrency: input.int_in_range(1..=4)?,
+            calls: input.arbitrary()?,
+        };
+        Ok(run)
+    }
+}
+
+#[derive(Debug)]
+enum NomtCall {
+    BeginSession { session_calls: Vec<SessionCall> },
+}
+
+#[derive(Debug)]
+enum SessionCall {
+    TentativeRead {
+        key_path: KeyPath,
+        expected_value: Option<Value>,
+    },
+    TentativeWrite {
+        key_path: KeyPath,
+    },
+    /// Commit and prove the given keys.
+    CommitAndProve {
+        keys: Vec<(KeyPath, KeyReadWrite)>,
+    },
+    /// Instructs to drop the session without committing.
+    Drop,
+}
+
+#[derive(Debug)]
+struct NomtCalls {
+    pub calls: Vec<NomtCall>,
+}
+
+impl<'a> Arbitrary<'a> for NomtCalls {
+    fn arbitrary(input: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let call_cnt = input.int_in_range(0..=10)?;
+        let mut calls = Vec::with_capacity(call_cnt);
+
+        let mut cx = Context {
+            key_paths: HashSet::new(),
+            committed: HashMap::new(),
+        };
+
+        for _ in 0..call_cnt {
+            let session_sz = input.int_in_range(0..=1000)?;
+
+            // Collect all the available keys into a vector and destroy the non-determinism
+            // by sorting them.
+            let mut available_keys = cx.key_paths.iter().copied().collect::<Vec<_>>();
+            available_keys.sort_unstable();
+
+            let mut session: Vec<(KeyPath, KeyReadWrite)> = Vec::new();
+            for _ in 0..session_sz {
+                // Select a key: either an already used key or a brand new one.
+                let key_path: KeyPath = if !available_keys.is_empty() && input.ratio(9, 10)? {
+                    let idx = input.choose_index(available_keys.len())?;
+                    available_keys.swap_remove(idx)
+                } else {
+                    // Create a brand new key.
+                    match cx.new_key_path(input)? {
+                        Some(key_path) => key_path,
+                        None => {
+                            // No new key path was created, so we need to skip this session.
+                            break;
+                        }
+                    }
+                };
+
+                // Now, we need to choose if we want to read, write, or read-then-write with each
+                // value.
+                match *input.choose(&[0, 1, 2])? {
+                    0 => {
+                        // Check if the key has been committed, because we need our session ops be
+                        // consistent with the committed state.
+                        let value = cx.committed.get(&key_path).cloned();
+                        session.push((key_path, KeyReadWrite::Read(value)));
+                    }
+                    1 => {
+                        session.push((key_path, KeyReadWrite::Write(cx.new_value(input)?)));
+                    }
+                    2 => {
+                        // Check if the key has been committed, because we need our session ops be
+                        // consistent with the committed state.
+                        let old_value = cx.committed.get(&key_path).cloned();
+                        let new_value = cx.new_value(input)?;
+                        session.push((key_path, KeyReadWrite::ReadThenWrite(old_value, new_value)));
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            session.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+
+            // Now having an idea what the session would look like we should create the calls to the
+            // api.
+            let mut session_calls = Vec::new();
+            for (key_path, key_rw) in &session {
+                match key_rw {
+                    KeyReadWrite::ReadThenWrite(v, _) | KeyReadWrite::Read(v) => {
+                        session_calls.push(SessionCall::TentativeRead {
+                            key_path: *key_path,
+                            expected_value: v.clone(),
+                        });
+                    }
+                    KeyReadWrite::Write(_) => {
+                        session_calls.push(SessionCall::TentativeWrite {
+                            key_path: *key_path,
+                        });
+                    }
+                }
+            }
+
+            let drop_session = input.ratio(1, 5)?;
+            if drop_session {
+                session_calls.push(SessionCall::Drop);
+            } else {
+                // Update committed state.
+                for (key_path, key_rw) in &session {
+                    match key_rw {
+                        KeyReadWrite::ReadThenWrite(_, new_value)
+                        | KeyReadWrite::Write(new_value) => {
+                            if let Some(new_value) = new_value {
+                                cx.committed.insert(*key_path, new_value.clone());
+                            }
+                        }
+                        KeyReadWrite::Read(_) => {}
+                    }
+                }
+                session_calls.push(SessionCall::CommitAndProve { keys: session });
+            }
+
+            calls.push(NomtCall::BeginSession { session_calls });
+        }
+        Ok(NomtCalls { calls })
+    }
+}
+
+fn open_db(fetch_concurrency: usize, traversal_concurrency: usize) -> Nomt {
+    let tempfile = tempfile::tempdir().unwrap();
+    let db_path = tempfile.path().join("db");
+    let options = Options {
+        path: db_path,
+        fetch_concurrency,
+        traversal_concurrency,
+    };
+    Nomt::open(options).unwrap()
+}


### PR DESCRIPTION
An initial implementation of fuzzing of the API surface using libfuzzer.

First install `cargo fuzz` as shown [here](https://rust-fuzz.github.io/book/cargo-fuzz/setup.html) and then:

```
cargo fuzz run api_surface --jobs=8
```