### PR TITLE
examples: init read_value, commit_batch and witness_verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,10 +165,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "commit-batch"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "nomt",
+ "sha2",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam"
@@ -218,6 +245,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +276,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -284,6 +331,16 @@ dependencies = [
  "log",
  "rustversion",
  "windows",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -378,7 +435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -680,6 +737,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "read_value"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "nomt",
+ "sha2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +898,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1027,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1049,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -1153,6 +1242,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "witness_verification"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "commit-batch",
+ "nomt-core",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "nomt", "fuzz"]
+members = ["core", "nomt", "fuzz", "examples/*"]
 exclude = [ "benchtop" ]
 
 [workspace.package]

--- a/examples/commit_batch/Cargo.toml
+++ b/examples/commit_batch/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "commit-batch"
+version = "0.1.0"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nomt = { path = "../../nomt"  }
+anyhow = "1.0.81"
+sha2 = "0.10.6"

--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use nomt::{KeyReadWrite, Node, Nomt, Options, Witness, WitnessedOperations};
+use sha2::Digest;
+use std::path::PathBuf;
+
+const NOMT_DB_FOLDER: &str = "nomt_db";
+
+pub struct NomtDB;
+
+impl NomtDB {
+    pub fn commit_batch() -> Result<(Node, Node, Witness, WitnessedOperations)> {
+        // Define the options used to open NOMT
+        let opts = Options {
+            path: PathBuf::from(NOMT_DB_FOLDER),
+            fetch_concurrency: 1,
+            traversal_concurrency: 1,
+        };
+
+        // Open NOMT database, it will create the folder if it does not exist
+        let nomt = Nomt::open(opts)?;
+
+        // Create a new Session object
+        //
+        // During a session, the backend is responsible for returning read keys
+        // and receiving hints about future writes
+        //
+        // Writes do not occur immediately, instead,
+        // they are cached and applied all at once later on
+        let mut session = nomt.begin_session();
+
+        // Here we will move the data saved under b"key1" to b"key2" and deletes it
+        //
+        // NOMT expects keys to be uniformly distributed across the key space
+        let key_path_1 = sha2::Sha256::digest(b"key1").into();
+        let key_path_2 = sha2::Sha256::digest(b"key2").into();
+
+        // First, read what is under key_path_1
+        //
+        // `tentative_read_slot` will immediately return the value present in the database
+        let value = session.tentative_read_slot(key_path_1)?;
+
+        // Second, write the value to key_path_2 and delete key_path_1
+        //
+        // As we can observe, the value is not being written at the moment.
+        // NOMT is just advertised here to inform that those keys
+        // will be written during the commit and prove stage
+        session.tentative_write_slot(key_path_1, true);
+        session.tentative_write_slot(key_path_2, false);
+
+        // Retrieve the previous value of the root before committing changes
+        let prev_root = nomt.root();
+
+        // To commit the batch to the backend we need to collect every
+        // performed actions into a vector where items are ordered by the key_path
+        let mut actual_access: Vec<_> = vec![
+            (key_path_1, KeyReadWrite::ReadThenWrite(value.clone(), None)),
+            (key_path_2, KeyReadWrite::Write(value)),
+        ];
+        actual_access.sort_by_key(|(k, _)| *k);
+
+        // The final step in handling a session involves committing all changes
+        // to update the trie structure and obtaining the new root of the trie,
+        // along with a witness and the witnessed operations.
+        let (root, witness, witnessed) = nomt.commit_and_prove(session, actual_access)?;
+
+        Ok((prev_root, root, witness, witnessed))
+    }
+}

--- a/examples/commit_batch/src/main.rs
+++ b/examples/commit_batch/src/main.rs
@@ -1,0 +1,3 @@
+fn main() -> anyhow::Result<()> {
+    commit_batch::NomtDB::commit_batch().map(|_| ())
+}

--- a/examples/read_value/Cargo.toml
+++ b/examples/read_value/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "read_value"
+version = "0.1.0"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nomt = { path = "../../nomt"  }
+anyhow = "1.0.81"
+sha2 = "0.10.6"

--- a/examples/read_value/src/main.rs
+++ b/examples/read_value/src/main.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use nomt::{Nomt, Options};
+use sha2::Digest;
+use std::path::PathBuf;
+
+const NOMT_DB_FOLDER: &str = "nomt_db";
+
+fn main() -> Result<()> {
+    // Define the options used to open NOMT
+    let opts = Options {
+        path: PathBuf::from(NOMT_DB_FOLDER),
+        fetch_concurrency: 1,
+        traversal_concurrency: 1,
+    };
+
+    // Open nomt database, it will create the folder if it does not exist
+    let nomt = Nomt::open(opts)?;
+
+    // Instantiate a new Session object to handle read and write operations
+    // and generate a Witness later on
+    let mut session = nomt.begin_session();
+
+    // Reading a key from the database
+    let key_path = sha2::Sha256::digest(b"key").into();
+    let _value = session.tentative_read_slot(key_path)?;
+
+    Ok(())
+}

--- a/examples/witness_verification/Cargo.toml
+++ b/examples/witness_verification/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "witness_verification"
+version = "0.1.0"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nomt-core = { path = "../../core"  }
+commit-batch = { path = "../commit_batch"  }
+anyhow = "1.0.81"
+blake3 = "1.5.1"

--- a/examples/witness_verification/src/main.rs
+++ b/examples/witness_verification/src/main.rs
@@ -1,0 +1,94 @@
+use anyhow::Result;
+use nomt_core::{
+    proof,
+    trie::{LeafData, NodeHasher},
+};
+
+// Hash nodes using blake3. The Hasher below will be utilized in the witness
+// verification stage and must conform to the hash used in the commitment
+// phase and subsequently during witness creation
+pub struct Blake3Hasher;
+
+impl NodeHasher for Blake3Hasher {
+    fn hash_node(data: &nomt_core::trie::NodePreimage) -> [u8; 32] {
+        blake3::hash(data).into()
+    }
+}
+
+fn main() -> Result<()> {
+    // The witness produced in the example `commit_batch` will be used
+    let (prev_root, new_root, witness, witnessed) = commit_batch::NomtDB::commit_batch().unwrap();
+
+    let mut updates = Vec::new();
+
+    // A witness is composed of multiple WitnessedPath objects,
+    // which stores all the necessary information to verify the operations
+    // performed on the same path
+    for (i, witnessed_path) in witness.path_proofs.iter().enumerate() {
+        // Constructing the verified operations
+        let verified = witnessed_path
+            .inner
+            .verify::<Blake3Hasher>(&witnessed_path.path, prev_root)
+            .unwrap();
+
+        // Among all read operations performed the ones that interact
+        // with the current verified path are selected
+        //
+        // Each witnessed operation contains an index to the path it needs to be verified against
+        //
+        // This information could already be known if we committed the batch initially,
+        // and thus, the witnessed field could be discarded entirely.
+        for read in witnessed
+            .reads
+            .iter()
+            .skip_while(|r| r.path_index != i)
+            .take_while(|r| r.path_index == i)
+        {
+            match read.value {
+                // Check for non-existence if the return value was None
+                None => assert!(verified.confirm_nonexistence(&read.key).unwrap()),
+                // Verify the correctness of the returned value when it is Some(_)
+                Some(ref v) => {
+                    let leaf = LeafData {
+                        key_path: read.key,
+                        value_hash: *blake3::hash(v).as_bytes(),
+                    };
+                    assert!(verified.confirm_value(&leaf).unwrap());
+                }
+            }
+        }
+
+        // The correctness of write operations cannot be easily verified like reads.
+        // Write operations need to be collected.
+        // All writes that have worked on shared prefixes,
+        // such as the witnessed_path, need to be bundled together.
+        // Later, it needs to be verified that all these writes bring
+        // the new trie to the expected state
+        let mut write_ops = Vec::new();
+        for write in witnessed
+            .writes
+            .iter()
+            .skip_while(|r| r.path_index != i)
+            .take_while(|r| r.path_index == i)
+        {
+            write_ops.push((
+                write.key,
+                write.value.as_ref().map(|v| *blake3::hash(v).as_bytes()),
+            ));
+        }
+
+        if !write_ops.is_empty() {
+            updates.push(proof::PathUpdate {
+                inner: verified,
+                ops: write_ops,
+            });
+        }
+    }
+
+    assert_eq!(
+        proof::verify_update::<Blake3Hasher>(prev_root, &updates).unwrap(),
+        new_root,
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Introducing the initial version of examples. They are:
1. read_value :: Simply open nomt and read a value from it
2. commit_batch :: Describing all the processes required to effectively read and write values to storage, explained through a simple example of a transfer workload
3. witness_verification :: Explaining how witnesses should be verified