### PR TITLE
refactor: benchtop workloads unique each iteration; remove unused code

### DIFF
--- a/benchtop/src/backend.rs
+++ b/benchtop/src/backend.rs
@@ -1,7 +1,4 @@
-use crate::{nomt::NomtDB, sov_db::SovDB, sp_trie::SpTrieDB, timer::Timer};
-
-type Value = Vec<u8>;
-type Key = Vec<u8>;
+use crate::{nomt::NomtDB, sov_db::SovDB, sp_trie::SpTrieDB, timer::Timer, workload::Workload};
 
 #[derive(Debug, Clone, clap::ValueEnum)]
 pub enum Backend {
@@ -10,58 +7,46 @@ pub enum Backend {
     SpTrie,
 }
 
-#[derive(Clone, Debug)]
-#[allow(unused)]
-pub enum Action {
-    // Write into the storage, None as value means delete that key
-    Write { key: Key, value: Option<Value> },
-    // Read the storage
-    Read { key: Key },
-}
-
-/// Trait implemented by all backends who wants to be benchmarked.
-pub trait Db {
-    /// Create a new backend using a copy of the database.
-    /// Delete any existing copies beforehand
-    fn open_copy(&self) -> Box<dyn Db>;
-
-    /// Apply the given actions to the storage, committing them
-    /// to the database at the end.
-    ///
-    /// The function can take an optional timer to measure key parts of backend operations.
-    ///
-    /// For each backend, three spans are required to be measured:
-    /// + `workload` :: measuring the entirety of the workload execution
-    /// + `read` :: measuring the read latency
-    /// + `commit_and_prove` :: measuring the time required to commit everything to the database
-    ///    and create a proof
-    ///
-    /// Other spans can be measured by each backend, leaving space
-    /// for more detailed tasks specific to each backend.
-    fn apply_actions(&mut self, actions: Vec<Action>, timer: Option<&mut Timer>);
-
-    /// Apply the actions to a copy of the backend to measure performance without altering
-    /// the original database structure. This allows for applying and reverting actions
-    /// iteratively to measure performance.
-    fn apply_and_revert_actions(&self, actions: Vec<Action>, timer: Option<&mut Timer>) {
-        let mut revert_db = self.open_copy();
-        revert_db.apply_actions(actions, timer);
-    }
-}
-
 impl Backend {
     pub fn all_backends() -> Vec<Self> {
-        vec![Backend::SovDB, Backend::Nomt]
+        vec![Backend::SovDB, Backend::SpTrie, Backend::Nomt]
     }
 
     // If reset is true, then erase any previous backend's database
     // and restart from an empty database.
     // Otherwise, use the already present database.
-    pub fn instantiate(&self, reset: bool) -> Box<dyn Db> {
+    pub fn instantiate(&self, reset: bool) -> DB {
         match self {
-            Backend::SovDB => Box::new(SovDB::open(reset)),
-            Backend::Nomt => Box::new(NomtDB::open(reset)),
-            Backend::SpTrie => Box::new(SpTrieDB::open(reset)),
+            Backend::SovDB => DB::Sov(SovDB::open(reset)),
+            Backend::Nomt => DB::Nomt(NomtDB::open(reset)),
+            Backend::SpTrie => DB::SpTrie(SpTrieDB::open(reset)),
+        }
+    }
+}
+
+/// A transaction over the database which allows reading and writing.
+pub trait Transaction {
+    /// Read a value from the database. If a value was previously written, return that.
+    fn read(&mut self, key: &[u8]) -> Option<Vec<u8>>;
+
+    /// Write a value to the database. `None` means to delete the previous value.
+    fn write(&mut self, key: &[u8], value: Option<&[u8]>);
+}
+
+/// A wrapper around all databases implemented in this tool.
+pub enum DB {
+    Sov(SovDB),
+    SpTrie(SpTrieDB),
+    Nomt(NomtDB),
+}
+
+impl DB {
+    /// Execute some code against the DB using the given closure.
+    pub fn execute(&mut self, timer: Option<&mut Timer>, workload: &mut dyn Workload) {
+        match self {
+            DB::Sov(db) => db.execute(timer, workload),
+            DB::SpTrie(db) => db.execute(timer, workload),
+            DB::Nomt(db) => db.execute(timer, workload),
         }
     }
 }

--- a/benchtop/src/cli.rs
+++ b/benchtop/src/cli.rs
@@ -80,7 +80,7 @@ pub struct WorkloadParams {
     #[arg(long = "workload-name", short)]
     pub name: String,
 
-    /// Parameters avaiable only with workload "transfer".
+    /// Parameters available only with workload "transfer".
     ///
     /// It is the percentage of transfers to a non-existing account,
     /// the remaining portion of transfers are to existing accounts
@@ -95,10 +95,7 @@ pub struct WorkloadParams {
     #[arg(long = "workload-size", short)]
     pub size: u64,
 
-    /// Additional size of the database before starting the benchmarks.
-    ///
-    /// Some workloads operate over existing keys in the database,
-    /// and this size is additional to those entries.
+    /// The size of the database before starting the benchmarks.
     ///
     /// The provided argument is the power of two exponent of the
     /// number of elements already present in the storage.

--- a/benchtop/src/custom_workload.rs
+++ b/benchtop/src/custom_workload.rs
@@ -1,100 +1,76 @@
-use crate::{backend::Action, workload::Workload};
-use anyhow::Result;
-use rand::{Rng, RngCore as _, SeedableRng as _};
-use ruint::Uint;
+use crate::{
+    backend::Transaction,
+    workload::{Init, Workload},
+};
+use rand::{Rng, SeedableRng as _};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-// The custom workload will follow these rules:
-// 1. Reads and writes are randomly and uniformly distributed across the key space,
-//    or sequentially starting from a random address (depending on the `seq` value).
-// 2. Deletes and updates will be performed on already present keys.
-// 3. additional_initial_capacity represents the amount of items already present
-//     in the DB in addition to the ones required to perform deletes and updates.
-// 4. Size represents the total number of operations, where reads, writes, etc
+/// Initialize a database with the given amount of key-value pairs.
+pub fn init(db_size: u64) -> Init {
+    Init {
+        keys: (0..db_size).map(|id| encode_id(id).to_vec()).collect(),
+        value: vec![64u8; 32],
+    }
+}
+
+fn encode_id(id: u64) -> [u8; 8] {
+    id.to_be_bytes()
+}
+
+/// Build a RwWorkload.
+pub fn build(reads: u8, writes: u8, workload_size: u64, db_size: u64) -> RwWorkload {
+    RwWorkload {
+        reads,
+        writes,
+        workload_size,
+        db_size,
+    }
+}
+
+// The read-write workload will follow these rules:
+// 1. Reads and writes are randomly and uniformly distributed across the key space.
+// 2. The DB size indicates the number of entries in the database.
+// 3. The workload size represents the total number of operations, where reads and writes
 //     are numbers that need to sum to 100 and represent a percentage of the total size.
-pub fn new_custom_workload(
-    reads: u8,
-    writes: u8,
-    deletes: u8,
-    updates: u8,
-    seq: bool,
-    size: u64,
-    additional_initial_capacity: u64,
-) -> Result<Workload> {
-    if reads + writes + deletes + updates != 100 {
-        anyhow::bail!("Operations (reads, writes, deletes, updates) must sum to 100");
+pub struct RwWorkload {
+    pub reads: u8,
+    pub writes: u8,
+    pub workload_size: u64,
+    pub db_size: u64,
+}
+
+impl Workload for RwWorkload {
+    fn run(&mut self, transaction: &mut dyn Transaction) {
+        let from_percentage = |p: u8| (self.workload_size as f64 * p as f64 / 100.0) as u64;
+        let n_reads = from_percentage(self.reads);
+        let n_writes = from_percentage(self.writes);
+
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("no time?")
+            .as_nanos()
+            .to_le_bytes()[0..16]
+            .try_into()
+            .unwrap();
+
+        let mut rng = rand_pcg::Lcg64Xsh32::from_seed(seed);
+
+        for _ in 0..n_reads {
+            let key = rng.gen_range(0..self.db_size);
+            let _ = transaction.read(&encode_id(key));
+        }
+
+        for _ in 0..n_writes {
+            let key = rng.gen_range(0..self.db_size);
+            let value = rand_key(&mut rng);
+
+            transaction.write(&encode_id(key), Some(&value));
+        }
     }
 
-    let from_percentage = |p: u8| (size as f64 * p as f64 / 100.0) as u64;
-    let n_reads = from_percentage(reads);
-    let n_writes = from_percentage(writes);
-    let n_deletes = from_percentage(deletes);
-    let n_updates = from_percentage(updates);
-
-    let n_required_key = n_deletes + n_updates;
-    let initial_writes = (0..n_required_key + additional_initial_capacity)
-        .map(|i| Action::Write {
-            key: i.to_be_bytes().to_vec(),
-            value: Some(vec![64u8; 32]),
-        })
-        .collect();
-
-    // new keys will be random or sequential from a random one
-    let rand_or_seq =
-        |prev: &mut Option<Uint<256, 4>>, rng: &mut rand_pcg::Lcg64Xsh32| -> Vec<u8> {
-            if seq {
-                let new_key = match prev {
-                    Some(prev_key) => *prev_key + Uint::<256, 4>::from(1),
-                    None => Uint::<256, 4>::from_be_bytes(rand_key(rng)),
-                };
-                *prev = Some(new_key);
-                new_key.to_be_bytes::<32>().to_vec()
-            } else {
-                rand_key(rng).to_vec()
-            }
-        };
-
-    // create two rng, one for read and one for write
-    let read_seed = SystemTime::now()
-        .duration_since(UNIX_EPOCH)?
-        .as_nanos()
-        .to_le_bytes()[0..16]
-        .try_into()?;
-    let mut rng_read = rand_pcg::Lcg64Xsh32::from_seed(read_seed);
-    let mut write_seed = [0; 16];
-    rng_read.fill_bytes(&mut write_seed);
-    let mut rng_write = rand_pcg::Lcg64Xsh32::from_seed(write_seed);
-
-    let mut read_init_key = None;
-    let read_actions = (0..n_reads).map(|_| Action::Read {
-        key: rand_or_seq(&mut read_init_key, &mut rng_read),
-    });
-
-    let mut write_init_key = None;
-    let write_actions = (n_reads..n_reads + n_writes).map(|_| Action::Write {
-        key: rand_or_seq(&mut write_init_key, &mut rng_write),
-        value: Some(vec![8; 16]),
-    });
-
-    let delete_actions = (0..n_deletes).map(|i| Action::Write {
-        key: i.to_be_bytes().to_vec(),
-        value: None,
-    });
-    let update_actions = (n_deletes..n_deletes + n_updates).map(|i| Action::Write {
-        key: i.to_be_bytes().to_vec(),
-        value: Some(vec![2; 16]),
-    });
-
-    let custom_actions = read_actions
-        .chain(write_actions)
-        .chain(delete_actions)
-        .chain(update_actions)
-        .collect();
-
-    Ok(Workload {
-        init_actions: initial_writes,
-        run_actions: custom_actions,
-    })
+    fn size(&self) -> usize {
+        self.workload_size as usize
+    }
 }
 
 fn rand_key(rng: &mut impl Rng) -> [u8; 32] {

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -27,27 +27,29 @@ pub fn main() -> Result<()> {
 }
 
 pub fn init(params: WorkloadParams) -> Result<()> {
-    let workload = workload::parse(
+    let (mut init, _) = workload::parse(
         params.name.as_str(),
         params.size,
         params.initial_capacity.map(|s| 1u64 << s).unwrap_or(0),
         params.percentage_cold,
     )?;
 
-    workload.init(&mut Backend::Nomt.instantiate(true));
+    let mut db = Backend::Nomt.instantiate(true);
+    db.execute(None, &mut init);
 
     Ok(())
 }
 
 pub fn run(params: WorkloadParams) -> Result<()> {
-    let workload = workload::parse(
+    let (_, mut workload) = workload::parse(
         params.name.as_str(),
         params.size,
         params.initial_capacity.map(|s| 1u64 << s).unwrap_or(0),
         params.percentage_cold,
     )?;
 
-    workload.run(&mut Backend::Nomt.instantiate(false), None, true);
+    let mut db = Backend::Nomt.instantiate(true);
+    db.execute(None, &mut *workload);
 
     Ok(())
 }

--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -1,14 +1,10 @@
-use crate::{
-    backend::{Action, Db},
-    timer::Timer,
-};
+use crate::{backend::Transaction, timer::Timer, workload::Workload};
 use fxhash::FxHashMap;
-use nomt::{KeyPath, KeyReadWrite, Nomt, Options};
+use nomt::{KeyPath, KeyReadWrite, Nomt, Options, Session};
 use sha2::Digest;
 use std::{collections::hash_map::Entry, path::PathBuf};
 
 const NOMT_DB_FOLDER: &str = "nomt_db";
-const NOMT_DB_FOLDER_COPY: &str = "nomt_db_copy";
 
 pub struct NomtDB {
     nomt: Nomt,
@@ -30,71 +26,66 @@ impl NomtDB {
         let nomt = Nomt::open(opts).unwrap();
         Self { nomt }
     }
-}
 
-impl Db for NomtDB {
-    fn open_copy(&self) -> Box<dyn Db> {
-        // Delete any previously existing copy of the db
-        let _ = std::fs::remove_dir_all(NOMT_DB_FOLDER_COPY);
-
-        std::process::Command::new("cp")
-            .args(["-r", NOMT_DB_FOLDER, NOMT_DB_FOLDER_COPY])
-            .output()
-            .expect("Impossible make a copy of the nomt db");
-
-        let opts = Options {
-            path: PathBuf::from(NOMT_DB_FOLDER_COPY),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        };
-
-        let nomt = Nomt::open(opts).unwrap();
-        Box::new(Self { nomt })
-    }
-
-    fn apply_actions(&mut self, actions: Vec<Action>, mut timer: Option<&mut Timer>) {
+    pub fn execute(&self, mut timer: Option<&mut Timer>, workload: &mut dyn Workload) {
         let _timer_guard_total = timer.as_mut().map(|t| t.record_span("workload"));
 
-        let mut session = self.nomt.begin_session();
-        let mut access: FxHashMap<KeyPath, KeyReadWrite> = FxHashMap::default();
+        let mut transaction = Tx {
+            session: self.nomt.begin_session(),
+            access: FxHashMap::default(),
+            timer,
+        };
 
-        for action in actions.into_iter() {
-            match action {
-                Action::Write { key, value } => {
-                    let key_path = sha2::Sha256::digest(key).into();
-                    let value = value.map(std::rc::Rc::new);
-                    let is_delete = value.is_none();
+        workload.run(&mut transaction);
 
-                    match access.entry(key_path) {
-                        Entry::Occupied(mut o) => {
-                            o.get_mut().write(value);
-                        }
-                        Entry::Vacant(v) => {
-                            v.insert(KeyReadWrite::Write(value));
-                        }
-                    }
-
-                    session.tentative_write_slot(key_path, is_delete);
-                }
-                Action::Read { key } => {
-                    let key_path = sha2::Sha256::digest(key).into();
-
-                    let _timer_guard_read = timer.as_mut().map(|t| t.record_span("read"));
-                    let _value = match access.entry(key_path) {
-                        Entry::Occupied(o) => o.get().last_value().cloned(),
-                        Entry::Vacant(v) => {
-                            let value = session.tentative_read_slot(key_path).unwrap();
-                            v.insert(KeyReadWrite::Read(value.clone()));
-                            value
-                        }
-                    };
-                }
-            }
-        }
+        let Tx {
+            session,
+            access,
+            mut timer,
+        } = transaction;
 
         let _timer_guard_commit = timer.as_mut().map(|t| t.record_span("commit_and_prove"));
         let mut actual_access: Vec<_> = access.into_iter().collect();
         actual_access.sort_by_key(|(k, _)| *k);
         self.nomt.commit_and_prove(session, actual_access).unwrap();
+    }
+}
+
+struct Tx<'a> {
+    timer: Option<&'a mut Timer>,
+    session: Session,
+    access: FxHashMap<KeyPath, KeyReadWrite>,
+}
+
+impl<'a> Transaction for Tx<'a> {
+    fn read(&mut self, key: &[u8]) -> Option<Vec<u8>> {
+        let key_path = sha2::Sha256::digest(key).into();
+        let _timer_guard_read = self.timer.as_mut().map(|t| t.record_span("read"));
+
+        match self.access.entry(key_path) {
+            Entry::Occupied(o) => o.get().last_value().map(|v| v.to_vec()),
+            Entry::Vacant(v) => {
+                let value = self.session.tentative_read_slot(key_path).unwrap();
+                v.insert(KeyReadWrite::Read(value.clone()));
+                value.map(|v| v.to_vec())
+            }
+        }
+    }
+
+    fn write(&mut self, key: &[u8], value: Option<&[u8]>) {
+        let key_path = sha2::Sha256::digest(key).into();
+        let value = value.map(|v| std::rc::Rc::new(v.to_vec()));
+        let is_delete = value.is_none();
+
+        match self.access.entry(key_path) {
+            Entry::Occupied(mut o) => {
+                o.get_mut().write(value);
+            }
+            Entry::Vacant(v) => {
+                v.insert(KeyReadWrite::Write(value));
+            }
+        }
+
+        self.session.tentative_write_slot(key_path, is_delete);
     }
 }

--- a/benchtop/src/sov_db.rs
+++ b/benchtop/src/sov_db.rs
@@ -1,17 +1,22 @@
-use crate::backend::{Action, Db};
+use crate::backend::Transaction;
 use crate::timer::Timer;
+use crate::workload::Workload;
+use fxhash::FxHashMap;
 use jmt::KeyHash;
-use jmt::{storage::TreeWriter, JellyfishMerkleTree};
+use jmt::{storage::TreeWriter, JellyfishMerkleTree, Version};
 use sov_db::state_db::StateDB;
 use sov_prover_storage_manager::SnapshotManager;
 use sov_schema_db::snapshot::DbSnapshot;
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::hash_map::Entry,
+    sync::{Arc, RwLock},
+};
 
 const SOV_DB_FOLDER: &str = "sov_db";
-const SOV_DB_FOLDER_COPY: &str = "sov_db_copy";
 
 pub struct SovDB {
     state_db: StateDB<SnapshotManager>,
+    version: Version,
 }
 
 impl SovDB {
@@ -29,40 +34,19 @@ impl SovDB {
         let state_db_snapshot = DbSnapshot::<SnapshotManager>::new(0, state_db_sm.into());
         let state_db = StateDB::with_db_snapshot(state_db_snapshot).unwrap();
 
-        Self { state_db }
+        Self {
+            state_db,
+            version: 1,
+        }
     }
-}
 
-impl Db for SovDB {
-    fn open_copy(&self) -> Box<dyn Db> {
-        // Delete any previously existing copy of the db
-        let _ = std::fs::remove_dir_all(SOV_DB_FOLDER_COPY);
-
-        std::process::Command::new("cp")
-            .args(["-r", SOV_DB_FOLDER, SOV_DB_FOLDER_COPY])
-            .output()
-            .expect("Impossible make a copy of the nomt db");
-
-        // Create the underlying rocks db database
-        let state_db_raw = StateDB::<SnapshotManager>::setup_schema_db(SOV_DB_FOLDER_COPY).unwrap();
-        // Create a 'dummy' SnapshotManager who just reads from the provided database
-        let state_db_sm = Arc::new(RwLock::new(SnapshotManager::orphan(state_db_raw)));
-        // Create a snapshot db and then the state db over RocksDB
-        let state_db_snapshot = DbSnapshot::<SnapshotManager>::new(0, state_db_sm.into());
-        let state_db = StateDB::with_db_snapshot(state_db_snapshot).unwrap();
-
-        Box::new(Self { state_db })
-    }
-    fn apply_actions(&mut self, actions: Vec<Action>, mut timer: Option<&mut Timer>) {
+    pub fn execute(&mut self, mut timer: Option<&mut Timer>, workload: &mut dyn Workload) {
         let _timer_guard_total = timer.as_mut().map(|t| t.record_span("workload"));
 
         self.state_db.inc_next_version();
 
         // Actions are applied to jmt and then applied to the backend
         let jmt = JellyfishMerkleTree::<_, sha2::Sha256>::new(&self.state_db);
-
-        let mut preimages = vec![];
-        let mut value_set = vec![];
 
         // Sov-db uses the struct `ProverStorage` to handle the modification of the trie.
         // https://github.com/Sovereign-Labs/sovereign-sdk/blob/2cc0656df3f12fca2026c20554b5f78ccb210b89/module-system/sov-state/src/prover_storage.rs#L75
@@ -86,40 +70,78 @@ impl Db for SovDB {
         // Reads are executed sequentially, reading actions, while writes
         // are collected and applied at the end before committing everything
         // to the database
-        //
-        // TODO: Collect writes is not technically correct, in a real scenario,
-        // there could be reads that refer to previous writes,
-        // but for now let's just collect them
-        for action in actions.into_iter() {
-            match action {
-                Action::Write { key, value } => {
-                    let key_hash = KeyHash::with::<sha2::Sha256>(&key);
 
-                    value_set.push((key_hash, value));
-                    preimages.push((key_hash, key.clone()));
-                }
-                Action::Read { key } => {
-                    let key_hash = KeyHash::with::<sha2::Sha256>(&key);
-
-                    let _timer_guard_read = timer.as_mut().map(|t| t.record_span("read"));
-                    let _result = jmt.get_with_proof(key_hash, 1);
-                }
-            }
-        }
-
+        let mut transaction = Tx {
+            timer,
+            access: FxHashMap::default(),
+            jmt,
+            version: self.version,
+        };
+        workload.run(&mut transaction);
+        let Tx {
+            mut timer,
+            mut access,
+            jmt,
+            ..
+        } = transaction;
         let _timer_guard_commit = timer.as_mut().map(|t| t.record_span("commit_and_prove"));
         // apply all writes
         // We are not interested in storing the witness, but we want to measure
         // the time required to create the proof
-        let (_new_root, _proof, tree_update) = jmt
-            .put_value_set_with_proof(value_set, 1)
-            .expect("JMT update must succeed");
+        let tree_update = {
+            let value_set = access
+                .iter_mut()
+                .map(|(k, v)| (k.clone(), v.as_mut().map(|v| std::mem::take(&mut v.value))));
+            let (_new_root, _proof, tree_update) = jmt
+                .put_value_set_with_proof(value_set, self.version)
+                .expect("JMT update must succeed");
 
-        self.state_db
-            .put_preimages(preimages.iter().map(|(k, v)| (*k, v)))
-            .unwrap();
+            tree_update
+        };
+
+        let preimages = access
+            .iter()
+            .filter_map(|(k, v)| v.as_ref().map(move |v| (*k, &v.preimage)));
+
+        self.state_db.put_preimages(preimages).unwrap();
         self.state_db
             .write_node_batch(&tree_update.node_batch)
             .unwrap();
+
+        self.version += 1;
+    }
+}
+
+struct ValueWithPreimage {
+    value: Vec<u8>,
+    preimage: Vec<u8>,
+}
+
+struct Tx<'a> {
+    timer: Option<&'a mut Timer>,
+    access: FxHashMap<KeyHash, Option<ValueWithPreimage>>,
+    jmt: JellyfishMerkleTree<'a, StateDB<SnapshotManager>, sha2::Sha256>,
+    version: Version,
+}
+
+impl<'a> Transaction for Tx<'a> {
+    fn read(&mut self, key: &[u8]) -> Option<Vec<u8>> {
+        let key_hash = KeyHash::with::<sha2::Sha256>(&key);
+        let _timer_guard_read = self.timer.as_mut().map(|t| t.record_span("read"));
+
+        match self.access.entry(key_hash) {
+            Entry::Occupied(o) => o.get().as_ref().map(|v| v.value.clone()),
+            Entry::Vacant(_) => self.jmt.get_with_proof(key_hash, self.version).unwrap().0,
+        }
+    }
+    fn write(&mut self, key: &[u8], value: Option<&[u8]>) {
+        let key_hash = KeyHash::with::<sha2::Sha256>(&key);
+
+        let value = value.map(|v| ValueWithPreimage {
+            value: v.to_vec(),
+            preimage: key.to_vec(),
+        });
+
+        self.access.insert(key_hash, value);
     }
 }

--- a/benchtop/src/transfer_workload.rs
+++ b/benchtop/src/transfer_workload.rs
@@ -1,81 +1,114 @@
-use crate::{backend::Action, workload::Workload};
+use crate::{
+    backend::Transaction,
+    workload::{Init, Workload},
+};
 
-// All transfers happen between different accounts.
-//
-// + `size` refers to the amount of transfer performed by the workload
-// + `percentage_cold_transfer` is the percentage of transfers to
-//    a non-existing account, the remaining portion of transfers are to existing accounts.
-//    It goes from 0 to 100
-// + `additional_initial_capacity` is the amount of elements already present in the storage
-// without counting all the accounts needed for the transfers.
-pub fn new_transfer_workload(
-    size: u64,
+/// Create an initialization command for this.
+pub fn init(num_accounts: u64) -> Init {
+    Init {
+        keys: (0..num_accounts).map(|id| encode_id(id).to_vec()).collect(),
+        value: encode_balance(1000).to_vec(),
+    }
+}
+
+fn encode_id(id: u64) -> [u8; 8] {
+    id.to_be_bytes()
+}
+
+fn encode_balance(balance: u64) -> [u8; 8] {
+    balance.to_be_bytes()
+}
+
+fn decode_balance(encoded: &[u8]) -> u64 {
+    let mut buf = [0; 8];
+    buf.copy_from_slice(encoded);
+    u64::from_be_bytes(buf)
+}
+
+/// Build a new workload meant to emulate transfers.
+///
+/// `num_accounts` refers to the amount of accounts in the database.
+///
+/// `percentage_cold_transfer` ranges from 0 to 100 and indicates the proportion of transfers
+/// which should be sent to a fresh account.
+pub fn build(
+    num_accounts: u64,
+    workload_size: u64,
     percentage_cold_transfer: u8,
-    additional_initial_capacity: u64,
-) -> Workload {
-    // `size` define the numer of transfer,
-    // the total number of accounts used is `size * 2`
-    //
-    let n_sender_accounts = size;
-    let sender_accounts = 0..n_sender_accounts;
-    // (cold) non existing accounts
-    let n_cold_accounts =
-        (n_sender_accounts as f64 * (percentage_cold_transfer as f64 / 100.0)) as u64;
-    // (warm) alredy existing accounts
-    let n_warm_accounts = n_sender_accounts - n_cold_accounts;
-    let warm_accounts = n_sender_accounts..n_sender_accounts + n_warm_accounts;
-    // warm and cold accounts will receive balance from the senders
+) -> TransferWorkload {
+    TransferWorkload {
+        num_accounts,
+        workload_size,
+        runs: 0,
+        percentage_cold_transfer,
+    }
+}
 
-    let n_total_accouts = n_sender_accounts + n_cold_accounts + n_warm_accounts;
+/// A transfer-like workload.
+pub struct TransferWorkload {
+    /// The number of accounts in the system.
+    pub num_accounts: u64,
+    /// The size of the workload.
+    pub workload_size: u64,
+    /// The number of runs performed.
+    pub runs: usize,
+    /// The percentage of transfers to make to fresh accounts.
+    pub percentage_cold_transfer: u8,
+}
 
-    // 0..n_sender_accounts are sender accounts
-    // n_sender_accounts..n_sender_accounts + n_warm_accounts are warm receiver
-    // n_sender_accounts + n_warm_accounts..n_total_accouts are cold receiver
+impl Workload for TransferWorkload {
+    fn run(&mut self, transaction: &mut dyn Transaction) {
+        let old_num_accounts = self.num_accounts as usize;
 
-    // prepare additional random entries
-    let additional_keys = n_total_accouts..n_total_accouts + additional_initial_capacity;
+        let cold_sends =
+            (old_num_accounts as f64 * (self.percentage_cold_transfer as f64 / 100.0)) as u64;
+        let warm_sends = self.workload_size - cold_sends;
 
-    let init_balance = Some(1000u64.to_be_bytes().to_vec());
-    let initial_writes: Vec<Action> = sender_accounts
-        .clone()
-        .chain(warm_accounts)
-        .chain(additional_keys)
-        .map(|id| Action::Write {
-            key: id.to_be_bytes().to_vec(),
-            value: init_balance.clone(),
-        })
-        .collect();
+        let mut start_offset = (self.runs * self.workload_size as usize) % old_num_accounts;
 
-    let mut transfer_actions = vec![];
-    let balance_from = Some(900u64.to_be_bytes().to_vec());
-    let balance_warm_to = Some(1100u64.to_be_bytes().to_vec());
-    let balance_cold_to = Some(100u64.to_be_bytes().to_vec());
-    // create the transfer vector of actions
-    for from in sender_accounts.into_iter() {
-        let to = from + n_sender_accounts;
-        let balance_to = if from < n_warm_accounts {
-            balance_warm_to.clone()
-        } else {
-            balance_cold_to.clone()
-        };
+        for i in 0..self.workload_size {
+            // totally arbitrary choice.
+            let send_account = start_offset as u64;
+            let recv_account = if i < warm_sends {
+                (old_num_accounts - start_offset) as u64
+            } else {
+                let a = self.num_accounts;
+                self.num_accounts += 1;
+                a
+            };
 
-        let from = from.to_be_bytes().to_vec();
-        let to = to.to_be_bytes().to_vec();
+            let send_balance = decode_balance(
+                &transaction
+                    .read(&encode_id(send_account))
+                    .expect("account exists"),
+            );
+            let recv_balance = transaction
+                .read(&encode_id(recv_account))
+                .map_or(0, |v| decode_balance(&v));
 
-        transfer_actions.push(Action::Read { key: from.clone() });
-        transfer_actions.push(Action::Read { key: to.clone() });
-        transfer_actions.push(Action::Write {
-            key: from,
-            value: balance_from.clone(),
-        });
-        transfer_actions.push(Action::Write {
-            key: to,
-            value: balance_to,
-        });
+            let new_send_balance = if send_balance == 0 {
+                1000 // yay, free money.
+            } else {
+                send_balance - 1
+            };
+            let new_recv_balance = recv_balance + 1;
+
+            transaction.write(
+                &encode_id(send_account),
+                Some(&encode_balance(new_send_balance)),
+            );
+            transaction.write(
+                &encode_id(recv_account),
+                Some(&encode_balance(new_recv_balance)),
+            );
+
+            start_offset = (start_offset + 1) % old_num_accounts;
+        }
+
+        self.runs += 1;
     }
 
-    Workload {
-        init_actions: initial_writes,
-        run_actions: transfer_actions,
+    fn size(&self) -> usize {
+        self.workload_size as usize
     }
 }


### PR DESCRIPTION
I reworked benchtop to produce a new workload each iteration rather than applying the same actions
each time.

This actually brings the sp-trie benchmark more in line with NOMT on commit, because it has a fast
path for when trie nodes aren't altered, and this is what we were seeing before.

I think this will lead to much more realistic testing.

I also removed a few things:
  1. Sequential workload - because we hash keys, they're not sequential. I still would like to have
     this at some point, but it doesn't make sense until we don't hash keys.
  2. Action - because generating fresh actions each time is really what we should be doing.