### PR TITLE
feat: hint when writing into empty pages

### DIFF
--- a/core/src/cursor.rs
+++ b/core/src/cursor.rs
@@ -35,7 +35,10 @@ pub trait Cursor {
     fn sibling(&mut self);
     /// Traverse to a child of the current position. Provide a bit that indicates whether
     /// the left or right child should be taken.
-    fn down(&mut self, bit: bool);
+    ///
+    /// The `hint_fresh` flag can be set to inform the cursor that the location being jumped to
+    /// is previously unallocated. Incorrect use of this flag can cause deletion of trie data.
+    fn down(&mut self, bit: bool, hint_fresh: bool);
     /// Traverse upwards by d bits. No-op if d is greater than the current position length.
     fn up(&mut self, d: u8);
 

--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -172,7 +172,7 @@ fn replace_subtrie<H: NodeHasher>(
     build_trie::<H>(skip, ops, |visit_control, node, leaf_data| {
         cursor.up(visit_control.up);
         for bit in visit_control.down.iter().by_vals() {
-            cursor.down(bit);
+            cursor.down(bit, true);
         }
 
         match leaf_data {

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -320,10 +320,11 @@ impl PageCache {
     /// Retrieves the page data at the given [`PageId`] synchronously.
     ///
     /// If the page is in the cache, it is returned immediately. If the page is not in the cache, it
-    /// is fetched from the underlying store and returned.
+    /// is fetched from the underlying store and returned. If `hint_fresh` is true, this immediately
+    /// returns a blank page.
     ///
     /// This method is blocking, but doesn't suffer from the channel overhead.
-    pub fn retrieve_sync(&self, page_id: PageId) -> Page {
+    pub fn retrieve_sync(&self, page_id: PageId, hint_fresh: bool) -> Page {
         let maybe_inflight = match self.shared.cached.entry(page_id.clone()) {
             Entry::Occupied(o) => {
                 let page = o.get();
@@ -337,6 +338,15 @@ impl PageCache {
                 }
             }
             Entry::Vacant(v) => {
+                if hint_fresh {
+                    let page_data =
+                        Arc::new(PageData::pristine_empty(&self.shared.page_rw_pass_domain));
+                    let page = Page {
+                        inner: page_data.clone(),
+                    };
+                    v.insert(PageState::Cached(page_data));
+                    return page;
+                }
                 v.insert(PageState::Inflight(Arc::new(InflightFetch::new())));
                 None
             }
@@ -463,7 +473,7 @@ impl Seeker {
         current_page: Option<&(PageId, Page)>,
     ) -> trie::LeafData {
         let (page, _, children) = locate_leaf_data(trie_pos, current_page, |page_id| {
-            self.cache.retrieve_sync(page_id)
+            self.cache.retrieve_sync(page_id, false)
         });
         trie::LeafData {
             key_path: page.node(&self.read_pass, children.left()),
@@ -487,7 +497,7 @@ impl Seeker {
                     .expect("Pages do not go deeper than the maximum layer, 42"),
             };
 
-            *cur_page = Some((page_id.clone(), self.cache.retrieve_sync(page_id)));
+            *cur_page = Some((page_id.clone(), self.cache.retrieve_sync(page_id, false)));
         }
         pos.down(bit);
 


### PR DESCRIPTION
hint fresh pages in update

We are currently querying the disk store for pages which are provably fresh, causing unnecessary
I/O in the critical section.

This shows about a 15% reduction in `update` runtime as a result.

before: https://share.firefox.dev/49QW4sv
after: https://share.firefox.dev/3xPp3Q0