### PR TITLE
bench: regression tool output file

### DIFF
--- a/benchtop/src/cli.rs
+++ b/benchtop/src/cli.rs
@@ -169,8 +169,12 @@ pub mod regression {
 
     #[derive(Debug, Args)]
     pub struct Params {
-        /// Path to the toml file
+        /// Path to the toml file containing workloads info
         #[arg(long, short)]
-        pub input_file: String,
+        pub input_file: Option<String>,
+
+        /// Optional path file where results will be stored
+        #[arg(long, short)]
+        pub output_file: Option<String>,
     }
 }

--- a/benchtop/src/regression.rs
+++ b/benchtop/src/regression.rs
@@ -1,13 +1,15 @@
+mod default_input;
+
 use crate::{bench, cli::regression::Params, timer::pretty_display_ns, workload, Backend};
 use anyhow::{anyhow, Result};
 use std::collections::BTreeMap;
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
 struct RegressionInputs {
     workloads: BTreeMap<String, WorkloadInfo>,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
 struct WorkloadInfo {
     name: String,
     size: u64,
@@ -16,34 +18,39 @@ struct WorkloadInfo {
     sequential: Option<Sequential>,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct Isolate {
     iterations: u64,
-    mean: u64,
+    mean: Option<u64>,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct Sequential {
     time_limit: Option<u64>,
     op_limit: Option<u64>,
-    mean: u64,
+    mean: Option<u64>,
 }
 
 pub fn regression(params: Params) -> Result<()> {
-    // load toml file
-    let input = std::fs::read_to_string(params.input_file)
-        .map_err(|_| anyhow!("regression input file does not exists"))?;
+    let mut regr_inputs: RegressionInputs = match &params.input_file {
+        Some(input_path) => {
+            // load toml file
+            let input = std::fs::read_to_string(input_path)
+                .map_err(|_| anyhow!("regression input file does not exists"))?;
 
-    // parse toml file
-    let regr_inputs: RegressionInputs =
-        toml::from_str(&input).map_err(|e| anyhow!("regression input file wrong format: {}", e))?;
+            // parse toml file
+            toml::from_str(&input)
+                .map_err(|e| anyhow!("regression input file wrong format: {}", e))?
+        }
+        None => default_input::default_regression_input(),
+    };
 
-    for (workload_name, workload_info) in regr_inputs.workloads {
+    for (workload_name, workload_info) in &mut regr_inputs.workloads {
         println!("\nExecuting Workload: {}\n", workload_name);
 
         if let Some(Isolate {
             iterations,
-            mean: prev_mean,
+            mean: ref mut prev_mean,
         }) = workload_info.isolate
         {
             let (init, workload) = workload::parse(
@@ -53,17 +60,18 @@ pub fn regression(params: Params) -> Result<()> {
                 None, // TODO: support cold percentage
             )?;
 
-            print!("Isolate: -");
+            print!("Isolate: ");
             let bench_results =
                 bench::bench_isolate(init, workload, vec![Backend::Nomt], iterations, false)?;
             let mean = *bench_results.first().expect("There must be nomt results");
             print_results(prev_mean, mean);
+            *prev_mean = Some(mean);
         };
 
         if let Some(Sequential {
             op_limit,
             time_limit,
-            mean: prev_mean,
+            mean: ref mut prev_mean,
         }) = workload_info.sequential
         {
             let (init, workload) = workload::parse(
@@ -73,7 +81,7 @@ pub fn regression(params: Params) -> Result<()> {
                 None, // TODO: support cold percentage
             )?;
 
-            print!("Sequential - ");
+            print!("Sequential: ");
             let bench_results = bench::bench_sequential(
                 init,
                 workload,
@@ -84,25 +92,40 @@ pub fn regression(params: Params) -> Result<()> {
             )?;
             let mean = *bench_results.first().expect("There must be nomt results");
             print_results(prev_mean, mean);
+            *prev_mean = Some(mean);
         };
+    }
+
+    if let Some(output_path) = params.output_file {
+        std::fs::write(output_path, toml::to_string(&regr_inputs)?)?;
     }
 
     Ok(())
 }
 
-fn print_results(prev_mean: u64, mean: u64) {
-    let results = format!(
-        "\n  Previous mean:  {}\n  Current mean:  {}",
-        pretty_display_ns(prev_mean),
-        pretty_display_ns(mean)
+fn print_results(maybe_prev_mean: &Option<u64>, curr_mean: u64) {
+    let format_curr_mean = format!(
+        "  Current mean:  {} ( {} [ns] )",
+        pretty_display_ns(curr_mean),
+        curr_mean
     );
 
-    if prev_mean < mean {
-        println!("Regression {}", results);
-    } else if prev_mean == mean {
+    let Some(prev_mean) = *maybe_prev_mean else {
+        println!("No previous mean specified");
+        println!("{}", format_curr_mean);
+        return;
+    };
+
+    let format_prev_mean = format!("  Previous mean:  {}", pretty_display_ns(prev_mean));
+
+    if prev_mean < curr_mean {
+        println!("Regression");
+    } else if prev_mean == curr_mean {
         println!("Nothing changed");
     } else {
-        println!("Improvement {}", results);
-        println!("  Current mean nanoseconds: {}", mean);
+        println!("Improvement");
     }
+
+    println!("{}", format_prev_mean);
+    println!("{}", format_curr_mean);
 }

--- a/benchtop/src/regression/default_input.rs
+++ b/benchtop/src/regression/default_input.rs
@@ -1,0 +1,78 @@
+use crate::regression::{Isolate, RegressionInputs, Sequential, WorkloadInfo};
+
+pub fn default_regression_input() -> RegressionInputs {
+    RegressionInputs {
+        workloads: [
+            (
+                "random_read_10".to_string(),
+                WorkloadInfo {
+                    name: "randr".to_string(),
+                    size: 25_000,
+                    initial_capacity: 10,
+                    isolate: None,
+                    sequential: Some(Sequential {
+                        time_limit: None,
+                        op_limit: Some(500_000),
+                        mean: None,
+                    }),
+                },
+            ),
+            (
+                "random_read_20".to_string(),
+                WorkloadInfo {
+                    name: "randr".to_string(),
+                    size: 25_000,
+                    initial_capacity: 20,
+                    isolate: None,
+                    sequential: Some(Sequential {
+                        time_limit: None,
+                        op_limit: Some(500_000),
+                        mean: None,
+                    }),
+                },
+            ),
+            (
+                "random_write_20".to_string(),
+                WorkloadInfo {
+                    name: "randw".to_string(),
+                    size: 25_000,
+                    initial_capacity: 20,
+                    isolate: None,
+                    sequential: Some(Sequential {
+                        time_limit: None,
+                        op_limit: Some(500_000),
+                        mean: None,
+                    }),
+                },
+            ),
+            (
+                "random_read_write_20".to_string(),
+                WorkloadInfo {
+                    name: "randrw".to_string(),
+                    size: 25_000,
+                    initial_capacity: 20,
+                    isolate: None,
+                    sequential: Some(Sequential {
+                        time_limit: None,
+                        op_limit: Some(500_000),
+                        mean: None,
+                    }),
+                },
+            ),
+            (
+                "transfer".to_string(),
+                WorkloadInfo {
+                    name: "transfer".to_string(),
+                    size: 30_000,
+                    initial_capacity: 20,
+                    isolate: Some(Isolate {
+                        iterations: 20,
+                        mean: None,
+                    }),
+                    sequential: None,
+                },
+            ),
+        ]
+        .into(),
+    }
+}


### PR DESCRIPTION
Add the possibility to serialize the workloads, with the recorded duration, into another file. This makes it possible to avoid updating timings manually by specifying the same file twice, as input and output

Add also the possibility to avoid specifying the input file and using a default set of workloads
