### PR TITLE
opt: preallocate space for siblings

### DIFF
--- a/nomt/src/cursor.rs
+++ b/nomt/src/cursor.rs
@@ -157,7 +157,7 @@ impl PageCacheCursor {
         self.rewind();
 
         let mut result = Seek {
-            siblings: Vec::new(),
+            siblings: Vec::with_capacity(32),
             terminal: None,
         };
 


### PR DESCRIPTION
32 gives 1KB and was chosen arbitrarily. It seems to help but we should probably adapt this to
the size of the trie in elements eventually.