### PR TITLE
bench: fix initialize backend only once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ profile.json
 /nomt/test
 
 # xtask
-/benchtop/sov_db
-/benchtop/nomt_db
-/benchtop/sp_trie_db
+/benchtop/sov_db*
+/benchtop/nomt_db*
+/benchtop/sp_trie_db*
 /benchtop/target

--- a/benchtop/src/bench.rs
+++ b/benchtop/src/bench.rs
@@ -2,20 +2,16 @@ use crate::{backend::Backend, cli::bench::Params, timer::Timer, workload};
 use anyhow::Result;
 
 pub fn bench(params: Params) -> Result<()> {
-    let workloads: Vec<_> = (0..params.iteration)
-        .map(|_| {
-            workload::parse(
-                params.workload.name.as_str(),
-                params.workload.size,
-                params
-                    .workload
-                    .initial_capacity
-                    .map(|s| 1u64 << s)
-                    .unwrap_or(0),
-                params.workload.percentage_cold,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let workload = workload::parse(
+        params.workload.name.as_str(),
+        params.workload.size,
+        params
+            .workload
+            .initial_capacity
+            .map(|s| 1u64 << s)
+            .unwrap_or(0),
+        params.workload.percentage_cold,
+    )?;
 
     let backends = if params.backends.is_empty() {
         Backend::all_backends()
@@ -25,14 +21,11 @@ pub fn bench(params: Params) -> Result<()> {
 
     for backend in backends {
         let mut timer = Timer::new(format!("{}", backend));
-
         let mut backend_instance = backend.instantiate(true);
 
-        if let Some(workload) = workloads.first() {
-            workload.init(&mut backend_instance);
-        }
+        workload.init(&mut backend_instance);
 
-        for workload in &workloads {
+        for _ in 0..params.iteration {
             workload.run(&mut backend_instance, Some(&mut timer));
         }
 

--- a/benchtop/src/workload.rs
+++ b/benchtop/src/workload.rs
@@ -22,12 +22,15 @@ pub struct Workload {
 }
 
 impl Workload {
+    // The workload initialization will persist in the database
     pub fn init(&self, backend: &mut Box<dyn Db>) {
         backend.apply_actions(self.init_actions.clone(), None);
     }
 
+    // The execution of the workload will not be persistent,
+    // any modifications made to the database will be rolled back to its previous state
     pub fn run(&self, backend: &mut Box<dyn Db>, timer: Option<&mut Timer>) {
-        backend.apply_actions(self.run_actions.clone(), timer);
+        backend.apply_and_revert_actions(self.run_actions.clone(), timer);
     }
 }
 


### PR DESCRIPTION
#149 introduces a useful feature, but it comes with the side effect of causing all workloads to be executed on top of the previous one.

This pull request changes how workload initialization and execution processes run: initialization runs on a database, while the execution runs on a copy of the initialized database.

There is redundant code between the `open` and `open_copy` functions within each backend due to an issue with "`backend::Db` not being able to be turned into an object" when attempting to move `open` inside the trait.

Suggestions for avoiding the redundant code are welcome!
