### PR TITLE
experiment: rewrite page ID as list of child indices

### DIFF
--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -156,18 +156,16 @@ fn main() {
 
     let mut now = std::time::Instant::now();
     loop {
-        for _ in 0..100 {
+        for _ in 0..10_000 {
             set_balance(&mut t, accounts, 1000);
             accounts += 1;
         }
-        for _ in 0..1000 {
-            for _ in 0..accounts {
-                {
-                    let _guard = t_transfer.record();
-                    transfer(&mut t, cur_account, (cur_account + 1) % accounts, 1);
-                }
-                cur_account = (cur_account + 1) % accounts;
+        for _ in 0..accounts * 10 {
+            {
+                let _guard = t_transfer.record();
+                transfer(&mut t, cur_account, (cur_account + 1) % accounts, 1);
             }
+            cur_account = (cur_account + 1) % accounts;
         }
         {
             let _guard = t_commit.record();

--- a/core/src/page.rs
+++ b/core/src/page.rs
@@ -58,7 +58,7 @@ impl<'a> PageView<'a> {
             return Err(InvalidPage::Length);
         }
 
-        PageId::from_bytes(data[NODES_PER_PAGE + 1]).map_err(|_| InvalidPage::Id)?;
+        PageId::decode(data[NODES_PER_PAGE + 1]).map_err(|_| InvalidPage::Id)?;
 
         Ok(PageView { data })
     }
@@ -70,7 +70,7 @@ impl<'a> PageView<'a> {
 
     /// Get the page ID of the page.
     pub fn id(&self) -> PageId {
-        PageId::from_bytes(self.data[NODES_PER_PAGE + 1])
+        PageId::decode(self.data[NODES_PER_PAGE + 1])
             .expect("PageView is being created checking the validity of its PageId")
     }
 }

--- a/nomt/src/store.rs
+++ b/nomt/src/store.rs
@@ -79,7 +79,7 @@ impl Store {
     /// Loads the given page.
     pub fn load_page(&self, page_id: PageId) -> anyhow::Result<Option<Vec<u8>>> {
         let cf = self.shared.db.cf_handle(PAGES_CF).unwrap();
-        let value = self.shared.db.get_cf(&cf, page_id.to_bytes().as_ref())?;
+        let value = self.shared.db.get_cf(&cf, page_id.encode().as_ref())?;
         Ok(value)
     }
 
@@ -152,8 +152,8 @@ impl Transaction {
     pub fn write_page<V: AsRef<[u8]>>(&mut self, page_id: PageId, value: Option<V>) {
         let cf = self.shared.db.cf_handle(PAGES_CF).unwrap();
         match value {
-            None => self.batch.delete_cf(&cf, page_id.to_bytes().as_ref()),
-            Some(value) => self.batch.put_cf(&cf, page_id.to_bytes().as_ref(), value),
+            None => self.batch.delete_cf(&cf, page_id.encode().as_ref()),
+            Some(value) => self.batch.put_cf(&cf, page_id.encode().as_ref(), value),
         }
     }
 


### PR DESCRIPTION
This is based off of two observations:
  1. Warmup workers spend a decent amount of time on `child_page_id` in seek. This replaces bit operations with simply writing a byte. 
  1. (seemingly outdated) Warmup workers spending a decent amount of time in `eq`

That said, we could also use this to optimize by partitioning the page cache based off of page depth,
and other such things, as the new structure gives more semantic information than the old one.

For now, I don't recommend merging, but worth a discussion.