### PR TITLE
fix the histogram bounds

### DIFF
--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -109,7 +109,7 @@ impl Timer {
     fn new(name: &'static str) -> Self {
         Self {
             name,
-            h: hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1000000000, 3).unwrap(),
+            h: hdrhistogram::Histogram::<u64>::new(3).unwrap(),
             ops: 0,
         }
     }


### PR DESCRIPTION
Use the regular [`new`](https://docs.rs/hdrhistogram/latest/hdrhistogram/struct.Histogram.html#method.new) to create the histogram. Otherwise, it leads to value-out-of range errors during very slow operations.