### PR TITLE
chore: squash warnings

### DIFF
--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -5,7 +5,6 @@ use crate::trie::{
     self, InternalData, KeyPath, LeafData, Node, NodeHasher, NodeHasherExt, NodeKind, TERMINATOR,
 };
 
-use alloc::vec::Vec;
 use bitvec::prelude::*;
 
 /// A proof of some particular path through the trie.

--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -76,7 +76,7 @@ pub fn update<H: NodeHasher>(
             Some(t) => t,
             None => {
                 // sanity: should never occur in correct API usage.
-                return
+                return;
             }
         };
         let leaf_data = terminal.leaf.clone();

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -347,7 +347,10 @@ impl WitnessBuilder {
 
     // builds the witness, the witnessed operations, and returns additional write operations
     // for leaves which are updated but where the existing value should be preserved.
-    fn build(self, cursor: &mut PageCacheCursor) -> (Witness, WitnessedOperations, Vec<VisitedTerminal>) {
+    fn build(
+        self,
+        cursor: &mut PageCacheCursor,
+    ) -> (Witness, WitnessedOperations, Vec<VisitedTerminal>) {
         let mut paths = Vec::with_capacity(self.terminals.len());
         let mut reads = Vec::new();
         let mut writes = Vec::new();

--- a/nomt/src/rw_pass_cell.rs
+++ b/nomt/src/rw_pass_cell.rs
@@ -86,8 +86,8 @@ impl RwPassDomain {
 }
 
 enum RwGuard {
-    Read(RwLockReadGuard),
-    Write(RwLockWriteGuard),
+    Read(#[allow(unused)] RwLockReadGuard),
+    Write(#[allow(unused)] RwLockWriteGuard),
 }
 
 /// A token that allows read access to the data within one domain.

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -57,7 +57,10 @@ impl Test {
                 v.insert(KeyReadWrite::Write(value));
             }
         }
-        self.session.as_mut().unwrap().tentative_write_slot(path, is_delete);
+        self.session
+            .as_mut()
+            .unwrap()
+            .tentative_write_slot(path, is_delete);
     }
 
     #[allow(unused)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,12 +5,10 @@ mod sov_db;
 mod timer;
 
 use anyhow::Result;
-use bench::bench;
 use clap::Parser;
 use cli::{Backend, Cli, Commands, Workload};
 use nomt::NomtDB;
 use sov_db::SovDB;
-use std::rc::Rc;
 
 pub trait DB {
     /// Apply the given actions to the storage, committing them

--- a/xtask/src/nomt.rs
+++ b/xtask/src/nomt.rs
@@ -1,8 +1,8 @@
 use crate::{Action, DB};
 use fxhash::FxHashMap;
-use nomt::{KeyPath, KeyReadWrite, Node, Nomt, Options, Session};
+use nomt::{KeyPath, KeyReadWrite, Nomt, Options};
 use sha2::Digest;
-use std::{collections::hash_map::Entry, path::PathBuf, rc::Rc};
+use std::{collections::hash_map::Entry, path::PathBuf};
 
 pub struct NomtDB {
     nomt: Nomt,


### PR DESCRIPTION
removing unused imports, allow unused for guard and fmt.