### PR TITLE
benchtop: plumb fetch concurrency from cli

### DIFF
--- a/benchtop/src/backend.rs
+++ b/benchtop/src/backend.rs
@@ -15,10 +15,10 @@ impl Backend {
     // If reset is true, then erase any previous backend's database
     // and restart from an empty database.
     // Otherwise, use the already present database.
-    pub fn instantiate(&self, reset: bool) -> DB {
+    pub fn instantiate(&self, reset: bool, fetch_concurrency: usize) -> DB {
         match self {
             Backend::SovDB => DB::Sov(SovDB::open(reset)),
-            Backend::Nomt => DB::Nomt(NomtDB::open(reset)),
+            Backend::Nomt => DB::Nomt(NomtDB::open(reset, fetch_concurrency)),
             Backend::SpTrie => DB::SpTrie(SpTrieDB::open(reset)),
         }
     }

--- a/benchtop/src/cli.rs
+++ b/benchtop/src/cli.rs
@@ -106,6 +106,13 @@ pub struct WorkloadParams {
     #[arg(long = "workload-capacity", short = 'c')]
     #[clap(value_parser=clap::value_parser!(u8).range(0..64))]
     pub initial_capacity: Option<u8>,
+
+    /// Number of concurrent fetches to perform. Only used with Nomt backend.
+    ///
+    /// Default value is 1
+    #[arg(long = "fetch-concurrency", short)]
+    #[clap(default_value = "1")]
+    pub fetch_concurrency: usize,
 }
 
 pub mod bench {

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -34,7 +34,7 @@ pub fn init(params: WorkloadParams) -> Result<()> {
         params.percentage_cold,
     )?;
 
-    let mut db = Backend::Nomt.instantiate(true);
+    let mut db = Backend::Nomt.instantiate(true, params.fetch_concurrency);
     db.execute(None, &mut init);
 
     Ok(())
@@ -48,7 +48,7 @@ pub fn run(params: WorkloadParams) -> Result<()> {
         params.percentage_cold,
     )?;
 
-    let mut db = Backend::Nomt.instantiate(true);
+    let mut db = Backend::Nomt.instantiate(true, params.fetch_concurrency);
     db.execute(None, &mut *workload);
 
     Ok(())

--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -11,7 +11,7 @@ pub struct NomtDB {
 }
 
 impl NomtDB {
-    pub fn open(reset: bool) -> Self {
+    pub fn open(reset: bool, fetch_concurrency: usize) -> Self {
         if reset {
             // Delete previously existing db
             let _ = std::fs::remove_dir_all(NOMT_DB_FOLDER);
@@ -19,7 +19,7 @@ impl NomtDB {
 
         let opts = Options {
             path: PathBuf::from(NOMT_DB_FOLDER),
-            fetch_concurrency: 1,
+            fetch_concurrency,
             traversal_concurrency: 1,
         };
 

--- a/benchtop/src/regression.rs
+++ b/benchtop/src/regression.rs
@@ -12,6 +12,7 @@ struct WorkloadInfo {
     name: String,
     size: u64,
     initial_capacity: u64,
+    fetch_concurrency: u64,
     isolate: Option<Isolate>,
     sequential: Option<Sequential>,
 }
@@ -54,8 +55,14 @@ pub fn regression(params: Params) -> Result<()> {
             )?;
 
             print!("Isolate: -");
-            let bench_results =
-                bench::bench_isolate(init, workload, vec![Backend::Nomt], iterations, false)?;
+            let bench_results = bench::bench_isolate(
+                init,
+                workload,
+                vec![Backend::Nomt],
+                iterations,
+                false,
+                workload_info.fetch_concurrency as usize,
+            )?;
             let mean = *bench_results.first().expect("There must be nomt results");
             print_results(prev_mean, mean);
         };
@@ -81,6 +88,7 @@ pub fn regression(params: Params) -> Result<()> {
                 op_limit,
                 time_limit,
                 false,
+                workload_info.fetch_concurrency as usize,
             )?;
             let mean = *bench_results.first().expect("There must be nomt results");
             print_results(prev_mean, mean);


### PR DESCRIPTION
This introduced --fetch-concurrency / -f to configure nomt to use the specified number of threads. The default is 1.