### PR TITLE
rw_pass_cell: remove WritePass custom Drop

### DIFF
--- a/nomt/src/rw_pass_cell.rs
+++ b/nomt/src/rw_pass_cell.rs
@@ -218,8 +218,10 @@ impl<R: Region + Clone> WritePass<R> {
 
     /// Consume this regioned write-pass, possibly yielding the parent region back.
     ///
-    /// If all other split descendents of the parent write pass have been dropped or consumed,
+    /// If all other split descendents of the parent write pass have been consumed,
     /// this will return a region equivalent to the parent's.
+    ///
+    /// All write-passes need to be consumed before being dropped to yield the parent region.
     pub fn consume(self) -> Option<Self> {
         let Some(ref parent) = self.parent else {
             return None;
@@ -256,15 +258,6 @@ impl WritePass<UniversalRegion> {
                 region,
                 _guard: self.read_pass._guard.clone(),
             },
-        }
-    }
-}
-
-impl<R> Drop for WritePass<R> {
-    fn drop(&mut self) {
-        if let Some(ref parent) = self.parent {
-            // SAFETY: release our writes to other threads.
-            parent.remaining_children.fetch_sub(1, Ordering::Release);
         }
     }
 }


### PR DESCRIPTION
If both `drop` and `consume` decrease `parent.remaining_children` by one,
then after calling `consume`, the final result would be a decrease of two
in `parent.remaining_children`

I tried to avoid making `consume` mandatory, but I couldn't find a way to make
the usage of `parent.remaining_children` work in the correct order.
If inside `drop` the value is fetched and subtracted by 1 with `Ordering::AcqRel`,
and then inside `consume` it is just loaded with `Ordering::Acquire`,
there are scenarios where both `consume` calls on two `write_pass` would return the same
`parent.remaining_children`, and then none of them would yield the parent region.
