### PR TITLE
chore: fix sp-trie in benchtop

### DIFF
--- a/benchtop/src/sov_db.rs
+++ b/benchtop/src/sov_db.rs
@@ -1,22 +1,53 @@
 use crate::backend::Transaction;
 use crate::timer::Timer;
 use crate::workload::Workload;
-use fxhash::FxHashMap;
+use fxhash::{FxHashMap, FxHashSet};
 use jmt::KeyHash;
 use jmt::{storage::TreeWriter, JellyfishMerkleTree, Version};
 use sov_db::state_db::StateDB;
-use sov_prover_storage_manager::SnapshotManager;
-use sov_schema_db::snapshot::DbSnapshot;
-use std::{
-    collections::hash_map::Entry,
-    sync::{Arc, RwLock},
-};
+use sov_schema_db::schema::KeyCodec;
+use sov_schema_db::snapshot::{DbSnapshot, QueryManager, SnapshotId};
+use sov_schema_db::{RawDbReverseIterator, Schema, SchemaKey};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 const SOV_DB_FOLDER: &str = "sov_db";
 
+struct DBQueryManager {
+    inner: sov_schema_db::DB,
+}
+
+// DbSnapshot uses this to query directly to DB.
+// implementing this was necessary because the vanilla SnapshotManager doesn't allow you to
+// directly add/commit snapshots.
+impl QueryManager for DBQueryManager {
+    type Iter<'a, S: Schema> = RawDbReverseIterator<'a> where Self: 'a;
+    type RangeIter<'a, S: Schema> = RawDbReverseIterator<'a> where Self: 'a;
+
+    fn get<S: Schema>(
+        &self,
+        _: SnapshotId,
+        key: &impl KeyCodec<S>,
+    ) -> anyhow::Result<Option<S::Value>> {
+        self.inner.get(key)
+    }
+
+    fn iter<S: Schema>(&self, _: SnapshotId) -> anyhow::Result<Self::Iter<'_, S>> {
+        self.inner.raw_iter::<S>()
+    }
+    fn iter_range<S: Schema>(
+        &self,
+        _: SnapshotId,
+        upper_bound: SchemaKey,
+    ) -> anyhow::Result<Self::RangeIter<'_, S>> {
+        let mut db_iter = self.inner.raw_iter::<S>()?;
+        db_iter.seek(upper_bound)?;
+        Ok(db_iter)
+    }
+}
+
 pub struct SovDB {
-    state_db: StateDB<SnapshotManager>,
-    version: Version,
+    trie_qm: Arc<RwLock<DBQueryManager>>,
 }
 
 impl SovDB {
@@ -26,122 +57,153 @@ impl SovDB {
             let _ = std::fs::remove_dir_all(SOV_DB_FOLDER);
         }
 
-        // Create the underlying rocks db database
-        let state_db_raw = StateDB::<SnapshotManager>::setup_schema_db(SOV_DB_FOLDER).unwrap();
-        // Create a 'dummy' SnapshotManager who just reads from the provided database
-        let state_db_sm = Arc::new(RwLock::new(SnapshotManager::orphan(state_db_raw)));
-        // Create a snapshot db and then the state db over RocksDB
-        let state_db_snapshot = DbSnapshot::<SnapshotManager>::new(0, state_db_sm.into());
-        let state_db = StateDB::with_db_snapshot(state_db_snapshot).unwrap();
+        // Create the underlying rocks db databases: one for trie nodes, one for key-value flat
+        // storage.
 
-        Self {
-            state_db,
-            version: 1,
+        let trie_db_raw = StateDB::<()>::setup_schema_db(SOV_DB_FOLDER).unwrap();
+
+        let trie_qm = DBQueryManager { inner: trie_db_raw };
+
+        SovDB {
+            trie_qm: Arc::new(RwLock::new(trie_qm)),
         }
     }
 
     pub fn execute(&mut self, mut timer: Option<&mut Timer>, workload: &mut dyn Workload) {
+        // sov-db's API initializes the StateDB struct afresh for each "block" - it is not meant
+        // to be a long-term handle. We do the same here with the following steps.
+        // Reads through go through these stages:
+        // Native/StateDB -> snapshot -> snapshot manager (parent snapshots - N/A here) -> rocksdb
+
         let _timer_guard_total = timer.as_mut().map(|t| t.record_span("workload"));
 
-        self.state_db.inc_next_version();
+        // 1. Create a "snapshot" (read-write storage overlays) for trie nodes.
+        //
+        // 0 is snapshot ID. this can be reused safely, as it's never committed to disk.
+        let snapshot_id = 0;
+        let trie_snapshot =
+            DbSnapshot::<DBQueryManager>::new(snapshot_id, self.trie_qm.clone().into());
+
+        // 2. Create higher-level API handles around the snapshot.
+        let trie_db = StateDB::with_db_snapshot(trie_snapshot).unwrap();
+
+        // sov-db is an archive DB, where all data from all versions is kept.
+        let write_version = trie_db.get_next_version();
+        assert!(write_version > 0);
+        let read_version = write_version - 1;
 
         // Actions are applied to jmt and then applied to the backend
-        let jmt = JellyfishMerkleTree::<_, sha2::Sha256>::new(&self.state_db);
-
-        // Sov-db uses the struct `ProverStorage` to handle the modification of the trie.
-        // https://github.com/Sovereign-Labs/sovereign-sdk/blob/2cc0656df3f12fca2026c20554b5f78ccb210b89/module-system/sov-state/src/prover_storage.rs#L75
-        // What it does is:
-        // + get
-        //      read value from db (apparently not from the trie but from the other DBs),
-        //      Add an hint into the witness, the hint is just the serialization of the value.
-        // + compute_state_update
-        //      accepts `OrderedReadsAndWrites` and `Witness`,
-        //      For each value that's been read from the tree,
-        //      read it from the JMT and populate witness with proof
-        //      (proofs are sequentil, one for each read)
-        //      Create the key_preimages vector (key_hash to key) and
-        //      the batch of writes.
-        //      Change version of the JMT and put the batch with the proof
-        //      that will be added to the witness
-        // + commit
-        //      insert key_preimages with `put_preimage` and write the
-        //      node batch created by the `compute_state_update` method
-        //
-        // Reads are executed sequentially, reading actions, while writes
-        // are collected and applied at the end before committing everything
-        // to the database
+        let jmt = JellyfishMerkleTree::<_, sha2::Sha256>::new(&trie_db);
 
         let mut transaction = Tx {
             timer,
-            access: FxHashMap::default(),
+            reads: FxHashSet::default(),
+            writes: HashMap::default(),
             jmt,
-            version: self.version,
+            version: read_version,
         };
         workload.run_step(&mut transaction);
         let Tx {
             mut timer,
-            mut access,
+            writes,
+            reads,
             jmt,
             ..
         } = transaction;
+
         let _timer_guard_commit = timer.as_mut().map(|t| t.record_span("commit_and_prove"));
-        // apply all writes
+
+        // 3. various committing/proving actions.
+
+        // prove all reads.
+        {
+            for key_hash in reads {
+                jmt.get_with_proof(key_hash, read_version).unwrap();
+            }
+        }
+
+        // write preimages to the trie snapshot. must be done first or trie update panics.
+        {
+            let preimages = writes.iter().map(|(k, v)| (k.clone(), v.preimage()));
+            trie_db.put_preimages(preimages).unwrap();
+        }
+
+        // apply all trie updates.
         // We are not interested in storing the witness, but we want to measure
         // the time required to create the proof
-        let tree_update = {
-            let value_set = access
-                .iter_mut()
-                .map(|(k, v)| (k.clone(), v.as_mut().map(|v| std::mem::take(&mut v.value))));
+        {
+            let value_set = writes
+                .iter()
+                .map(|(k, v)| (k.clone(), v.value()));
+
             let (_new_root, _proof, tree_update) = jmt
-                .put_value_set_with_proof(value_set, self.version)
+                .put_value_set_with_proof(value_set, write_version)
                 .expect("JMT update must succeed");
 
-            tree_update
-        };
+            trie_db.write_node_batch(&tree_update.node_batch).unwrap();
+        }
 
-        let preimages = access
-            .iter()
-            .filter_map(|(k, v)| v.as_ref().map(move |v| (*k, &v.preimage)));
+        // 4. up to now, nothing has been committed to disk. do that by freezing and committing
+        //    to underlying DB handle.
+        let trie_qm = self.trie_qm.read().unwrap();
 
-        self.state_db.put_preimages(preimages).unwrap();
-        self.state_db
-            .write_node_batch(&tree_update.node_batch)
+        trie_qm
+            .inner
+            .write_schemas(trie_db.freeze().unwrap().into())
             .unwrap();
-
-        self.version += 1;
     }
 }
 
-struct ValueWithPreimage {
-    value: Vec<u8>,
-    preimage: Vec<u8>,
+enum PreparedWrite {
+    Delete(Vec<u8>),
+    Put(Vec<u8>, Vec<u8>),
+}
+
+impl PreparedWrite {
+    fn value(&self) -> Option<Vec<u8>> {
+        match self {
+            PreparedWrite::Delete(_) => None,
+            PreparedWrite::Put(_, ref v) => Some(v.clone()),
+        }
+    }
+
+    // sov-db requires &Vec - don't shoot the messenger.
+    fn preimage(&self) -> &Vec<u8> {
+        match self {
+            PreparedWrite::Delete(ref p) => p,
+            PreparedWrite::Put(ref p, _) => p,
+        }
+    }
 }
 
 struct Tx<'a> {
     timer: Option<&'a mut Timer>,
-    access: FxHashMap<KeyHash, Option<ValueWithPreimage>>,
-    jmt: JellyfishMerkleTree<'a, StateDB<SnapshotManager>, sha2::Sha256>,
+    reads: FxHashSet<KeyHash>,
+    writes: FxHashMap<KeyHash, PreparedWrite>,
+    jmt: JellyfishMerkleTree<'a, StateDB<DBQueryManager>, sha2::Sha256>,
     version: Version,
 }
 
 impl<'a> Transaction for Tx<'a> {
     fn read(&mut self, key: &[u8]) -> Option<Vec<u8>> {
-        let key_hash = KeyHash::with::<sha2::Sha256>(&key);
         let _timer_guard_read = self.timer.as_mut().map(|t| t.record_span("read"));
 
-        match self.access.entry(key_hash) {
-            Entry::Occupied(o) => o.get().as_ref().map(|v| v.value.clone()),
-            Entry::Vacant(_) => self.jmt.get_with_proof(key_hash, self.version).unwrap().0,
+        let key = key.to_vec();
+        let key_hash = KeyHash::with::<sha2::Sha256>(&key);
+        if let Some(value) = self.writes.get(&key_hash).and_then(|v| v.value()) {
+            return Some(value);
         }
+        self.reads.insert(key_hash);
+
+        // note: this just reads from flat storage and doesn't do a full trie lookup.
+        self.jmt.get(key_hash, self.version).unwrap()
     }
     fn write(&mut self, key: &[u8], value: Option<&[u8]>) {
         let key_hash = KeyHash::with::<sha2::Sha256>(&key);
-
-        let value = value.map(|v| ValueWithPreimage {
-            value: v.to_vec(),
-            preimage: key.to_vec(),
-        });
-
-        self.access.insert(key_hash, value);
+        let write = match value {
+            None => PreparedWrite::Delete(key.to_vec()),
+            Some(v) => PreparedWrite::Put(key.to_vec(), v.to_vec()),
+        };
+        self.writes.insert(key_hash, write);
     }
 }


### PR DESCRIPTION
1. read the root from the underlying DB
2. use prefixed memory DB to handle key prefixes

note: if we use ParityDB (and IMO we should; it's supposed to be better), we would have to sanitize the prefixes.