### PR TITLE
bench: separate workload init and run

### DIFF
--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -966,7 +966,6 @@ dependencies = [
  "anyhow",
  "bitvec",
  "blake3",
- "crossbeam-channel",
  "dashmap",
  "fxhash",
  "nomt-core",
@@ -980,6 +979,7 @@ name = "nomt-core"
 version = "0.1.0"
 dependencies = [
  "bitvec",
+ "hex",
  "ruint",
 ]
 

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -23,10 +23,11 @@ pub fn bench(params: Params) -> Result<()> {
         let mut timer = Timer::new(format!("{}", backend));
 
         for _ in 0..params.iteration {
-            let backend_instance = backend.instantiate();
+            let mut backend_instance = backend.instantiate();
 
+            workload.init(&mut backend_instance);
             // it's up to the workload implementation to measure the relevant parts
-            workload.run(backend_instance, &mut timer);
+            workload.run(&mut backend_instance, &mut timer);
         }
 
         timer.print();

--- a/xtask/src/transfer_workload.rs
+++ b/xtask/src/transfer_workload.rs
@@ -14,21 +14,20 @@ use crate::{
 // without counting all the accounts needed for the transfers.
 #[derive(Debug, Clone)]
 pub struct TransferWorkload {
-    pub size: u64,
-    pub percentage_cold_transfer: u8,
-    pub additional_initial_capacity: u64,
+    init_actions: Vec<Action>,
+    run_actions: Vec<Action>,
 }
 
-impl Workload for TransferWorkload {
-    fn run(&self, mut backend: Box<dyn Db>, timer: &mut Timer) {
-        // `self.size` define the numer of transfer,
-        // the total number of accounts used is `self.size * 2`
+impl TransferWorkload {
+    pub fn new(size: u64, percentage_cold_transfer: u8, additional_initial_capacity: u64) -> Self {
+        // `size` define the numer of transfer,
+        // the total number of accounts used is `size * 2`
         //
-        let n_sender_accounts = self.size;
+        let n_sender_accounts = size;
         let sender_accounts = 0..n_sender_accounts;
         // (cold) non existing accounts
         let n_cold_accounts =
-            (n_sender_accounts as f64 * (self.percentage_cold_transfer as f64 / 100.0)) as u64;
+            (n_sender_accounts as f64 * (percentage_cold_transfer as f64 / 100.0)) as u64;
         // (warm) alredy existing accounts
         let n_warm_accounts = n_sender_accounts - n_cold_accounts;
         let warm_accounts = n_sender_accounts..n_sender_accounts + n_warm_accounts;
@@ -41,21 +40,18 @@ impl Workload for TransferWorkload {
         // n_sender_accounts + n_warm_accounts..n_total_accouts are cold receiver
 
         // prepare additional random entries
-        let additional_keys = n_total_accouts..n_total_accouts + self.additional_initial_capacity;
+        let additional_keys = n_total_accouts..n_total_accouts + additional_initial_capacity;
 
         let init_balance = Some(1000u64.to_be_bytes().to_vec());
         let initial_writes: Vec<Action> = sender_accounts
             .clone()
-            .into_iter()
-            .chain(warm_accounts.into_iter())
-            .chain(additional_keys.into_iter())
+            .chain(warm_accounts)
+            .chain(additional_keys)
             .map(|id| Action::Write {
                 key: id.to_be_bytes().to_vec(),
                 value: init_balance.clone(),
             })
             .collect();
-
-        backend.apply_actions(initial_writes, None);
 
         let mut transfer_actions = vec![];
         let balance_from = Some(900u64.to_be_bytes().to_vec());
@@ -85,7 +81,19 @@ impl Workload for TransferWorkload {
             });
         }
 
-        // apply the transfer vector of actions
-        backend.apply_actions(transfer_actions, Some(timer))
+        Self {
+            init_actions: initial_writes,
+            run_actions: transfer_actions,
+        }
+    }
+}
+
+impl Workload for TransferWorkload {
+    fn init(&self, backend: &mut Box<dyn Db>) {
+        backend.apply_actions(self.init_actions.clone(), None);
+    }
+
+    fn run(&self, backend: &mut Box<dyn Db>, timer: &mut Timer) {
+        backend.apply_actions(self.run_actions.clone(), Some(timer));
     }
 }

--- a/xtask/src/workload.rs
+++ b/xtask/src/workload.rs
@@ -14,7 +14,8 @@ use anyhow::Result;
 // Each workload will set up the DB differently and reads and writes arbitrarily,
 // whether the key is not present or already present.
 pub trait Workload {
-    fn run(&self, backend: Box<dyn Db>, timer: &mut Timer);
+    fn init(&self, backend: &mut Box<dyn Db>);
+    fn run(&self, backend: &mut Box<dyn Db>, timer: &mut Timer);
 }
 
 pub fn parse(
@@ -24,11 +25,11 @@ pub fn parse(
     percentage_cold_transfer: Option<u8>,
 ) -> Result<Box<dyn Workload>> {
     Ok(match name {
-        "transfer" => Box::new(TransferWorkload {
+        "transfer" => Box::new(TransferWorkload::new(
             size,
-            percentage_cold_transfer: percentage_cold_transfer.unwrap_or(0),
+            percentage_cold_transfer.unwrap_or(0),
             additional_initial_capacity,
-        }),
+        )),
         "set_balance" | "heavy_write" => Box::new(CustomWorkload::new(
             0,   // reads
             100, // writes


### PR DESCRIPTION
Useful to avoid rebuilding all actions before applying them and
important to be able to prepare the backend and apply the actions separately.