### PR TITLE
bench: add regression tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ profile.json
 /nomt/test
 
 # xtask
+/benchtop/regression.toml
 /benchtop/sov_db*
 /benchtop/nomt_db*
 /benchtop/sp_trie_db*

--- a/benchtop/Cargo.lock
+++ b/benchtop/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "rand",
  "rand_pcg",
  "ruint",
+ "serde",
  "sha2 0.10.8",
  "sov-db",
  "sov-prover-storage-manager",
@@ -481,6 +482,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-state-machine",
  "sp-trie 32.0.0",
+ "toml 0.8.12",
  "trie-db",
 ]
 
@@ -2395,7 +2397,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2953,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -2971,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2999,6 +3001,15 @@ checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
  "serde",
 ]
 
@@ -3797,10 +3808,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.12",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3810,7 +3836,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -3821,7 +3847,7 @@ checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -3832,7 +3858,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -4512,6 +4551,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]

--- a/benchtop/Cargo.toml
+++ b/benchtop/Cargo.toml
@@ -18,6 +18,8 @@ rand = "0.8.5"
 rand_pcg = "0.3.1"
 sha2 = { version = "0.10.6" }
 ruint = { version = "1.12.1" }
+toml = "0.8.12"
+serde = "1.0.199"
 
 # sov-db
 sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk" }

--- a/benchtop/src/cli.rs
+++ b/benchtop/src/cli.rs
@@ -27,6 +27,29 @@ pub enum Commands {
     /// If the NOMT's database is not there, it will start with an empty database;
     /// otherwise, it will use the already present one.
     Run(WorkloadParams),
+
+    /// Check regression over multiple workloads
+    ///
+    /// Load a TOML file containing multiple workloads specifications
+    /// and their mean execution time, re-execute all the workloads,
+    /// and compare the results.
+    ///
+    /// Example of entry in the toml file:
+    ///
+    /// [workloads.<name_of_workload>] {n}
+    /// name = "randr" {n}
+    /// size = 25000 {n}
+    /// initial_capacity = 20 {n}
+    /// # then you can specify isolate {n}
+    /// [workloads.random_read_20.isolate] {n}
+    /// iterations = 10 {n}
+    /// mean = 909901824 # mean in ns to be compared with {n}
+    /// # or sequential (or both){n}
+    /// [workloads.random_read_20.sequential] {n}
+    /// time_limit = 100000 # in nanoseconds {n}
+    /// op_limit = 100 {n}
+    /// mean = 909901824 {n}
+    Regression(regression::Params),
 }
 
 impl Display for Backend {
@@ -141,5 +164,16 @@ pub mod bench {
         #[clap(default_value = "10")]
         #[arg(long, short)]
         pub iterations: u64,
+    }
+}
+
+pub mod regression {
+    use super::Args;
+
+    #[derive(Debug, Args)]
+    pub struct Params {
+        /// Path to the toml file
+        #[arg(long, short)]
+        pub input_file: String,
     }
 }

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -3,6 +3,7 @@ mod bench;
 mod cli;
 mod custom_workload;
 mod nomt;
+mod regression;
 mod sov_db;
 mod sp_trie;
 mod timer;
@@ -21,6 +22,7 @@ pub fn main() -> Result<()> {
         Commands::Bench(params) => bench::bench(params),
         Commands::Init(params) => init(params),
         Commands::Run(params) => run(params),
+        Commands::Regression(params) => regression::regression(params),
     }
 }
 

--- a/benchtop/src/regression.rs
+++ b/benchtop/src/regression.rs
@@ -1,0 +1,100 @@
+use crate::{bench, cli::regression::Params, timer::pretty_display_ns, workload, Backend};
+use anyhow::{anyhow, Result};
+use std::collections::BTreeMap;
+
+#[derive(serde::Deserialize, Debug)]
+struct RegressionInputs {
+    workloads: BTreeMap<String, WorkloadInfo>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct WorkloadInfo {
+    name: String,
+    size: u64,
+    initial_capacity: u64,
+    isolate: Option<Isolate>,
+    sequential: Option<Sequential>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Isolate {
+    iterations: u64,
+    mean: u64,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Sequential {
+    time_limit: Option<u64>,
+    op_limit: Option<u64>,
+    mean: u64,
+}
+
+pub fn regression(params: Params) -> Result<()> {
+    // load toml file
+    let input = std::fs::read_to_string(params.input_file)
+        .map_err(|_| anyhow!("regression input file does not exists"))?;
+
+    // parse toml file
+    let regr_inputs: RegressionInputs =
+        toml::from_str(&input).map_err(|e| anyhow!("regression input file wrong format: {}", e))?;
+
+    for (workload_name, workload_info) in regr_inputs.workloads {
+        let workload = workload::parse(
+            workload_info.name.as_str(),
+            workload_info.size,
+            1u64 << workload_info.initial_capacity,
+            None, // TODO: support cold percentage
+        )?;
+
+        println!("\nExecuting Workload: {}\n", workload_name);
+
+        if let Some(Isolate {
+            iterations,
+            mean: prev_mean,
+        }) = workload_info.isolate
+        {
+            print!("Isolate: -");
+            let bench_results =
+                bench::bench_isolate(workload.clone(), vec![Backend::Nomt], iterations, false)?;
+            let mean = *bench_results.first().expect("There must be nomt results");
+            print_results(prev_mean, mean);
+        };
+
+        if let Some(Sequential {
+            op_limit,
+            time_limit,
+            mean: prev_mean,
+        }) = workload_info.sequential
+        {
+            print!("Sequential - ");
+            let bench_results = bench::bench_sequential(
+                workload,
+                vec![Backend::Nomt],
+                op_limit,
+                time_limit,
+                false,
+            )?;
+            let mean = *bench_results.first().expect("There must be nomt results");
+            print_results(prev_mean, mean);
+        };
+    }
+
+    Ok(())
+}
+
+fn print_results(prev_mean: u64, mean: u64) {
+    let results = format!(
+        "\n  Previous mean:  {}\n  Current mean:  {}",
+        pretty_display_ns(prev_mean),
+        pretty_display_ns(mean)
+    );
+
+    if prev_mean < mean {
+        println!("Regression {}", results);
+    } else if prev_mean == mean {
+        println!("Nothing changed");
+    } else {
+        println!("Improvement {}", results);
+        println!("  Current mean nanoseconds: {}", mean);
+    }
+}

--- a/benchtop/src/timer.rs
+++ b/benchtop/src/timer.rs
@@ -52,6 +52,15 @@ impl Timer {
             .value_iterated_to())
     }
 
+    pub fn get_mean_workload_duration(&self) -> anyhow::Result<u64> {
+        Ok(self
+            .spans
+            .get("workload")
+            .ok_or(anyhow::anyhow!("`workload` span not recordered"))?
+            .borrow()
+            .mean() as u64)
+    }
+
     pub fn print(&mut self) {
         println!("{}", self.name);
 
@@ -79,7 +88,7 @@ impl Timer {
     }
 }
 
-fn pretty_display_ns(ns: u64) -> String {
+pub fn pretty_display_ns(ns: u64) -> String {
     // preserve 3 sig figs at minimum.
     let (val, unit) = if ns > 100 * 1_000_000_000 {
         (ns / 1_000_000_000, "s")

--- a/benchtop/src/workload.rs
+++ b/benchtop/src/workload.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 //
 // Each workload will set up the DB differently and reads and writes arbitrarily,
 // whether the key is not present or already present.
+#[derive(Clone)]
 pub struct Workload {
     pub init_actions: Vec<Action>,
     pub run_actions: Vec<Action>,


### PR DESCRIPTION
simple cli command that parses a toml file that contains a set of workloads with an expected
average duration, executes them in, and then compares the results

I have considered a more sophisticated and reliable method for managing regression testing, but for now, the simplest and valuable approach may be to maintain a manually updated reference 

I is very simple to use:

```shell
benchtop git:(gab_bench_workloads_exec_type) ✗  ➜ cargo run --release -- regression -i regression.toml
   Compiling benchtop v0.1.0 (/home/gabriele/Documents/thrum/nomt/benchtop)
    Finished release [optimized] target(s) in 8.66s      ld `op_limit` on 
     Running `target/release/benchtop regression -i regr.toml`

Executing Workload: random_read_20
Sequential - Improvent 
  Previous mean:  909 ms
  Current mean:  224 ms
  Current mean nanosecons: 224346112  // <- this can be used to update the value in the toml file
```

one example of toml file is
```toml
[workloads.transfer_easy]
name = "transfer"
size = 25000
initial_capacity = 0
iterations = 10
[workloads.transfer_easy.isolate]
iterations = 10
mean = 1246000000
[workloads.transfer_easy.sequential]
op_limit = 1000000
mean = 795000000

[workloads.random_read_10]
name = "randr"
size = 25000
initial_capacity = 10
[workloads.random_read_10.sequential]
op_limit = 100000
mean = 186548224
```
