### PR TITLE
bench: add cli init and run commands

### DIFF
--- a/xtask/src/backend.rs
+++ b/xtask/src/backend.rs
@@ -33,10 +33,13 @@ impl Backend {
         vec![Backend::SovDB, Backend::Nomt]
     }
 
-    pub fn instantiate(&self) -> Box<dyn Db> {
+    // If reset is true, then erase any previous backend's database
+    // and restart from an empty database.
+    // Otherwise, use the already present database.
+    pub fn instantiate(&self, reset: bool) -> Box<dyn Db> {
         match self {
-            Backend::SovDB => Box::new(SovDB::new()),
-            Backend::Nomt => Box::new(NomtDB::new()),
+            Backend::SovDB => Box::new(SovDB::new(reset)),
+            Backend::Nomt => Box::new(NomtDB::new(reset)),
         }
     }
 }

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -23,11 +23,14 @@ pub fn bench(params: Params) -> Result<()> {
         let mut timer = Timer::new(format!("{}", backend));
 
         for _ in 0..params.iteration {
-            let mut backend_instance = backend.instantiate();
+            let mut backend_instance = backend.instantiate(true);
 
+            // TODO: if the initial capacity is large, this repetition could become time-consuming.
+            // It would be better to initialize the database once,
+            // copy it to a location, and then only run the workload for each iteration
             workload.init(&mut backend_instance);
             // it's up to the workload implementation to measure the relevant parts
-            workload.run(&mut backend_instance, &mut timer);
+            workload.run(&mut backend_instance, Some(&mut timer));
         }
 
         timer.print();

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -11,7 +11,21 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Benchmark different workloads against different backends
+    ///
+    /// It is a combination of Init and Exec with specifiable iterations
+    /// over possible multiple backends
     Bench(bench::Params),
+    /// Initialize NOMT backend for the specified workload.
+    ///
+    /// The backend will be initialized with all the data required
+    /// to execute the workload.
+    Init(WorkloadParams),
+    /// Execute a workload once over NOMT.
+    ///
+    /// If the NOMT's database is not there, it will start with an empty database;
+    /// otherwise, it will use the already present one.
+    Run(WorkloadParams),
 }
 
 impl Display for Backend {
@@ -24,8 +38,50 @@ impl Display for Backend {
     }
 }
 
+#[derive(Clone, Debug, Args)]
+pub struct WorkloadParams {
+    /// Workload used by benchmarks.
+    ///
+    /// Possible values are: transfer, set_balance/heavy_write, heavy_read, heavy_update, heavy_delete
+    ///
+    /// Transfer workload involves balancing transfer between two different accounts
+    #[clap(default_value = "transfer")]
+    #[arg(long = "workload-name", short)]
+    pub name: String,
+
+    /// Parameters avaiable only with workload "transfer".
+    ///
+    /// It is the percentage of transfers to a non-existing account,
+    /// the remaining portion of transfers are to existing accounts
+    ///
+    /// Accepted values are in the range of 0 to 100
+    #[clap(value_parser=clap::value_parser!(u8).range(0..=100))]
+    #[arg(long = "workload-percentage-cold", short)]
+    pub percentage_cold: Option<u8>,
+
+    /// Amount of operations performed in the workload
+    #[clap(default_value = "1000")]
+    #[arg(long = "workload-size", short)]
+    pub size: u64,
+
+    /// Additional size of the database before starting the benchmarks.
+    ///
+    /// Some workloads operate over existing keys in the database,
+    /// and this size is additional to those entries.
+    ///
+    /// The provided argument is the power of two exponent of the
+    /// number of elements already present in the storage.
+    ///
+    /// Accepted values are in the range of 0 to 63
+    ///
+    /// Leave it empty to specify an initial empty storage
+    #[arg(long = "workload-capacity", short = 'c')]
+    #[clap(value_parser=clap::value_parser!(u8).range(0..64))]
+    pub initial_capacity: Option<u8>,
+}
+
 pub mod bench {
-    use super::{Args, Backend};
+    use super::{Args, Backend, WorkloadParams};
 
     #[derive(Debug, Args)]
     pub struct Params {
@@ -46,47 +102,5 @@ pub mod bench {
         #[clap(default_value = "100")]
         #[arg(long, short)]
         pub iteration: u64,
-    }
-
-    #[derive(Clone, Debug, Args)]
-    pub struct WorkloadParams {
-        /// Workload used by benchmarks.
-        ///
-        /// Possible values are: transfer, set_balance/heavy_write, heavy_read, heavy_update, heavy_delete
-        ///
-        /// Transfer workload involves balancing transfer between two different accounts
-        #[clap(default_value = "transfer")]
-        #[arg(long = "workload-name", short)]
-        pub name: String,
-
-        /// Parameters avaiable only with workload "transfer".
-        ///
-        /// It is the percentage of transfers to a non-existing account,
-        /// the remaining portion of transfers are to existing accounts
-        ///
-        /// Accepted values are in the range of 0 to 100
-        #[clap(value_parser=clap::value_parser!(u8).range(0..=100))]
-        #[arg(long = "workload-percentage-cold", short)]
-        pub percentage_cold: Option<u8>,
-
-        /// Amount of operations performed in the workload
-        #[clap(default_value = "1000")]
-        #[arg(long = "workload-size", short)]
-        pub size: u64,
-
-        /// Additional size of the database before starting the benchmarks.
-        ///
-        /// Some workloads operate over existing keys in the database,
-        /// and this size is additional to those entries.
-        ///
-        /// The provided argument is the power of two exponent of the
-        /// number of elements already present in the storage.
-        ///
-        /// Accepted values are in the range of 0 to 63
-        ///
-        /// Leave it empty to specify an initial empty storage
-        #[arg(long = "workload-capacity", short = 'c')]
-        #[clap(value_parser=clap::value_parser!(u8).range(0..64))]
-        pub initial_capacity: Option<u8>,
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,13 +8,43 @@ mod timer;
 mod transfer_workload;
 mod workload;
 
+use anyhow::Result;
+use backend::Backend;
 use clap::Parser;
-use cli::{Cli, Commands};
+use cli::{Cli, Commands, WorkloadParams};
 
-pub fn main() -> anyhow::Result<()> {
+pub fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
         Commands::Bench(params) => bench::bench(params),
+        Commands::Init(params) => init(params),
+        Commands::Run(params) => run(params),
     }
+}
+
+pub fn init(params: WorkloadParams) -> Result<()> {
+    let workload = workload::parse(
+        params.name.as_str(),
+        params.size,
+        params.initial_capacity.map(|s| 1u64 << s).unwrap_or(0),
+        params.percentage_cold,
+    )?;
+
+    workload.init(&mut Backend::Nomt.instantiate(true));
+
+    Ok(())
+}
+
+pub fn run(params: WorkloadParams) -> Result<()> {
+    let workload = workload::parse(
+        params.name.as_str(),
+        params.size,
+        params.initial_capacity.map(|s| 1u64 << s).unwrap_or(0),
+        params.percentage_cold,
+    )?;
+
+    workload.run(&mut Backend::Nomt.instantiate(false), None);
+
+    Ok(())
 }

--- a/xtask/src/nomt.rs
+++ b/xtask/src/nomt.rs
@@ -12,8 +12,11 @@ pub struct NomtDB {
 }
 
 impl NomtDB {
-    pub fn new() -> Self {
-        let _ = std::fs::remove_dir_all("nomt_db");
+    pub fn new(reset: bool) -> Self {
+        if reset {
+            // Delete previously existing db
+            let _ = std::fs::remove_dir_all("nomt_db");
+        }
 
         let opts = Options {
             path: PathBuf::from("nomt_db"),

--- a/xtask/src/sov_db.rs
+++ b/xtask/src/sov_db.rs
@@ -12,9 +12,11 @@ pub struct SovDB {
 }
 
 impl SovDB {
-    pub fn new() -> Self {
-        // Delete previously existing db
-        let _ = std::fs::remove_dir_all("sov_db");
+    pub fn new(reset: bool) -> Self {
+        if reset {
+            // Delete previously existing db
+            let _ = std::fs::remove_dir_all("sov_db");
+        }
 
         // Create the underlying rocks db database
         let state_db_raw = StateDB::<SnapshotManager>::setup_schema_db("sov_db").unwrap();

--- a/xtask/src/workload.rs
+++ b/xtask/src/workload.rs
@@ -26,8 +26,8 @@ impl Workload {
         backend.apply_actions(self.init_actions.clone(), None);
     }
 
-    pub fn run(&self, backend: &mut Box<dyn Db>, timer: &mut Timer) {
-        backend.apply_actions(self.run_actions.clone(), Some(timer));
+    pub fn run(&self, backend: &mut Box<dyn Db>, timer: Option<&mut Timer>) {
+        backend.apply_actions(self.run_actions.clone(), timer);
     }
 }
 


### PR DESCRIPTION
Init will initialize nomt backend given a workload and run will execute it skipping the
initialization phase. It allows the possibility of easily using samply over workloads,
example of usage:

```shell
cd xtask
cargo build
./target/debug/xtask init -n transfer -s 10000 -c 15
samply record target/debug/xtask run -n transfer -s 10000 -c 15
```
