### PR TITLE
benchtop: better key path gen

### DIFF
--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -11,7 +11,7 @@ fn path(id: u64) -> KeyPath {
     let mut rng = rand_pcg::Lcg64Xsh32::from_seed(seed);
     let mut path = KeyPath::default();
     for i in 0..4 {
-        path[i] = rng.next_u32() as u8;
+        path[i * 4 ..][..4].copy_from_slice(&rng.next_u32().to_le_bytes());
     }
     path
 }


### PR DESCRIPTION
The previous iteration was not gathering enough entropy, which caused lots of collisions. The first
collision was at approximately N=28000, which isn't too far off from the expected 2^(32/2) = 65535
that we'd need in theory. The solution is to gather more bits of key material. We could probably
get away with gathering less, like 64 bits, while doing tests with millions of keys, but we can
optimize later. The XORshift should be very fast.

The current method gives 11,661 collisions in the first 10M accounts, or ~0.1% and 112 collisions in the first 1M accounts.