### PR TITLE
bench: add more granular timing

### DIFF
--- a/benchtop/src/backend.rs
+++ b/benchtop/src/backend.rs
@@ -24,8 +24,16 @@ pub trait Db {
     /// Apply the given actions to the storage, committing them
     /// to the database at the end.
     ///
-    /// The function also accepts an optional timer that will be used to measure
-    /// the relevant parts of the backend that effectively apply the actions.
+    /// The function can take an optional timer to measure key parts of backend operations.
+    ///
+    /// For each backend, three spans are required to be measured:
+    /// + `workload` :: measuring the entirety of the workload execution
+    /// + `read` :: measuring the read latency
+    /// + `commit_and_prove` :: measuring the time required to commit everything to the database
+    ///    and create a proof
+    ///
+    /// Other spans can be measured by each backend, leaving space
+    /// for more detailed tasks specific to each backend.
     fn apply_actions(&mut self, actions: Vec<Action>, timer: Option<&mut Timer>);
 }
 

--- a/benchtop/src/custom_workload.rs
+++ b/benchtop/src/custom_workload.rs
@@ -47,7 +47,7 @@ pub fn new_custom_workload(
                     Some(prev_key) => *prev_key + Uint::<256, 4>::from(1),
                     None => Uint::<256, 4>::from_be_bytes(rand_key(rng)),
                 };
-                *prev = Some(new_key.clone());
+                *prev = Some(new_key);
                 new_key.to_be_bytes::<32>().to_vec()
             } else {
                 rand_key(rng).to_vec()


### PR DESCRIPTION
Measure 3 things:
1. entirety of the workload
2. read latency
3. time consumed in commit and prove

example:
```shell
Running `target/release/benchtop bench -b nomt,sov-db,sp-trie -n transfer -s 10000 -i 1`
nomt
  mean workload: 301 ms
  mean read: 2136 ns
  mean commit_and_prove: 201 ms
sov-db
  mean workload: 2653 ms
  mean read: 63102 ns
  mean commit_and_prove: 1345 ms
sp-trie
  mean workload: 229 ms
  mean read: 2334 ns
  mean commit_and_prove: 85032 us
```