### PR TITLE
add optional metrics collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "arbitrary"
@@ -58,9 +58,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bindgen"
@@ -148,12 +148,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -308,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys",
@@ -318,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "funty"
@@ -380,9 +381,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -414,9 +415,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -457,7 +458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -478,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.16"
+version = "1.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+checksum = "0078520875cbd94735b332bca766d640ca0754e5419dce654dcee9115c4239f0"
 dependencies = [
  "cc",
  "pkg-config",
@@ -489,15 +490,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -650,9 +651,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -660,15 +661,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -697,9 +698,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -707,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -779,11 +780,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -863,9 +864,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -876,15 +877,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scoped-tls"
@@ -900,18 +901,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -920,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -963,9 +964,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1123,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1133,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
  "windows-result",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1142,7 +1143,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1151,22 +1152,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1175,21 +1161,15 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1199,21 +1179,9 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1229,21 +1197,9 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1253,21 +1209,9 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/benchtop/src/backend.rs
+++ b/benchtop/src/backend.rs
@@ -72,4 +72,11 @@ impl DB {
             }
         }
     }
+
+    pub fn print_metrics(&self) {
+        match self {
+            DB::Nomt(db) => db.print_metrics(),
+            _ => (),
+        }
+    }
 }

--- a/benchtop/src/bench.rs
+++ b/benchtop/src/bench.rs
@@ -1,0 +1,146 @@
+use crate::{
+    backend::Backend,
+    cli::bench::BenchType,
+    timer::Timer,
+    workload,
+    workload::{Init, Workload},
+};
+use anyhow::Result;
+
+pub fn bench(bench_type: BenchType) -> Result<()> {
+    let common_params = match bench_type {
+        BenchType::Isolate(ref params) => &params.common_params,
+        BenchType::Sequential(ref params) => &params.common_params,
+    };
+
+    let (init, workload) = workload::parse(
+        common_params.workload.name.as_str(),
+        common_params.workload.size,
+        common_params
+            .workload
+            .initial_capacity
+            .map(|s| 1u64 << s)
+            .unwrap_or(0),
+        common_params.workload.percentage_cold,
+    )?;
+    let fetch_concurrency = common_params.workload.fetch_concurrency;
+
+    let backends = if common_params.backends.is_empty() {
+        Backend::all_backends()
+    } else {
+        common_params.backends.clone()
+    };
+
+    match bench_type {
+        BenchType::Isolate(params) => bench_isolate(
+            init,
+            workload,
+            backends,
+            params.iterations,
+            true,
+            fetch_concurrency,
+        )
+        .map(|_| ()),
+        BenchType::Sequential(params) => bench_sequential(
+            init,
+            workload,
+            backends,
+            params.op_limit,
+            params.time_limit,
+            true,
+            fetch_concurrency,
+        )
+        .map(|_| ()),
+    }
+}
+
+// Benchmark the workload across multiple backends multiple times.
+// Each iteration will be executed on a freshly initialized database.
+//
+// Return the mean execution time of the workloads for each backends
+// in the order the backends are provided
+pub fn bench_isolate(
+    mut init: Init,
+    mut workload: Box<dyn Workload>,
+    backends: Vec<Backend>,
+    iterations: u64,
+    print: bool,
+    fetch_concurrency: usize,
+) -> Result<Vec<u64>> {
+    let mut mean_results = vec![];
+    for backend in backends {
+        let mut timer = Timer::new(format!("{}", backend));
+
+        for _ in 0..iterations {
+            let mut db = backend.instantiate(true, fetch_concurrency);
+            db.execute(None, &mut init);
+            db.execute(Some(&mut timer), &mut *workload);
+            db.print_metrics();
+        }
+
+        if print {
+            timer.print();
+        }
+        mean_results.push(timer.get_mean_workload_duration()?);
+    }
+
+    Ok(mean_results)
+}
+
+// Benchmark the workload across multiple backends multiple times.
+// Each iteration will be executed on the same db repeatedly
+// without clearing it until a time or operation count limit is reaced.
+//
+// Return the mean execution time of the workloads for each backends
+// in the order the backends are provided
+pub fn bench_sequential(
+    mut init: Init,
+    mut workload: Box<dyn Workload>,
+    backends: Vec<Backend>,
+    op_limit: Option<u64>,
+    time_limit: Option<u64>,
+    print: bool,
+    fetch_concurrency: usize,
+) -> Result<Vec<u64>> {
+    if let (None, None) = (op_limit, time_limit) {
+        anyhow::bail!("You need to specify at least one limiter between operations and time")
+    }
+
+    let mut mean_results = vec![];
+
+    for backend in backends {
+        let mut timer = Timer::new(format!("{}", backend));
+        let mut db = backend.instantiate(true, fetch_concurrency);
+
+        let mut elapsed_time = 0;
+        let mut op_count = 0;
+
+        db.execute(None, &mut init);
+
+        loop {
+            db.execute(Some(&mut timer), &mut *workload);
+
+            // check if time limit exceeded
+            elapsed_time += timer.get_last_workload_duration()?;
+            match time_limit {
+                Some(limit) if elapsed_time >= (limit * 1000000) => break,
+                _ => (),
+            };
+
+            // check if op limit exceeded
+            op_count += workload.size() as u64;
+            match op_limit {
+                Some(limit) if op_count >= limit => break,
+                _ => (),
+            };
+        }
+
+        db.print_metrics();
+
+        if print {
+            timer.print();
+        }
+        mean_results.push(timer.get_mean_workload_duration()?);
+    }
+    Ok(mean_results)
+}

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -71,6 +71,7 @@ pub fn run(params: RunParams) -> Result<()> {
         db.execute(Some(&mut timer), &mut *workload);
     }
 
+    db.print_metrics();
     timer.print();
 
     Ok(())

--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -20,6 +20,7 @@ impl NomtDB {
         let mut opts = Options::new();
         opts.path(NOMT_DB_FOLDER);
         opts.fetch_concurrency(fetch_concurrency);
+        opts.metrics(true);
 
         let nomt = Nomt::open(opts).unwrap();
         Self { nomt }
@@ -46,6 +47,10 @@ impl NomtDB {
         let mut actual_access: Vec<_> = access.into_iter().collect();
         actual_access.sort_by_key(|(k, _)| *k);
         self.nomt.commit_and_prove(session, actual_access).unwrap();
+    }
+
+    pub fn print_metrics(&self) {
+        self.nomt.print_metrics()
     }
 }
 

--- a/nomt/src/metrics.rs
+++ b/nomt/src/metrics.rs
@@ -1,0 +1,131 @@
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+/// Metrics collector, if active, it provides Counters and Timers
+#[derive(Clone)]
+pub enum Metrics {
+    Active(Arc<ActiveMetrics>),
+    Inactive,
+}
+
+impl Metrics {
+    /// Returns the Metrics object, active or not based on the specified input
+    pub fn new(metrics: bool) -> Self {
+        if metrics {
+            Metrics::Active(Arc::new(ActiveMetrics {
+                page_requests_count: AtomicU64::new(0),
+                page_cache_misses_count: AtomicU64::new(0),
+                page_fetch_time: Timer::new(),
+                value_fetch_time: Timer::new(),
+            }))
+        } else {
+            Metrics::Inactive
+        }
+    }
+
+    /// Print collected metrics to stdout
+    pub fn print(&self) {
+        match self {
+            Metrics::Active(metrics) => {
+                println!("metrics");
+
+                let tot_page_requests = metrics.page_requests_count.load(Ordering::Relaxed);
+                println!("  page requests         {}", tot_page_requests);
+
+                if tot_page_requests != 0 {
+                    let cache_misses = metrics.page_cache_misses_count.load(Ordering::Relaxed);
+                    let percentage_cache_misses =
+                        (cache_misses as f64 / tot_page_requests as f64) * 100.0;
+
+                    println!(
+                        "  page cache misses     {} - {:.2}% of page requests",
+                        cache_misses, percentage_cache_misses
+                    );
+                }
+
+                println!(
+                    "  page fetch mean       {}",
+                    pretty_display_ns(metrics.page_fetch_time.mean())
+                );
+
+                println!(
+                    "  value fetch mean      {}",
+                    pretty_display_ns(metrics.value_fetch_time.mean())
+                );
+            }
+            Metrics::Inactive => {
+                println!("Metrics collection was not activated")
+            }
+        }
+    }
+}
+
+/// Active metrics that can be collected during execution.
+pub struct ActiveMetrics {
+    pub page_requests_count: AtomicU64,
+    pub page_cache_misses_count: AtomicU64,
+    pub page_fetch_time: Timer,
+    pub value_fetch_time: Timer,
+}
+
+fn pretty_display_ns(ns: u64) -> String {
+    // preserve 3 sig figs at minimum.
+    let (val, unit) = if ns > 100 * 1_000_000_000 {
+        (ns / 1_000_000_000, "s")
+    } else if ns > 100 * 1_000_000 {
+        (ns / 1_000_000, "ms")
+    } else if ns > 100 * 1_000 {
+        (ns / 1_000, "us")
+    } else {
+        (ns, "ns")
+    };
+
+    format!("{val} {unit}")
+}
+
+/// Used in [`ActiveMetrics`] to record timings
+pub struct Timer {
+    number_of_records: AtomicU64,
+    sum: AtomicU64,
+}
+
+impl Timer {
+    fn new() -> Self {
+        Timer {
+            number_of_records: AtomicU64::new(0),
+            sum: AtomicU64::new(0),
+        }
+    }
+
+    fn mean(&self) -> u64 {
+        let n = self.number_of_records.load(Ordering::Relaxed);
+        let sum = self.sum.load(Ordering::Relaxed);
+        sum / n
+    }
+
+    /// Returns a guard that, when dropped, will record in [`ActiveMetrics`]
+    /// the time passed since creation
+    pub fn record<'a>(&'a self) -> Option<impl Drop + 'a> {
+        struct TimerGuard<'a> {
+            start: std::time::Instant,
+            n: &'a AtomicU64,
+            sum: &'a AtomicU64,
+        }
+
+        impl Drop for TimerGuard<'_> {
+            fn drop(&mut self) {
+                let elapsed = self.start.elapsed().as_nanos() as u64;
+                self.n.fetch_add(1, Ordering::Relaxed);
+                self.sum.fetch_add(elapsed, Ordering::Relaxed);
+            }
+        }
+
+        Some(TimerGuard {
+            start: std::time::Instant::now(),
+            n: &self.number_of_records,
+            sum: &self.sum,
+        })
+    }
+}

--- a/nomt/src/options.rs
+++ b/nomt/src/options.rs
@@ -7,6 +7,8 @@ pub struct Options {
     /// The maximum number of concurrent page fetches. Values over 64 will be rounded down to 64.
     /// May not be zero.
     pub(crate) fetch_concurrency: usize,
+    /// Enable or disable metrics collection.
+    pub(crate) metrics: bool,
 }
 
 impl Default for Options {
@@ -14,6 +16,7 @@ impl Default for Options {
         Self {
             path: PathBuf::from("nomt_db"),
             fetch_concurrency: 1,
+            metrics: false,
         }
     }
 }
@@ -36,5 +39,12 @@ impl Options {
     /// May not be zero.
     pub fn fetch_concurrency(&mut self, fetch_concurrency: usize) {
         self.fetch_concurrency = fetch_concurrency;
+    }
+
+    /// Set metrics collection on or off.
+    ///
+    /// Default: off.
+    pub fn metrics(&mut self, metrics: bool) {
+        self.metrics = metrics;
     }
 }


### PR DESCRIPTION
measure page_requests_count, page_cache_misses, page_fetch_time, and value_fetch_time

The decision I have made for now is to collect metrics based on nomt instance. Metrics are collected across all sessions and printed on-demand. If you prefer to collect them per session, it would be easy to update. Thinking about #195, it would probably be nice to remove the initialization from the metric collection. This can be addressed in a follow-up

example outcome:
```shell
     Running `target/debug/benchtop bench sequential -b nomt -n randrw -s 25000 -c 15 --op-limit 100000`
metrics:
  page requests         747026
  page cache misses     174420 - 23.35% of page requests
  page fetch mean       10232 ns
  value fetch mean      8437 ns
nomt
  mean workload: 2535 ms
  mean read: 9712 ns
  mean commit_and_prove: 1946 ms
```