### PR TITLE
refactor: remove leaf_meta

### DIFF
--- a/nomt/src/page_walker.rs
+++ b/nomt/src/page_walker.rs
@@ -508,7 +508,6 @@ impl<H: NodeHasher> PageWalker<H> {
         let diff = self.diffs.entry(page_id.clone()).or_default();
         diff.set_changed(children.left());
         diff.set_changed(children.right());
-        diff.set_changed(crate::page_cache::LEAF_META_BITFIELD_SLOT);
     }
 
     fn assert_page_in_scope(&self, page_id: Option<&PageId>) {


### PR DESCRIPTION
This removes the leaf_meta bitfield from pages. It was only necessary because the cursor API
couldn't rely on a user removing the leaf children before writing nodes below the leaf. Now that
we've moved update over to the page-walker in #170, it is no longer necessary.