### PR TITLE
xtask: add profiling tool

### DIFF
--- a/xtask/src/backend.rs
+++ b/xtask/src/backend.rs
@@ -33,10 +33,13 @@ impl Backend {
         vec![Backend::SovDB, Backend::Nomt]
     }
 
-    pub fn instantiate(&self) -> Box<dyn Db> {
+    // If reset is true, then erase any previous backend's database
+    // and restart from an empty database.
+    // Otherwise, use the already present database.
+    pub fn instantiate(&self, reset: bool) -> Box<dyn Db> {
         match self {
-            Backend::SovDB => Box::new(SovDB::new()),
-            Backend::Nomt => Box::new(NomtDB::new()),
+            Backend::SovDB => Box::new(SovDB::new(reset)),
+            Backend::Nomt => Box::new(NomtDB::new(reset)),
         }
     }
 }

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -23,11 +23,14 @@ pub fn bench(params: Params) -> Result<()> {
         let mut timer = Timer::new(format!("{}", backend));
 
         for _ in 0..params.iteration {
-            let mut backend_instance = backend.instantiate();
+            let mut backend_instance = backend.instantiate(true);
 
+            // TODO: if the initial capacity is large, this repetition could become time-consuming.
+            // It would be better to initialize the database once,
+            // copy it to a location, and then only run the workload for each iteration
             workload.init(&mut backend_instance);
             // it's up to the workload implementation to measure the relevant parts
-            workload.run(&mut backend_instance, &mut timer);
+            workload.run(&mut backend_instance, Some(&mut timer));
         }
 
         timer.print();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,6 +3,7 @@ mod bench;
 mod cli;
 mod custom_workload;
 mod nomt;
+mod profile;
 mod sov_db;
 mod timer;
 mod transfer_workload;
@@ -16,5 +17,7 @@ pub fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Bench(params) => bench::bench(params),
+        Commands::Profile(params) => profile::profile(params),
+        Commands::Exec(params) => profile::exec(params),
     }
 }

--- a/xtask/src/nomt.rs
+++ b/xtask/src/nomt.rs
@@ -12,8 +12,11 @@ pub struct NomtDB {
 }
 
 impl NomtDB {
-    pub fn new() -> Self {
-        let _ = std::fs::remove_dir_all("nomt_db");
+    pub fn new(reset: bool) -> Self {
+        if reset {
+            // Delete previously existing db
+            let _ = std::fs::remove_dir_all("nomt_db");
+        }
 
         let opts = Options {
             path: PathBuf::from("nomt_db"),

--- a/xtask/src/profile.rs
+++ b/xtask/src/profile.rs
@@ -1,0 +1,58 @@
+use crate::{cli::profile::Params, workload};
+use anyhow::Result;
+use std::collections::VecDeque;
+use std::process::Command;
+
+pub fn profile(params: Params) -> Result<()> {
+    // check for samply to be installed
+    Command::new("sh")
+        .args(["-c", "command", "-v", "samply"])
+        .output()
+        .map_err(|_| {
+            anyhow::anyhow!("Install sampy (`cargo install samply`) to execute profiling")
+        })?;
+
+    let workload = workload::parse(
+        params.workload.name.as_str(),
+        params.workload.size,
+        params
+            .workload
+            .initial_capacity
+            .map(|s| 1u64 << s)
+            .unwrap_or(0),
+        params.workload.percentage_cold,
+    )?;
+
+    workload.init(&mut params.backend.instantiate(true));
+
+    // TODO: make cwd independent
+    let mut samply_args: VecDeque<String> = std::env::args().collect();
+    samply_args[1] = "exec".to_string();
+    samply_args.push_front("record".to_string());
+
+    let mut profiler_command = Command::new("samply").args(samply_args).spawn()?;
+    profiler_command.wait()?;
+
+    Ok(())
+}
+
+pub fn exec(params: Params) -> Result<()> {
+    // TODO: it would be super to avoid the construction
+    // of the workload in the profiler
+    // TODO: at least avoid constructing the init_actions that will not be used
+    let workload = workload::parse(
+        params.workload.name.as_str(),
+        params.workload.size,
+        params
+            .workload
+            .initial_capacity
+            .map(|s| 1u64 << s)
+            .unwrap_or(0),
+        params.workload.percentage_cold,
+    )?;
+
+    let mut backend_instance = params.backend.instantiate(false);
+
+    workload.run(&mut backend_instance, None);
+    Ok(())
+}

--- a/xtask/src/sov_db.rs
+++ b/xtask/src/sov_db.rs
@@ -12,9 +12,11 @@ pub struct SovDB {
 }
 
 impl SovDB {
-    pub fn new() -> Self {
-        // Delete previously existing db
-        let _ = std::fs::remove_dir_all("sov_db");
+    pub fn new(reset: bool) -> Self {
+        if reset {
+            // Delete previously existing db
+            let _ = std::fs::remove_dir_all("sov_db");
+        }
 
         // Create the underlying rocks db database
         let state_db_raw = StateDB::<SnapshotManager>::setup_schema_db("sov_db").unwrap();

--- a/xtask/src/workload.rs
+++ b/xtask/src/workload.rs
@@ -26,8 +26,8 @@ impl Workload {
         backend.apply_actions(self.init_actions.clone(), None);
     }
 
-    pub fn run(&self, backend: &mut Box<dyn Db>, timer: &mut Timer) {
-        backend.apply_actions(self.run_actions.clone(), Some(timer));
+    pub fn run(&self, backend: &mut Box<dyn Db>, timer: Option<&mut Timer>) {
+        backend.apply_actions(self.run_actions.clone(), timer);
     }
 }
 


### PR DESCRIPTION
Add two commands (profile and exec) to xtask to enable executing `samply` over a custom workload

example usage: 

```rust
cd xtask
cargo run -- profile -b nomt -n heavy_read -s 10000 -c 10
```
