### PR TITLE
bench: workload execution type

### DIFF
--- a/benchtop/src/bench.rs
+++ b/benchtop/src/bench.rs
@@ -1,7 +1,20 @@
-use crate::{backend::Backend, cli::bench::Params, timer::Timer, workload};
+use crate::{
+    backend::Backend,
+    cli::bench::{BenchType, CommonParams, IsolateParams, SequentialParams},
+    timer::Timer,
+    workload,
+    workload::Workload,
+};
 use anyhow::Result;
 
-pub fn bench(params: Params) -> Result<()> {
+pub fn bench(bench_type: BenchType) -> Result<()> {
+    match bench_type {
+        BenchType::Isolate(params) => bench_isolate(params),
+        BenchType::Sequential(params) => bench_sequential(params),
+    }
+}
+
+fn get_workload_and_backends(params: CommonParams) -> Result<(Workload, Vec<Backend>)> {
     let workload = workload::parse(
         params.workload.name.as_str(),
         params.workload.size,
@@ -19,14 +32,60 @@ pub fn bench(params: Params) -> Result<()> {
         params.backends
     };
 
+    Ok((workload, backends))
+}
+
+pub fn bench_isolate(params: IsolateParams) -> Result<()> {
+    let (workload, backends) = get_workload_and_backends(params.common_params)?;
+
     for backend in backends {
         let mut timer = Timer::new(format!("{}", backend));
         let mut backend_instance = backend.instantiate(true);
 
         workload.init(&mut backend_instance);
 
-        for _ in 0..params.iteration {
-            workload.run(&mut backend_instance, Some(&mut timer));
+        for _ in 0..params.iterations {
+            workload.run(&mut backend_instance, Some(&mut timer), true);
+        }
+
+        timer.print();
+    }
+
+    Ok(())
+}
+
+pub fn bench_sequential(params: SequentialParams) -> Result<()> {
+    let (workload, backends) = get_workload_and_backends(params.common_params)?;
+
+    if let (None, None) = (params.op_limit, params.time_limit) {
+        anyhow::bail!("You need to specify at least one limiter between operations and time")
+    }
+
+    for backend in backends {
+        let mut timer = Timer::new(format!("{}", backend));
+        let mut backend_instance = backend.instantiate(true);
+
+        let mut elapsed_time = 0;
+        let mut op_count = 0;
+
+        workload.init(&mut backend_instance);
+
+        loop {
+            workload.run(&mut backend_instance, Some(&mut timer), false);
+
+            // check if time limit exceeded
+            elapsed_time += timer.get_last_workload_duration()?;
+            match params.time_limit {
+                Some(limit) if elapsed_time >= (limit * 1000000) => break,
+                _ => (),
+            };
+
+            // check if op limit exceeded
+            op_count += workload.run_actions.len() as u64;
+            match params.op_limit {
+                Some(limit) if op_count >= limit => break,
+                _ => (),
+            };
         }
 
         timer.print();

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -45,7 +45,7 @@ pub fn run(params: WorkloadParams) -> Result<()> {
         params.percentage_cold,
     )?;
 
-    workload.run(&mut Backend::Nomt.instantiate(false), None);
+    workload.run(&mut Backend::Nomt.instantiate(false), None, true);
 
     Ok(())
 }

--- a/benchtop/src/timer.rs
+++ b/benchtop/src/timer.rs
@@ -39,6 +39,19 @@ impl Timer {
         }
     }
 
+    pub fn get_last_workload_duration(&self) -> anyhow::Result<u64> {
+        let h = self
+            .spans
+            .get("workload")
+            .ok_or(anyhow::anyhow!("`workload` span not recordered"))?;
+
+        Ok(h.borrow()
+            .iter_recorded()
+            .last()
+            .ok_or(anyhow::anyhow!("No recorded value for `workload` span"))?
+            .value_iterated_to())
+    }
+
     pub fn print(&mut self) {
         println!("{}", self.name);
 

--- a/benchtop/src/workload.rs
+++ b/benchtop/src/workload.rs
@@ -27,10 +27,15 @@ impl Workload {
         backend.apply_actions(self.init_actions.clone(), None);
     }
 
-    // The execution of the workload will not be persistent,
-    // any modifications made to the database will be rolled back to its previous state
-    pub fn run(&self, backend: &mut Box<dyn Db>, timer: Option<&mut Timer>) {
-        backend.apply_and_revert_actions(self.run_actions.clone(), timer);
+    // The workload execution is not persistent, any database modifications will be reverted
+    // to the previous state if `revert` is true.
+    // Otherwise, actions are applied to the backend
+    pub fn run(&self, backend: &mut Box<dyn Db>, timer: Option<&mut Timer>, revert: bool) {
+        if revert {
+            backend.apply_and_revert_actions(self.run_actions.clone(), timer);
+        } else {
+            backend.apply_actions(self.run_actions.clone(), timer);
+        }
     }
 }
 


### PR DESCRIPTION
Add two subcommands to the `bench` command to enable the following functionalities:
1. Isolate benchmarking by executing each workload on a copy of the initialized backend
2. Sequential benchmarking by continuously repeating workloads on the same backend until a specified time or operation limit is reached

The possibility of manually interrupting the execution is out of scope for this PR because it would require some new dependencies (handling ctrl+c), therefore, it will be implemented separately in a follow up pr
