### PR TITLE
fix: only visit leaves which have writes

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -382,6 +382,7 @@ impl WitnessBuilder {
                         path_index: i,
                     }),
             );
+            let has_writes = !terminal.writes.is_empty();
             writes.extend(
                 terminal
                     .writes
@@ -393,7 +394,7 @@ impl WitnessBuilder {
                         path_index: i,
                     }),
             );
-            if let Some(leaf) = terminal.leaf {
+            if let Some(leaf) = terminal.leaf.filter(|_| has_writes) {
                 visited_leaves.push(leaf)
             }
         }


### PR DESCRIPTION
otherwise, we'd pass incorrect info to `update::update`.