### PR TITLE
feat: minimize jumping in update

### DIFF
--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -254,7 +254,7 @@ pub fn verify_update<H: NodeHasher>(
             }
         };
 
-        let sub_root = crate::update::build_sub_trie::<H>(skip, leaf, ops, |_, _, _| {});
+        let sub_root = crate::update::build_sub_trie::<H>(skip, leaf, ops, |_, _| {});
 
         let mut cur_node = sub_root;
         let mut cur_layer = skip;


### PR DESCRIPTION
this is just an experiment, as it seems to have relatively little effect - it avoids a `DashMap` lookup
in a few cases and seems to improve the performance of `replace_subtrie` by about 10%. However,
that in itself is a relatively small proportion of the runtime, so the extra complexity may not be
worth it.