### PR TITLE
bench: add custom workload

### DIFF
--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -52,7 +52,7 @@ pub mod bench {
     pub struct WorkloadParams {
         /// Workload used by benchmarks.
         ///
-        /// Possible values are: transfer, set_balance, heavy_read, heavy_update, heavy_delete
+        /// Possible values are: transfer, set_balance/heavy_write, heavy_read, heavy_update, heavy_delete
         ///
         /// Transfer workload involves balancing transfer between two different accounts
         #[clap(default_value = "transfer")]

--- a/xtask/src/custom_workload.rs
+++ b/xtask/src/custom_workload.rs
@@ -1,0 +1,98 @@
+use crate::{
+    backend::{Action, Db},
+    timer::Timer,
+    workload::Workload,
+};
+use anyhow::Result;
+
+// The custom workload will follow these rules:
+// 1. Reads and writes are randomly and uniformly distributed over the key space.
+// 2. Deletes and updates will be performed on already present keys.
+// 3. additional_initial_capacity represents the amount of items already present
+//     in the DB in addition to the ones required to perform deletes and updates.
+// 4. Size represents the total number of operations, where reads, writes, etc
+//     are numbers that need to sum to 100 and represent a percentage of the total size.
+#[derive(Debug, Clone)]
+#[allow(unused)]
+pub struct CustomWorkload {
+    reads: u8,
+    writes: u8,
+    deletes: u8,
+    updates: u8,
+    size: u64,
+    additional_initial_capacity: u64,
+}
+
+impl CustomWorkload {
+    pub fn new(
+        reads: u8,
+        writes: u8,
+        deletes: u8,
+        updates: u8,
+        size: u64,
+        additional_initial_capacity: u64,
+    ) -> Result<Self> {
+        if reads + writes + deletes + updates != 100 {
+            anyhow::bail!("Operations (reads, writes, deletes, updates) must sum to 100");
+        }
+        Ok(Self {
+            reads,
+            writes,
+            deletes,
+            updates,
+            size,
+            additional_initial_capacity,
+        })
+    }
+}
+
+impl Workload for CustomWorkload {
+    fn run(&self, mut backend: Box<dyn Db>, timer: &mut Timer) {
+        let from_percentage = |p: u8| (self.size as f64 * p as f64 / 100.0) as u64;
+        let n_reads = from_percentage(self.reads);
+        let n_writes = from_percentage(self.writes);
+        let n_deletes = from_percentage(self.deletes);
+        let n_updates = from_percentage(self.updates);
+
+        let n_required_key = n_deletes + n_updates;
+        let initial_writes = (0..n_required_key + self.additional_initial_capacity)
+            .map(|i| Action::Write {
+                key: i.to_be_bytes().to_vec(),
+                value: Some(vec![64u8; 32]),
+            })
+            .collect();
+        backend.apply_actions(initial_writes, None);
+
+        let read_actions = (0..n_reads).map(|i| Action::Read { key: rand_key(i) });
+        let write_actions = (n_reads..n_reads + n_writes).map(|i| Action::Write {
+            key: rand_key(i),
+            value: Some(vec![8; 16]),
+        });
+
+        let delete_actions = (0..n_deletes).map(|i| Action::Write {
+            key: i.to_be_bytes().to_vec(),
+            value: None,
+        });
+        let update_actions = (n_deletes..n_deletes + n_updates).map(|i| Action::Write {
+            key: i.to_be_bytes().to_vec(),
+            value: Some(vec![2; 16]),
+        });
+
+        let actions = read_actions
+            .chain(write_actions)
+            .chain(delete_actions)
+            .chain(update_actions)
+            .collect();
+
+        backend.apply_actions(actions, Some(timer));
+    }
+}
+
+fn rand_key(id: u64) -> Vec<u8> {
+    // keys must be uniformly distributed
+    use rand::{RngCore as _, SeedableRng as _};
+    let mut seed = [0; 16];
+    seed[0..8].copy_from_slice(&id.to_le_bytes());
+    let mut rng = rand_pcg::Lcg64Xsh32::from_seed(seed);
+    rng.next_u32().to_le_bytes().to_vec()
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod bench;
 mod cli;
+mod custom_workload;
 mod nomt;
 mod sov_db;
 mod timer;

--- a/xtask/src/timer.rs
+++ b/xtask/src/timer.rs
@@ -8,8 +8,7 @@ impl Timer {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            // The minimum is 1 nanosecond and the maximum is 100 seconds
-            h: hdrhistogram::Histogram::<u64>::new_with_bounds(1, 100000000000, 3).unwrap(),
+            h: hdrhistogram::Histogram::<u64>::new(3).unwrap(),
             ops: 0,
         }
     }
@@ -39,10 +38,25 @@ impl Timer {
         println!("  ops={}", self.ops);
         for q in [0.001, 0.01, 0.25, 0.50, 0.75, 0.95, 0.99, 0.999] {
             let lat = self.h.value_at_quantile(q);
-            println!("  {}th: {} ns", q * 100.0, lat);
+            println!("  {}th: {}", q * 100.0, pretty_display_ns(lat));
         }
-        println!("   mean={} ns", self.h.mean());
+        println!("  mean={}", pretty_display_ns(self.h.mean() as u64));
         println!();
         self.ops = 0;
     }
+}
+
+fn pretty_display_ns(ns: u64) -> String {
+    // preserve 3 sig figs at minimum.
+    let (val, unit) = if ns > 100 * 1_000_000_000 {
+        (ns / 1_000_000_000, "s")
+    } else if ns > 100 * 1_000_000 {
+        (ns / 1_000_000, "ms")
+    } else if ns > 100 * 1_000 {
+        (ns / 1_000, "us")
+    } else {
+        (ns, "ns")
+    };
+
+    format!("{val} {unit}")
 }

--- a/xtask/src/workload.rs
+++ b/xtask/src/workload.rs
@@ -1,4 +1,6 @@
-use crate::{backend::Db, timer::Timer, transfer_workload::TransferWorkload};
+use crate::{
+    backend::Db, custom_workload::CustomWorkload, timer::Timer, transfer_workload::TransferWorkload,
+};
 use anyhow::Result;
 
 // Workload abstracts the type of work the DB will have to deal with.
@@ -15,30 +17,6 @@ pub trait Workload {
     fn run(&self, backend: Box<dyn Db>, timer: &mut Timer);
 }
 
-// The custom workload will follow these rules:
-// 1. Reads and writes are randomly and uniformly distributed over the key space.
-// 2. Deletes and updates will be performed on already present keys.
-// 3. additional_initial_capacity represents the amount of items already present
-//     in the DB in addition to the ones required to perform deletes and updates.
-// 4. Size represents the total number of operations, where reads, writes, etc
-//     are numbers that need to sum to 100 and represent a percentage of the total size.
-#[derive(Debug, Clone)]
-#[allow(unused)]
-pub struct CustomWorkload {
-    reads: u8,
-    writes: u8,
-    delete: u8,
-    update: u8,
-    size: u64,
-    additional_initial_capacity: u64,
-}
-
-impl Workload for CustomWorkload {
-    fn run(&self, _backend: Box<dyn Db>, _timer: &mut Timer) {
-        todo!()
-    }
-}
-
 pub fn parse(
     name: &str,
     size: u64,
@@ -51,38 +29,38 @@ pub fn parse(
             percentage_cold_transfer: percentage_cold_transfer.unwrap_or(0),
             additional_initial_capacity,
         }),
-        "set_balance" => Box::new(CustomWorkload {
-            reads: 0,
-            writes: 100,
-            delete: 0,
-            update: 0,
+        "set_balance" | "heavy_write" => Box::new(CustomWorkload::new(
+            0,   // reads
+            100, // writes
+            0,   // deletes
+            0,   // updates
             size,
             additional_initial_capacity,
-        }),
-        "heavy_read" => Box::new(CustomWorkload {
-            reads: 10,
-            writes: 90,
-            delete: 0,
-            update: 0,
+        )?),
+        "heavy_read" => Box::new(CustomWorkload::new(
+            90, // reads
+            10, // writes
+            0,  // deletes
+            0,  // updates
             size,
             additional_initial_capacity,
-        }),
-        "heavy_update" => Box::new(CustomWorkload {
-            reads: 5,
-            writes: 5,
-            delete: 0,
-            update: 90,
+        )?),
+        "heavy_update" => Box::new(CustomWorkload::new(
+            5,  // reads
+            5,  // writes
+            0,  // deletes
+            90, // updates
             size,
             additional_initial_capacity,
-        }),
-        "heavy_delete" => Box::new(CustomWorkload {
-            reads: 5,
-            writes: 5,
-            delete: 90,
-            update: 0,
+        )?),
+        "heavy_delete" => Box::new(CustomWorkload::new(
+            5,  // reads
+            5,  // writes
+            90, // deletes
+            0,  // updates
             size,
             additional_initial_capacity,
-        }),
+        )?),
         name => anyhow::bail!("invalid workload name: {}", name),
     })
 }


### PR DESCRIPTION
from the cli, it is now possible to execute workloads like:
set_balace (heavy_write), heavy_read, heavy_update, or heavy_delete