### PR TITLE
opt: store node index in cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ name = "nomt-core"
 version = "0.1.0"
 dependencies = [
  "bitvec",
+ "hex",
  "ruint",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 ruint = { version = "1.12.1", default-features = false }
+hex = "0.4"
 
 [features]
 default = ["std"]

--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -294,6 +294,7 @@ pub fn build_sub_trie<H: NodeHasher>(
                     right: sibling,
                 }
             };
+
             last_node = H::hash_internal(&node_data);
             visit(this_key, (skip + layer) as u8, last_node, None);
         }


### PR DESCRIPTION
We were spending a lot of time while warming up and updating in the cursor doing bitvec ops when moving up and jumping around.

I think that this plus #97 could be interesting.