### PR TITLE
nomt: encapsulate options

### DIFF
--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -2,7 +2,7 @@ use crate::{backend::Transaction, timer::Timer, workload::Workload};
 use fxhash::FxHashMap;
 use nomt::{KeyPath, KeyReadWrite, Nomt, Options, Session};
 use sha2::Digest;
-use std::{collections::hash_map::Entry, path::PathBuf};
+use std::collections::hash_map::Entry;
 
 const NOMT_DB_FOLDER: &str = "nomt_db";
 
@@ -17,11 +17,9 @@ impl NomtDB {
             let _ = std::fs::remove_dir_all(NOMT_DB_FOLDER);
         }
 
-        let opts = Options {
-            path: PathBuf::from(NOMT_DB_FOLDER),
-            fetch_concurrency,
-            traversal_concurrency: 1,
-        };
+        let mut opts = Options::new();
+        opts.path(NOMT_DB_FOLDER);
+        opts.fetch_concurrency(fetch_concurrency);
 
         let nomt = Nomt::open(opts).unwrap();
         Self { nomt }

--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use nomt::{KeyReadWrite, Node, Nomt, Options, Witness, WitnessedOperations};
 use sha2::Digest;
-use std::path::PathBuf;
 
 const NOMT_DB_FOLDER: &str = "nomt_db";
 
@@ -10,11 +9,9 @@ pub struct NomtDB;
 impl NomtDB {
     pub fn commit_batch() -> Result<(Node, Node, Witness, WitnessedOperations)> {
         // Define the options used to open NOMT
-        let opts = Options {
-            path: PathBuf::from(NOMT_DB_FOLDER),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        };
+        let mut opts = Options::new();
+        opts.path(NOMT_DB_FOLDER);
+        opts.fetch_concurrency(1);
 
         // Open NOMT database, it will create the folder if it does not exist
         let nomt = Nomt::open(opts)?;

--- a/examples/read_value/src/main.rs
+++ b/examples/read_value/src/main.rs
@@ -1,17 +1,14 @@
 use anyhow::Result;
 use nomt::{Nomt, Options};
 use sha2::Digest;
-use std::path::PathBuf;
 
 const NOMT_DB_FOLDER: &str = "nomt_db";
 
 fn main() -> Result<()> {
     // Define the options used to open NOMT
-    let opts = Options {
-        path: PathBuf::from(NOMT_DB_FOLDER),
-        fetch_concurrency: 1,
-        traversal_concurrency: 1,
-    };
+    let mut opts = Options::new();
+    opts.path(NOMT_DB_FOLDER);
+    opts.fetch_concurrency(1);
 
     // Open nomt database, it will create the folder if it does not exist
     let nomt = Nomt::open(opts)?;

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -5,7 +5,6 @@
 use bitvec::prelude::*;
 use std::{
     mem,
-    path::PathBuf,
     rc::Rc,
     sync::{atomic::AtomicUsize, Arc},
 };
@@ -23,8 +22,10 @@ use store::Store;
 
 pub use nomt_core::proof;
 pub use nomt_core::trie::{KeyPath, LeafData, Node};
+pub use options::Options;
 
 mod commit;
+mod options;
 mod page_cache;
 mod page_region;
 mod page_walker;
@@ -36,17 +37,6 @@ const MAX_FETCH_CONCURRENCY: usize = 64;
 
 /// A full value stored within the trie.
 pub type Value = Rc<Vec<u8>>;
-
-/// Options when opening a [`Nomt`] instance.
-pub struct Options {
-    /// The path to the directory where the trie is stored.
-    pub path: PathBuf,
-    /// The maximum number of concurrent page fetches. Values over 64 will be rounded down to 64.
-    /// May not be zero.
-    pub fetch_concurrency: usize,
-    /// The maximum number of concurrent background page fetches.
-    pub traversal_concurrency: usize,
-}
 
 struct Shared {
     /// The current root of the trie.

--- a/nomt/src/options.rs
+++ b/nomt/src/options.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+
+/// Options when opening a [`Nomt`] instance.
+pub struct Options {
+    /// The path to the directory where the trie is stored.
+    pub(crate) path: PathBuf,
+    /// The maximum number of concurrent page fetches. Values over 64 will be rounded down to 64.
+    /// May not be zero.
+    pub(crate) fetch_concurrency: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::from("nomt_db"),
+            fetch_concurrency: 1,
+        }
+    }
+}
+
+impl Options {
+    /// Create a new `Options` instance with the default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the path to the directory where the trie is stored.
+    pub fn path(&mut self, path: impl Into<PathBuf>) {
+        self.path = path.into();
+    }
+
+    /// Set the maximum number of concurrent page fetches.
+    ///
+    /// Values over 64 will be rounded down to 64.
+    ///
+    /// May not be zero.
+    pub fn fetch_concurrency(&mut self, fetch_concurrency: usize) {
+        self.fetch_concurrency = fetch_concurrency;
+    }
+}

--- a/nomt/src/page_walker.rs
+++ b/nomt/src/page_walker.rs
@@ -607,11 +607,7 @@ mod tests {
     #[should_panic]
     fn advance_backwards_panics() {
         let root = trie::TERMINATOR;
-        let page_cache = PageCache::new_mocked(&crate::Options {
-            path: "".into(),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        });
+        let page_cache = PageCache::new_mocked(&crate::Options::new());
 
         let mut walker = PageWalker::<Blake3Hasher>::new(root, page_cache.clone(), None);
         let mut write_pass = page_cache.new_write_pass();
@@ -625,11 +621,7 @@ mod tests {
     #[should_panic]
     fn advance_same_panics() {
         let root = trie::TERMINATOR;
-        let page_cache = PageCache::new_mocked(&crate::Options {
-            path: "".into(),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        });
+        let page_cache = PageCache::new_mocked(&crate::Options::new());
 
         let mut walker = PageWalker::<Blake3Hasher>::new(root, page_cache.clone(), None);
         let mut write_pass = page_cache.new_write_pass();
@@ -642,11 +634,7 @@ mod tests {
     #[should_panic]
     fn advance_to_parent_page_panics() {
         let root = trie::TERMINATOR;
-        let page_cache = PageCache::new_mocked(&crate::Options {
-            path: "".into(),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        });
+        let page_cache = PageCache::new_mocked(&crate::Options::new());
 
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_cache.clone(), Some(ROOT_PAGE_ID));
@@ -659,11 +647,7 @@ mod tests {
     #[should_panic]
     fn advance_to_root_with_parent_page_panics() {
         let root = trie::TERMINATOR;
-        let page_cache = PageCache::new_mocked(&crate::Options {
-            path: "".into(),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        });
+        let page_cache = PageCache::new_mocked(&crate::Options::new());
 
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_cache.clone(), Some(ROOT_PAGE_ID));
@@ -674,11 +658,7 @@ mod tests {
     #[test]
     fn compacts_and_updates_root() {
         let root = trie::TERMINATOR;
-        let page_cache = PageCache::new_mocked(&crate::Options {
-            path: "".into(),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        });
+        let page_cache = PageCache::new_mocked(&crate::Options::new());
 
         let mut walker = PageWalker::<Blake3Hasher>::new(root, page_cache.clone(), None);
         let mut write_pass = page_cache.new_write_pass();
@@ -727,11 +707,7 @@ mod tests {
     #[test]
     fn sets_child_page_roots() {
         let root = trie::TERMINATOR;
-        let page_cache = PageCache::new_mocked(&crate::Options {
-            path: "".into(),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        });
+        let page_cache = PageCache::new_mocked(&crate::Options::new());
 
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_cache.clone(), Some(ROOT_PAGE_ID));
@@ -810,11 +786,7 @@ mod tests {
     #[test]
     fn tracks_sibling_prev_values() {
         let root = trie::TERMINATOR;
-        let page_cache = PageCache::new_mocked(&crate::Options {
-            path: "".into(),
-            fetch_concurrency: 1,
-            traversal_concurrency: 1,
-        });
+        let page_cache = PageCache::new_mocked(&crate::Options::new());
         let mut write_pass = page_cache.new_write_pass();
 
         let path_1 = key_path![0, 0, 0, 0];

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -30,11 +30,10 @@ pub fn expected_root(accounts: u64) -> Node {
 }
 
 fn opts(path: PathBuf) -> Options {
-    Options {
-        path,
-        fetch_concurrency: 1,
-        traversal_concurrency: 1,
-    }
+    let mut opts = Options::new();
+    opts.path(path);
+    opts.fetch_concurrency(1);
+    opts
 }
 
 pub struct Test {


### PR DESCRIPTION
This helps not changing N places when adding an option and also also helps versioning somewhat.