### PR TITLE
test: add an integration test for correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 # samply / benchtop
 profile.json
 /test
+/nomt/test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,8 +478,11 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "fxhash",
+ "hex-literal",
  "nomt-core",
  "parking_lot",
+ "rand",
+ "rand_pcg",
  "rocksdb",
  "threadpool",
 ]

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -21,3 +21,8 @@ bitvec = { version = "1" }
 blake3 = "1.5.1"
 fxhash = "0.2.1"
 dashmap = "5.5.3"
+
+[dev-dependencies]
+rand = "0.8.5"
+rand_pcg = "0.3.1"
+hex-literal = "0.4"

--- a/nomt/tests/add_remove.rs
+++ b/nomt/tests/add_remove.rs
@@ -1,0 +1,52 @@
+mod common;
+
+use common::Test;
+use hex_literal::hex;
+use nomt::Node;
+
+#[test]
+fn add_remove_1000() {
+    let mut accounts = 0;
+    let mut t = Test::new();
+    //let mut v = Vec::new();
+
+    let expected_roots = [
+        hex!("0000000000000000000000000000000000000000000000000000000000000000"),
+        hex!("4a7a6fe118037086a49ff10484f4d80b0a9f31f1060eeb1c9f0162634604b0d9"),
+        hex!("7d5b013105d7b835225256f2233a458e1a158a53d20e0d3834886df89a26c27b"),
+        hex!("1a290e07bcacfb58ddcd0b9da348c740ca1bf87b05ed96752a1503ed7c187b69"),
+        hex!("5e9abfee6d927b084fed3e1306bbe65f0880d0b7de12522c38813014927f1336"),
+        hex!("57b39e06b2ee98dccd882033eb4136f5376699128b421c83bdc7c6ca96168938"),
+        hex!("7fd75809ef0e2133102eb5e31e47cb577149dcaebb42cddeb2fd6754256b365f"),
+        hex!("7c00cb11ec8262385078613e7b7977e50b0751f8cb2384fdccc048eea02acb63"),
+        hex!("516d6911c3b0a36c9227922ca0273a4aee44886201bd186f7ee7e538a769eaa5"),
+        hex!("381b24719ff91b13d36cf0dd7622f391f4a461452ed7547a46a992ee4a4025aa"),
+        hex!("207793e2ce76c1feb68c7259f883229f985706c8cc2fcf99f481b622a54ba375"),
+    ];
+
+    let mut root = Node::default();
+    for i in 0..10 {
+        for _ in 0..100 {
+            common::set_balance(&mut t, accounts, 1000);
+            accounts += 1;
+        }
+        {
+            root = t.commit();
+        }
+
+        assert_eq!(root, expected_roots[i + 1]);
+    }
+
+    assert_eq!(root, expected_roots[10]);
+
+    for i in 0..10 {
+        for _ in 0..100 {
+            accounts -= 1;
+            common::kill(&mut t, accounts);
+        }
+        {
+            root = t.commit();
+        }
+        assert_eq!(root, expected_roots[10 - i - 1]);
+    }
+}

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -1,0 +1,109 @@
+use nomt::{KeyPath, KeyReadWrite, Node, Nomt, Options, Session};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    mem,
+    rc::Rc,
+};
+
+pub fn account_path(id: u64) -> KeyPath {
+    // KeyPaths must be uniformly distributed, but we don't want to spend time on a good hash. So
+    // the next best option is to use a PRNG seeded with the id.
+    use rand::{RngCore as _, SeedableRng as _};
+    let mut seed = [0; 16];
+    seed[0..8].copy_from_slice(&id.to_le_bytes());
+    let mut rng = rand_pcg::Lcg64Xsh32::from_seed(seed);
+    let mut path = KeyPath::default();
+    for i in 0..4 {
+        path[i * 4..][..4].copy_from_slice(&rng.next_u32().to_le_bytes());
+    }
+    path
+}
+
+fn opts() -> Options {
+    Options {
+        path: "test".into(),
+        fetch_concurrency: 1,
+        traversal_concurrency: 1,
+    }
+}
+
+pub struct Test {
+    nomt: Nomt,
+    session: Option<Session>,
+    access: HashMap<KeyPath, KeyReadWrite>,
+}
+
+impl Test {
+    pub fn new() -> Self {
+        let _ = std::fs::remove_dir_all("test");
+        let nomt = Nomt::open(opts()).unwrap();
+        let session = nomt.begin_session();
+        Self {
+            nomt,
+            session: Some(session),
+            access: HashMap::default(),
+        }
+    }
+
+    pub fn write(&mut self, id: u64, value: Option<u64>) {
+        let path = account_path(id);
+        let value = value.map(|v| Rc::new(v.to_le_bytes().to_vec()));
+        match self.access.entry(path) {
+            Entry::Occupied(mut o) => {
+                o.get_mut().write(value);
+            }
+            Entry::Vacant(v) => {
+                v.insert(KeyReadWrite::Write(value));
+            }
+        }
+        self.session.as_mut().unwrap().tentative_write_slot(path);
+    }
+
+    #[allow(unused)]
+    pub fn read(&mut self, id: u64) -> Option<u64> {
+        let path = account_path(id);
+        let to_u64 = |v: Option<&[u8]>| v.map(|v| u64::from_le_bytes(v.try_into().unwrap()));
+        let value = match self.access.entry(path) {
+            Entry::Occupied(o) => o.get().last_value().cloned(),
+            Entry::Vacant(v) => {
+                let value = self
+                    .session
+                    .as_mut()
+                    .unwrap()
+                    .tentative_read_slot(path)
+                    .unwrap();
+                v.insert(KeyReadWrite::Read(value.clone()));
+                value
+            }
+        };
+        to_u64(value.as_ref().map(|v| &v[..]))
+    }
+
+    pub fn commit(&mut self) -> Node {
+        let session = mem::take(&mut self.session).unwrap();
+        let mut actual_access: Vec<_> = mem::take(&mut self.access).into_iter().collect();
+        actual_access.sort_by_key(|(k, _)| *k);
+        self.nomt.commit_and_prove(session, actual_access).unwrap();
+        self.session = Some(self.nomt.begin_session());
+        self.nomt.root()
+    }
+}
+
+pub fn set_balance(t: &mut Test, id: u64, balance: u64) {
+    t.write(id, Some(balance));
+}
+
+#[allow(unused)]
+pub fn transfer(t: &mut Test, from: u64, to: u64, amount: u64) {
+    let from = t.read(from).unwrap_or(0);
+    let to = t.read(to).unwrap_or(0);
+    if from < amount {
+        return;
+    }
+    t.write(from, Some(from - amount));
+    t.write(to, Some(to + amount));
+}
+
+pub fn kill(t: &mut Test, from: u64) {
+    t.write(from, None);
+}


### PR DESCRIPTION
This adds an integration test for root calculation consistency when building and subsequently 
deconstructing a trie.

Annoyingly, RocksDB doesn't seem to work with a temp dir on my machine. We will address that when
other tests are added.