### PR TITLE
feat: sharded page cache + LRU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +22,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anyhow"
@@ -365,6 +383,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -503,6 +525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +586,7 @@ dependencies = [
  "fxhash",
  "hex-literal",
  "loom",
+ "lru",
  "nomt-core",
  "parking_lot",
  "rand",
@@ -1260,6 +1292,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -21,6 +21,7 @@ blake3 = "1.5.1"
 fxhash = "0.2.1"
 dashmap = "5.5.3"
 crossbeam = "0.8.4"
+lru = "0.12.3"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -1,47 +1,54 @@
 use crate::{
     page_region::PageRegion,
-    rw_pass_cell::{ReadPass, RegionContains, RwPassCell, RwPassDomain, WritePass},
+    rw_pass_cell::{ReadPass, Region, RegionContains, RwPassCell, RwPassDomain, WritePass},
     store::{Store, Transaction},
     Options,
 };
 use bitvec::prelude::*;
-use dashmap::{mapref::entry::Entry, DashMap};
-use fxhash::FxBuildHasher;
+use fxhash::{FxBuildHasher, FxHashMap};
+use lru::LruCache;
 use nomt_core::{
     page::DEPTH,
-    page_id::{PageId, ROOT_PAGE_ID},
+    page_id::{ChildPageIndex, PageId, NUM_CHILDREN, ROOT_PAGE_ID},
     trie::{LeafData, Node},
     trie_pos::{ChildNodeIndices, TriePosition},
 };
-use parking_lot::{Condvar, Mutex};
-use std::{fmt, mem, sync::Arc};
+use parking_lot::{Condvar, Mutex, RwLock};
+use std::{collections::hash_map::Entry, fmt, num::NonZeroUsize, sync::Arc};
 use threadpool::ThreadPool;
+
+#[cfg(test)]
+use dashmap::DashMap;
 
 // Total number of nodes stored in one Page. It depends on the `DEPTH`
 // of the rootless sub-binary tree stored in a page following this formula:
 // (2^(DEPTH + 1)) - 2
 pub const NODES_PER_PAGE: usize = (1 << DEPTH + 1) - 2;
 
+// Every 256 pages is 1MB.
+const CACHE_PAGE_LIMIT: usize = 256 * 256;
+const PAGE_LIMIT_PER_ROOT_CHILD: usize = CACHE_PAGE_LIMIT / 64;
+
 struct PageData {
-    data: RwPassCell<Option<Vec<u8>>, PageId>,
+    data: RwPassCell<Option<Vec<u8>>, ShardIndex>,
 }
 
 impl PageData {
     /// Creates a page with the given data.
-    fn pristine_with_data(domain: &RwPassDomain, page_id: PageId, data: Vec<u8>) -> Self {
+    fn pristine_with_data(domain: &RwPassDomain, shard_index: ShardIndex, data: Vec<u8>) -> Self {
         Self {
-            data: domain.protect_with_id(Some(data), page_id),
+            data: domain.protect_with_id(Some(data), shard_index),
         }
     }
 
     /// Creates an empty page.
-    fn pristine_empty(domain: &RwPassDomain, page_id: PageId) -> Self {
+    fn pristine_empty(domain: &RwPassDomain, shard_index: ShardIndex) -> Self {
         Self {
-            data: domain.protect_with_id(None, page_id),
+            data: domain.protect_with_id(None, shard_index),
         }
     }
 
-    fn node(&self, read_pass: &ReadPass<impl RegionContains<PageId>>, index: usize) -> Node {
+    fn node(&self, read_pass: &ReadPass<impl RegionContains<ShardIndex>>, index: usize) -> Node {
         assert!(index < NODES_PER_PAGE, "index out of bounds");
         let data = self.data.read(read_pass);
         if let Some(data) = &*data {
@@ -57,7 +64,7 @@ impl PageData {
 
     fn set_node(
         &self,
-        write_pass: &mut WritePass<impl RegionContains<PageId>>,
+        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
         index: usize,
         node: Node,
     ) {
@@ -71,7 +78,7 @@ impl PageData {
 
     fn set_leaf_data(
         &self,
-        write_pass: &mut WritePass<impl RegionContains<PageId>>,
+        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
         children: ChildNodeIndices,
         leaf_data: LeafData,
     ) {
@@ -87,7 +94,7 @@ impl PageData {
 
     fn clear_leaf_data(
         &self,
-        write_pass: &mut WritePass<impl RegionContains<PageId>>,
+        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
         children: ChildNodeIndices,
     ) {
         let left_index = children.left();
@@ -130,11 +137,6 @@ impl PageDiff {
     }
 }
 
-enum PageState {
-    Inflight(Arc<InflightFetch>),
-    Cached(Arc<PageData>),
-}
-
 /// A handle to the page.
 ///
 /// Can be cloned cheaply.
@@ -145,14 +147,18 @@ pub struct Page {
 
 impl Page {
     /// Read out the node at the given index.
-    pub fn node(&self, read_pass: &ReadPass<impl RegionContains<PageId>>, index: usize) -> Node {
+    pub fn node(
+        &self,
+        read_pass: &ReadPass<impl RegionContains<ShardIndex>>,
+        index: usize,
+    ) -> Node {
         self.inner.node(read_pass, index)
     }
 
     /// Write the node at the given index.
     pub fn set_node(
         &self,
-        write_pass: &mut WritePass<impl RegionContains<PageId>>,
+        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
         index: usize,
         node: Node,
     ) {
@@ -162,7 +168,7 @@ impl Page {
     /// Write leaf data at two positions under a leaf node.
     pub fn set_leaf_data(
         &self,
-        write_pass: &mut WritePass<impl RegionContains<PageId>>,
+        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
         children: ChildNodeIndices,
         leaf_data: LeafData,
     ) {
@@ -172,7 +178,7 @@ impl Page {
     /// Clear leaf data at two child positions.
     pub fn clear_leaf_data(
         &self,
-        write_pass: &mut WritePass<impl RegionContains<PageId>>,
+        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
         children: ChildNodeIndices,
     ) {
         self.inner.clear_leaf_data(write_pass, children)
@@ -269,39 +275,121 @@ impl PageStore {
     }
 }
 
-/// The page-cache provides an in-memory layer between the user and the underlying DB.
-/// It stores full pages and can be shared between threads.
-#[derive(Clone)]
-pub struct PageCache {
-    shared: Arc<Shared>,
+// Each shard has its own domain and handles a sub-tree of the page tree, defined by a
+// continuous set of children of the root page.
+struct CacheShard {
+    region: PageRegion,
+    locked: Mutex<CacheShardLocked>,
+    page_limit: NonZeroUsize,
+}
+
+struct CacheShardLocked {
+    inflight: FxHashMap<PageId, Arc<InflightFetch>>,
+    cached: LruCache<PageId, Arc<PageData>, FxBuildHasher>,
+}
+
+impl CacheShardLocked {
+    fn evict(&mut self, limit: NonZeroUsize) {
+        while self.cached.len() > limit.get() {
+            let _ = self.cached.pop_lru();
+        }
+    }
 }
 
 struct Shared {
+    shards: Vec<CacheShard>,
+    root_page: RwLock<Arc<PageData>>,
     page_rw_pass_domain: RwPassDomain,
     store: PageStore,
     /// The thread pool used for fetching pages from the store.
     ///
     /// Used for limiting the number of concurrent page fetches.
     fetch_tp: ThreadPool,
-    /// The pages loaded from the store, possibly dirty.
-    cached: DashMap<PageId, PageState, FxBuildHasher>,
+}
+
+fn shard_regions(num_shards: usize) -> Vec<(PageRegion, usize)> {
+    // We apply a simple strategy that assumes keys are uniformly distributed, and give
+    // each shard an approximately even number of root child pages. This scales well up to
+    // 64 shards.
+    // The first `remainder` shards get `part + 1` children and the rest get `part`.
+    let part = NUM_CHILDREN / num_shards;
+    let remainder = NUM_CHILDREN % num_shards;
+
+    let mut regions = Vec::with_capacity(num_shards);
+    for shard_index in 0..num_shards {
+        let (start, count) = if shard_index >= remainder {
+            (part * shard_index + remainder, part)
+        } else {
+            (part * shard_index + shard_index, part + 1)
+        };
+
+        // UNWRAP: start / start + count are both less than the number of children.
+        let start_child = ChildPageIndex::new(start as u8).unwrap();
+        let end_child = ChildPageIndex::new((start + count - 1) as u8).unwrap();
+        let region = PageRegion::from_page_id_descendants(ROOT_PAGE_ID, start_child, end_child);
+        regions.push((region, count));
+    }
+
+    regions
+}
+
+fn make_shards(num_shards: usize) -> Vec<CacheShard> {
+    assert!(num_shards > 0);
+    shard_regions(num_shards)
+        .into_iter()
+        .map(|(region, count)| CacheShard {
+            region,
+            locked: Mutex::new(CacheShardLocked {
+                inflight: FxHashMap::default(),
+                cached: LruCache::unbounded_with_hasher(FxBuildHasher::default()),
+            }),
+            // UNWRAP: both factors are non-zero
+            page_limit: NonZeroUsize::new(PAGE_LIMIT_PER_ROOT_CHILD * count).unwrap(),
+        })
+        .collect()
+}
+
+/// The index of a shard of a page cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShardIndex {
+    /// The "shard" containing nothing but the root page.
+    Root,
+    /// The shard with the given index.
+    Shard(usize),
+}
+
+/// The page-cache provides an in-memory layer between the user and the underyling DB.
+/// It stores full pages and can be shared between threads.
+///
+/// It has a sharded representation for efficient concurrent access.
+#[derive(Clone)]
+pub struct PageCache {
+    shared: Arc<Shared>,
 }
 
 impl PageCache {
     /// Create a new `PageCache` atop the provided [`Store`].
-    pub fn new(store: Store, o: &Options) -> Self {
+    pub fn new(store: Store, o: &Options) -> anyhow::Result<Self> {
         let fetch_tp = threadpool::Builder::new()
             .num_threads(o.fetch_concurrency)
             .thread_name("nomt-page-fetch".to_string())
             .build();
-        Self {
+
+        let domain = RwPassDomain::new();
+        let root_page = store.load_page(ROOT_PAGE_ID)?.map_or_else(
+            || PageData::pristine_empty(&domain, ShardIndex::Root),
+            |data| PageData::pristine_with_data(&domain, ShardIndex::Root, data),
+        );
+
+        Ok(Self {
             shared: Arc::new(Shared {
-                page_rw_pass_domain: RwPassDomain::new(),
-                cached: DashMap::with_hasher(FxBuildHasher::default()),
+                shards: make_shards(o.fetch_concurrency),
+                root_page: RwLock::new(Arc::new(root_page)),
+                page_rw_pass_domain: domain,
                 store: PageStore::Real(store),
                 fetch_tp,
             }),
-        }
+        })
     }
 
     /// Create a new `PageCache` with a mocked store for testing.
@@ -312,13 +400,33 @@ impl PageCache {
             .thread_name("nomt-page-fetch".to_string())
             .build();
 
+        let domain = RwPassDomain::new();
+        let root_page = PageData::pristine_empty(&domain, ShardIndex::Root);
+
         Self {
             shared: Arc::new(Shared {
-                page_rw_pass_domain: RwPassDomain::new(),
-                cached: DashMap::with_hasher(FxBuildHasher::default()),
+                shards: make_shards(o.fetch_concurrency),
+                root_page: RwLock::new(Arc::new(root_page)),
+                page_rw_pass_domain: domain,
                 store: PageStore::Mock(DashMap::new()),
                 fetch_tp,
             }),
+        }
+    }
+
+    fn shard_index_for(&self, page_id: &PageId) -> Option<usize> {
+        if page_id == &ROOT_PAGE_ID {
+            None
+        } else {
+            let res = self
+                .shared
+                .shards
+                .iter()
+                .position(|s| s.region.contains_exclusive(&page_id));
+
+            // note: this is ALWAYS `Some` because the whole page space is covered.
+            assert!(res.is_some());
+            res
         }
     }
 
@@ -327,10 +435,22 @@ impl PageCache {
     /// If the page is already in the cache, this method does nothing. Otherwise, it fetches the
     /// page from the underlying store and caches it.
     pub fn prepopulate(&self, page_id: PageId) {
-        if let Entry::Vacant(v) = self.shared.cached.entry(page_id.clone()) {
+        let shard_index = match self.shard_index_for(&page_id) {
+            None => return, // root is always populated.
+            Some(index) => index,
+        };
+
+        let mut shard = self.shard(shard_index).locked.lock();
+
+        if !shard.cached.contains(&page_id) {
+            let v = match shard.inflight.entry(page_id.clone()) {
+                Entry::Vacant(v) => v,
+                Entry::Occupied(_) => return, // fetch in-flight already.
+            };
+
             // Nope, then we need to fetch the page from the store.
             let inflight = Arc::new(InflightFetch::new());
-            v.insert(PageState::Inflight(inflight.clone()));
+            v.insert(inflight.clone());
             let task = {
                 let shared = self.shared.clone();
                 move || {
@@ -347,35 +467,32 @@ impl PageCache {
                             || {
                                 PageData::pristine_empty(
                                     &shared.page_rw_pass_domain,
-                                    page_id.clone(),
+                                    ShardIndex::Shard(shard_index),
                                 )
                             },
                             |data| {
                                 PageData::pristine_with_data(
                                     &shared.page_rw_pass_domain,
-                                    page_id.clone(),
+                                    ShardIndex::Shard(shard_index),
                                     data,
                                 )
                             },
                         );
                     let entry = Arc::new(entry);
 
-                    // Unwrap: the operation was inserted above. It is scheduled for execution only
-                    // once. It may removed only in the line below. Therefore, `None` is impossible.
-                    let mut page_state_guard = shared.cached.get_mut(&page_id).unwrap();
-                    let page_state = page_state_guard.value_mut();
-
-                    if let PageState::Cached(_) = page_state {
+                    let mut shard = shared.shards[shard_index].locked.lock();
+                    if shard.cached.contains(&page_id) {
                         // We race against pre-emption in the case other code pre-empts us by
                         // allocating an empty page.
                         return;
                     }
 
-                    if let PageState::Inflight(inflight) =
-                        mem::replace(page_state, PageState::Cached(entry.clone()))
-                    {
-                        inflight.complete_and_notify(Page { inner: entry });
-                    }
+                    // UNWRAP: if we haven't been pre-empted, this can not have been
+                    // removed.
+                    let inflight = shard.inflight.remove(&page_id).unwrap();
+
+                    shard.cached.push(page_id.clone(), entry.clone());
+                    inflight.complete_and_notify(Page { inner: entry });
                 }
             };
             self.shared.fetch_tp.execute(task);
@@ -389,25 +506,23 @@ impl PageCache {
     /// This is not guaranteed to cancel the request if it is already being processed by a
     /// DB thread.
     pub fn cancel_prepopulate(&self, page_id: PageId) {
-        let Some(mut page_state_guard) = self.shared.cached.get_mut(&page_id) else {
+        let shard_index = match self.shard_index_for(&page_id) {
+            None => return, // root always populated.
+            Some(i) => i,
+        };
+
+        let mut shard = self.shard(shard_index).locked.lock();
+        let page_data = Arc::new(PageData::pristine_empty(
+            &self.shared.page_rw_pass_domain,
+            ShardIndex::Shard(shard_index),
+        ));
+
+        let Some(inflight) = shard.inflight.remove(&page_id) else {
             return;
         };
-        let page_state = page_state_guard.value_mut();
 
-        let page_data = {
-            let PageState::Inflight(inflight) = page_state else {
-                return;
-            };
-            let page_data = Arc::new(PageData::pristine_empty(
-                &self.shared.page_rw_pass_domain,
-                page_id.clone(),
-            ));
-            inflight.complete_and_notify(Page {
-                inner: page_data.clone(),
-            });
-            page_data
-        };
-        *page_state = PageState::Cached(page_data);
+        shard.cached.push(page_id.clone(), page_data.clone());
+        inflight.complete_and_notify(Page { inner: page_data });
     }
 
     /// Retrieves the page data at the given [`PageId`] synchronously.
@@ -418,56 +533,63 @@ impl PageCache {
     ///
     /// This method is blocking, but doesn't suffer from the channel overhead.
     pub fn retrieve_sync(&self, page_id: PageId, hint_fresh: bool) -> Page {
-        let maybe_inflight = match self.shared.cached.entry(page_id.clone()) {
-            Entry::Occupied(mut o) => {
-                let page = o.get_mut();
-                match page {
-                    PageState::Cached(ref page) => {
-                        return Page {
-                            inner: page.clone(),
-                        };
-                    }
-                    PageState::Inflight(ref inflight) => {
-                        if hint_fresh {
-                            // pre-empt stale fetch.
-
-                            let page_data = Arc::new(PageData::pristine_empty(
-                                &self.shared.page_rw_pass_domain,
-                                page_id,
-                            ));
-                            let fresh_page = Page {
-                                inner: page_data.clone(),
-                            };
-
-                            inflight.complete_and_notify(fresh_page.clone());
-                            *page = PageState::Cached(page_data);
-                            return fresh_page;
-                        } else {
-                            Some(inflight.clone())
-                        }
-                    }
-                }
+        let shard_index = match self.shard_index_for(&page_id) {
+            None => {
+                let page_data = self.shared.root_page.read().clone();
+                return Page { inner: page_data };
             }
-            Entry::Vacant(v) => {
-                if hint_fresh {
-                    let page_data = Arc::new(PageData::pristine_empty(
-                        &self.shared.page_rw_pass_domain,
-                        page_id,
-                    ));
-                    let page = Page {
-                        inner: page_data.clone(),
-                    };
-                    v.insert(PageState::Cached(page_data));
-                    return page;
-                }
-                v.insert(PageState::Inflight(Arc::new(InflightFetch::new())));
-                None
-            }
+            Some(i) => i,
         };
 
-        // do not wait with dashmap lock held; deadlock
-        if let Some(existing_inflight) = maybe_inflight {
-            return existing_inflight.wait();
+        let mut shard = self.shard(shard_index).locked.lock();
+        if let Some(page) = shard.cached.get(&page_id) {
+            return Page {
+                inner: page.clone(),
+            };
+        }
+
+        let shard_mut = &mut *shard;
+        let existing_inflight = if let Some(inflight) = shard_mut.inflight.get(&page_id) {
+            if hint_fresh {
+                // pre-empt stale fetch.
+
+                let page_data = Arc::new(PageData::pristine_empty(
+                    &self.shared.page_rw_pass_domain,
+                    ShardIndex::Shard(shard_index),
+                ));
+
+                let fresh_page = Page {
+                    inner: page_data.clone(),
+                };
+
+                shard_mut.cached.push(page_id.clone(), page_data.clone());
+                inflight.complete_and_notify(fresh_page.clone());
+                shard_mut.inflight.remove(&page_id);
+                return fresh_page;
+            } else {
+                Some(inflight.clone())
+            }
+        } else if hint_fresh {
+            let page_data = Arc::new(PageData::pristine_empty(
+                &self.shared.page_rw_pass_domain,
+                ShardIndex::Shard(shard_index),
+            ));
+
+            let fresh_page = Page {
+                inner: page_data.clone(),
+            };
+            shard_mut.cached.push(page_id, page_data);
+            return fresh_page;
+        } else {
+            None
+        };
+
+        // do not wait with shard lock held; deadlock
+        drop(shard);
+
+        if let Some(inflight) = existing_inflight {
+            let page = inflight.wait();
+            return page;
         }
 
         let entry = self
@@ -476,31 +598,35 @@ impl PageCache {
             .load_page(page_id.clone())
             .expect("db load failed") // TODO: handle the error
             .map_or_else(
-                || PageData::pristine_empty(&self.shared.page_rw_pass_domain, page_id.clone()),
+                || {
+                    PageData::pristine_empty(
+                        &self.shared.page_rw_pass_domain,
+                        ShardIndex::Shard(shard_index),
+                    )
+                },
                 |data| {
                     PageData::pristine_with_data(
                         &self.shared.page_rw_pass_domain,
-                        page_id.clone(),
+                        ShardIndex::Shard(shard_index),
                         data,
                     )
                 },
             );
+
         let entry = Arc::new(entry);
 
-        // UNWRAP: we inserted a value into the map which cannot have been evicted in the meantime.
-        let mut page_state_guard = self.shared.cached.get_mut(&page_id).unwrap();
-        let page_state = page_state_guard.value_mut();
+        // re-acquire lock after doing I/O
+        let mut shard = self.shard(shard_index).locked.lock();
 
-        if let PageState::Cached(page_data) = page_state {
-            // pre-empted by retrieve_sync (hint_fresh=true) on another thread
+        if let Some(page) = shard.cached.peek(&page_id) {
+            // pre-empted while lock wasn't held
             return Page {
-                inner: page_data.clone(),
+                inner: page.clone(),
             };
         }
 
-        if let PageState::Inflight(inflight) =
-            std::mem::replace(page_state, PageState::Cached(entry.clone()))
-        {
+        shard.cached.push(page_id.clone(), entry.clone());
+        if let Some(inflight) = shard.inflight.remove(&page_id) {
             inflight.complete_and_notify(Page {
                 inner: entry.clone(),
             });
@@ -509,19 +635,33 @@ impl PageCache {
     }
 
     /// Acquire a read pass for all pages in the cache.
-    pub fn new_read_pass(&self) -> ReadPass<PageRegion> {
+    pub fn new_read_pass(&self) -> ReadPass<ShardIndex> {
         self.shared
             .page_rw_pass_domain
             .new_read_pass()
-            .with_region(PageRegion::universe())
+            .with_region(ShardIndex::Root)
     }
 
     /// Acquire a write pass for all pages in the cache.
-    pub fn new_write_pass(&self) -> WritePass<PageRegion> {
+    pub fn new_write_pass(&self) -> WritePass<ShardIndex> {
         self.shared
             .page_rw_pass_domain
             .new_write_pass()
-            .with_region(PageRegion::universe())
+            .with_region(ShardIndex::Root)
+    }
+
+    /// Get the number of shards in this page region.
+    pub fn shard_count(&self) -> usize {
+        self.shared.shards.len()
+    }
+
+    /// Get the page-region associated with a shard.
+    ///
+    /// # Panics
+    ///
+    /// Panics if shard index is out of range.
+    pub fn shard_region(&self, shard_index: usize) -> PageRegion {
+        self.shard(shard_index).region.clone()
     }
 
     /// Flushes all the dirty pages into the underlying store.
@@ -536,39 +676,109 @@ impl PageCache {
         const FULL_PAGE_THRESHOLD: usize = 32;
 
         let read_pass = self.new_read_pass();
-        for (page_id, page_diff) in page_diffs {
-            if let Some(ref page) = self.shared.cached.get(&page_id) {
-                match page.value() {
-                    PageState::Cached(ref page) => {
-                        let page_data = page.data.read(&read_pass);
-                        if page_data.as_ref().map_or(true, |p| page_is_empty(&p[..])) {
-                            tx.delete_page(page_id);
-                            continue;
-                        }
-
-                        let Some(page_data) = page_data.as_ref() else {
-                            continue;
-                        };
-
-                        let updated_count = page_diff.updated_slots.count_ones();
-                        if updated_count >= FULL_PAGE_THRESHOLD {
-                            tx.write_page(page_id, page_data);
-                            continue;
-                        }
-
-                        let mut tagged_nodes = Vec::with_capacity(33 * updated_count);
-                        for slot_index in page_diff.updated_slots.iter_ones() {
-                            tagged_nodes.push(slot_index as u8);
-
-                            tagged_nodes.extend(&page_data[slot_index * 32..][..32]);
-                        }
-                        tx.write_page_nodes(page_id, tagged_nodes);
-                    }
-                    PageState::Inflight(_) => {
-                        panic!("dirty page is inflight");
-                    }
-                }
+        let mut apply_page = |page_id, page_data: Option<&Vec<u8>>, page_diff: PageDiff| {
+            if page_data.map_or(true, |p| page_is_empty(&p[..])) {
+                tx.delete_page(page_id);
+                return;
             }
+
+            let Some(page_data) = page_data else {
+                return;
+            };
+
+            let updated_count = page_diff.updated_slots.count_ones();
+            if updated_count >= FULL_PAGE_THRESHOLD {
+                tx.write_page(page_id, page_data);
+                return;
+            }
+
+            let mut tagged_nodes = Vec::with_capacity(33 * updated_count);
+            for slot_index in page_diff.updated_slots.iter_ones() {
+                tagged_nodes.push(slot_index as u8);
+
+                tagged_nodes.extend(&page_data[slot_index * 32..][..32]);
+            }
+            tx.write_page_nodes(page_id, tagged_nodes);
+        };
+
+        // helper for exploiting locality effects in the diffs to avoid searching through
+        // shards constantly.
+        let mut last_shard_index = None;
+        let shard_guards = self
+            .shared
+            .shards
+            .iter()
+            .map(|s| s.locked.lock())
+            .collect::<Vec<_>>();
+
+        for (page_id, page_diff) in page_diffs {
+            if page_id == ROOT_PAGE_ID {
+                let page = self.shared.root_page.read();
+                let page_data = page.data.read(&read_pass);
+                apply_page(page_id, page_data.as_ref(), page_diff);
+                continue;
+            }
+
+            // UNWRAP: all pages which are not the root page are in a shard.
+            let shard_index = match last_shard_index {
+                Some(i) if self.shard(i).region.contains(&page_id) => i,
+                _ => self.shard_index_for(&page_id).unwrap(),
+            };
+            last_shard_index = Some(shard_index);
+
+            if let Some(ref page) = shard_guards[shard_index].cached.peek(&page_id) {
+                let page_data = page.data.read(&read_pass);
+                apply_page(page_id, page_data.as_ref(), page_diff);
+            } else {
+                panic!("dirty page {:?} is missing", page_id);
+            }
+        }
+
+        // purge stale pages.
+        for (shard, mut guard) in self.shared.shards.iter().zip(shard_guards) {
+            guard.evict(shard.page_limit);
+        }
+    }
+
+    fn shard(&self, index: usize) -> &CacheShard {
+        &self.shared.shards[index]
+    }
+}
+
+impl Region for ShardIndex {
+    fn encompasses(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ShardIndex::Root, _) => true,
+            (ShardIndex::Shard(a), ShardIndex::Shard(b)) => a == b,
+            _ => false,
+        }
+    }
+
+    fn excludes_unique(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ShardIndex::Shard(a), ShardIndex::Shard(b)) => a != b,
+            _ => false,
+        }
+    }
+}
+
+unsafe impl RegionContains<ShardIndex> for ShardIndex {
+    fn contains(&self, page_shard: &ShardIndex) -> bool {
+        match (self, page_shard) {
+            (ShardIndex::Shard(a), ShardIndex::Shard(b)) => a == b,
+            (ShardIndex::Root, _) => true,
+            (ShardIndex::Shard(_), ShardIndex::Root) => {
+                // safe to read the root page from any shard pass.
+                true
+            }
+        }
+    }
+
+    fn contains_exclusive(&self, page_shard: &ShardIndex) -> bool {
+        match (self, page_shard) {
+            (ShardIndex::Shard(a), ShardIndex::Shard(b)) => a == b,
+            (ShardIndex::Root, _) => true,
+            _ => false, // exclusive access only to pages in this shard.
         }
     }
 }

--- a/nomt/src/seek.rs
+++ b/nomt/src/seek.rs
@@ -1,8 +1,7 @@
 //! Seek for a path in the trie, pre-fetching pages as necessary.
 
 use crate::{
-    page_cache::{self, Page, PageCache},
-    page_region::PageRegion,
+    page_cache::{self, Page, PageCache, ShardIndex},
     rw_pass_cell::ReadPass,
 };
 use bitvec::prelude::*;
@@ -56,7 +55,7 @@ impl Seeker {
         &self,
         trie_pos: &TriePosition,
         current_page: Option<&(PageId, Page)>,
-        read_pass: &ReadPass<PageRegion>,
+        read_pass: &ReadPass<ShardIndex>,
     ) -> trie::LeafData {
         let (page, _, children) = page_cache::locate_leaf_data(trie_pos, current_page, |page_id| {
             self.cache.retrieve_sync(page_id, false)
@@ -72,7 +71,7 @@ impl Seeker {
         bit: bool,
         pos: &mut TriePosition,
         cur_page: &mut Option<(PageId, Page)>,
-        read_pass: &ReadPass<PageRegion>,
+        read_pass: &ReadPass<ShardIndex>,
     ) -> (Node, Node) {
         if pos.depth() as usize % DEPTH == 0 {
             // attempt to load next page if we are at the end of our previous page or the root.
@@ -105,7 +104,7 @@ impl Seeker {
         &self,
         dest: KeyPath,
         options: SeekOptions,
-        read_pass: &ReadPass<PageRegion>,
+        read_pass: &ReadPass<ShardIndex>,
     ) -> Seek {
         /// The breadth of the prefetch request.
         ///


### PR DESCRIPTION
This shards the page cache based on the number of workers, and gives each shard an LRU cache.

A further step would be to give each worker a mutable handle to their shard during `update`.

not implemented: cache eviction during retrieval.