### PR TITLE
record path in seek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/core/src/cursor.rs
+++ b/core/src/cursor.rs
@@ -27,11 +27,6 @@ pub trait Cursor {
     /// Jump to the node at the given path. Only the first `depth` bits are relevant.
     /// It is possible to jump out of bounds, that is, to a node whose parent is a terminal.
     fn jump(&mut self, path: KeyPath, depth: u8);
-    /// Seek to the terminal of the given path. Returns the terminal node and its depth.
-    ///
-    /// This can be more efficient than using repeated calls to `down` in the case that I/O may
-    /// be predicted based on the key-path.
-    fn seek(&mut self, path: KeyPath);
 
     /// Traverse to the sibling node of the current position. No-op at the root.
     fn sibling(&mut self);


### PR DESCRIPTION
We were redundantly recording paths for all encountered terminals. The `seek` function already
traversed to the node, so it's a simple matter to record all the siblings at that time.

In the future we could even record the page IDs and pages encountered during a `seek`. This would
be useful for two reasons:
  1. providing pages directly to the `Cursor` used in `update`
  2. parallel update scheduling

I also removed the `seek` function from the `Cursor` trait as it's not used in `update` since #96