### PR TITLE
fix: only put write terminals when there are writes

### DIFF
--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -76,7 +76,7 @@ pub fn update<H: NodeHasher>(
             Some(t) => t,
             None => {
                 // sanity: should never occur in correct API usage.
-                return
+                return;
             }
         };
         let leaf_data = terminal.leaf.clone();

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -347,7 +347,10 @@ impl WitnessBuilder {
 
     // builds the witness, the witnessed operations, and returns additional write operations
     // for leaves which are updated but where the existing value should be preserved.
-    fn build(self, cursor: &mut PageCacheCursor) -> (Witness, WitnessedOperations, Vec<VisitedTerminal>) {
+    fn build(
+        self,
+        cursor: &mut PageCacheCursor,
+    ) -> (Witness, WitnessedOperations, Vec<VisitedTerminal>) {
         let mut paths = Vec::with_capacity(self.terminals.len());
         let mut reads = Vec::new();
         let mut writes = Vec::new();
@@ -360,7 +363,6 @@ impl WitnessBuilder {
                 terminal: terminal.leaf.clone(),
                 siblings,
             };
-
             if !terminal.writes.is_empty() {
                 visited_terminals.push(VisitedTerminal {
                     path: {

--- a/nomt/tests/add_remove.rs
+++ b/nomt/tests/add_remove.rs
@@ -25,6 +25,7 @@ fn add_remove_1000() {
 
     let mut root = Node::default();
     for i in 0..10 {
+        let _ = t.read(0);
         for _ in 0..100 {
             common::set_balance(&mut t, accounts, 1000);
             accounts += 1;


### PR DESCRIPTION
This lead to pretty large logic errors when reading, not just writing keys.

The test diff fails on master and passes with this changeset.