### PR TITLE
refactor: fix review from 84

### DIFF
--- a/core/src/trie.rs
+++ b/core/src/trie.rs
@@ -112,9 +112,14 @@ impl LeafData {
     /// Encode the leaf node.
     pub fn encode(&self) -> NodePreimage {
         let mut node = [0u8; 64];
-        node[0..32].copy_from_slice(&self.key_path[..]);
-        node[32..64].copy_from_slice(&self.value_hash[..]);
+        self.encode_into(&mut node[..]);
         node
+    }
+
+    /// Encode the leaf node into the given slice. It must have length at least 64 or this panics.
+    pub fn encode_into(&self, buf: &mut [u8]) {
+        buf[0..32].copy_from_slice(&self.key_path[..]);
+        buf[32..64].copy_from_slice(&self.value_hash[..]);
     }
 
     /// Decode the leaf node. Fails if the provided slice is not 64 bytes.

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -233,17 +233,8 @@ impl Nomt {
                 read_write
             {
                 let value_hash = value.as_ref().map(|v| *blake3::hash(v).as_bytes());
-                let prev_value = match terminal_info.leaf.as_ref() {
-                    None => None,
-                    Some(l) if l.key_path == path => Some(l.value_hash),
-                    Some(_) => None,
-                };
                 ops.push((path, value_hash));
-                tx.write_value::<Blake3Hasher>(
-                    path,
-                    prev_value,
-                    value_hash.zip(value.as_ref().map(|v| &v[..])),
-                );
+                tx.write_value(path, value.as_ref().map(|x| &x[..]));
             }
             witness_builder.insert(path, terminal_info.clone(), &read_write);
         }


### PR DESCRIPTION
This addresses almost all of the comments from #84, which were largely style nits with one larger issue.

#84 contained hacky behavior, where the user of the Cursor had to explicitly clear leaves while also
being careful not to overwrite leaves while building a tree upwards. These were major undocumented
footguns.

This fixes that, by using `NODES_PER_PAGE` bits at the end of each page to keep track of which
positions are leaf data and which are nodes. When a node is written beyond the end of the leaf,
the leaf is invalidated and our bit vector lets us subsequently overwrite the leaf without clearing
the previous node.