### PR TITLE
bench: timer updates

### DIFF
--- a/xtask/src/timer.rs
+++ b/xtask/src/timer.rs
@@ -8,8 +8,7 @@ impl Timer {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            // The minimum is 1 nanosecond and the maximum is 100 seconds
-            h: hdrhistogram::Histogram::<u64>::new_with_bounds(1, 100000000000, 3).unwrap(),
+            h: hdrhistogram::Histogram::<u64>::new(3).unwrap(),
             ops: 0,
         }
     }
@@ -39,10 +38,25 @@ impl Timer {
         println!("  ops={}", self.ops);
         for q in [0.001, 0.01, 0.25, 0.50, 0.75, 0.95, 0.99, 0.999] {
             let lat = self.h.value_at_quantile(q);
-            println!("  {}th: {} ns", q * 100.0, lat);
+            println!("  {}th: {}", q * 100.0, pretty_display_ns(lat));
         }
-        println!("   mean={} ns", self.h.mean());
+        println!("  mean={}", pretty_display_ns(self.h.mean() as u64));
         println!();
         self.ops = 0;
     }
+}
+
+fn pretty_display_ns(ns: u64) -> String {
+    // preserve 3 sig figs at minimum.
+    let (val, unit) = if ns > 100 * 1_000_000_000 {
+        (ns / 1_000_000_000, "s")
+    } else if ns > 100 * 1_000_000 {
+        (ns / 1_000_000, "ms")
+    } else if ns > 100 * 1_000 {
+        (ns / 1_000, "us")
+    } else {
+        (ns, "ns")
+    };
+
+    format!("{val} {unit}")
 }


### PR DESCRIPTION
remove histogram bounds and print prettier timings (modifications already made on benchtop in #102 #105)