### PR TITLE
refactor: metrics are referenced with enums

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -3,7 +3,7 @@
 //! A Nearly-Optimal Merkle Trie Database.
 
 use bitvec::prelude::*;
-use metrics::Metrics;
+use metrics::{Metric, Metrics};
 use std::{
     mem,
     rc::Rc,
@@ -308,10 +308,7 @@ impl Session {
         // UNWRAP: committer always `Some` during lifecycle.
         self.committer.as_mut().unwrap().warm_up(path, false);
 
-        let _maybe_guard = match self.metrics {
-            Metrics::Active(ref metrics) => Some(metrics.value_fetch_time.record()),
-            Metrics::Inactive => None,
-        };
+        let _maybe_guard = self.metrics.record(Metric::ValueFetchTime);
 
         let value = self.store.load_value(path)?.map(Rc::new);
         Ok(value)

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -1,5 +1,5 @@
 use crate::{
-    metrics::Metrics,
+    metrics::{Metric, Metrics},
     page_region::PageRegion,
     rw_pass_cell::{ReadPass, Region, RegionContains, RwPassCell, RwPassDomain, WritePass},
     store::{Store, Transaction},
@@ -413,7 +413,7 @@ impl PageCache {
                 page_rw_pass_domain: domain,
                 store: PageStore::Mock(DashMap::new()),
                 fetch_tp,
-                metrics: Metrics::Inactive,
+                metrics: Metrics::new(false),
             }),
         }
     }
@@ -439,11 +439,7 @@ impl PageCache {
     /// If the page is already in the cache, this method does nothing. Otherwise, it fetches the
     /// page from the underlying store and caches it.
     pub fn prepopulate(&self, page_id: PageId) {
-        if let Metrics::Active(metrics) = &self.shared.metrics {
-            metrics
-                .page_requests_count
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
+        self.shared.metrics.count(Metric::PageRequests);
 
         let shard_index = match self.shard_index_for(&page_id) {
             None => return, // root is always populated.
@@ -458,11 +454,7 @@ impl PageCache {
                 Entry::Occupied(_) => return, // fetch in-flight already.
             };
 
-            if let Metrics::Active(metrics) = &self.shared.metrics {
-                metrics
-                    .page_cache_misses_count
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            }
+            self.shared.metrics.count(Metric::PageCacheMisses);
 
             // Nope, then we need to fetch the page from the store.
             let inflight = Arc::new(InflightFetch::new());
@@ -470,10 +462,7 @@ impl PageCache {
             let task = {
                 let shared = self.shared.clone();
                 move || {
-                    let _maybe_guard = match shared.metrics {
-                        Metrics::Active(ref metrics) => Some(metrics.page_fetch_time.record()),
-                        Metrics::Inactive => None,
-                    };
+                    let _maybe_guard = shared.metrics.record(Metric::PageFetchTime);
 
                     // the page fetch has been pre-empted in the meantime. avoid querying.
                     if Arc::strong_count(&inflight) == 1 {


### PR DESCRIPTION
This PR aims to address the following comment: https://github.com/thrumdev/nomt/pull/193#discussion_r1605440239

The main problem is handling interior mutability while working with Sync types. ~~This solution utilizes immutable structs so that metrics can be accessed from multiple threads and allows working with atomic types.~~

The names `Metrics` and `Metric` may not be the best choices, but I couldn't think of alternatives. Suggestions are welcome!