### PR TITLE
commit_and_prove docs: remove old comment

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -229,8 +229,6 @@ impl Nomt {
         mut session: Session,
         actuals: Vec<(KeyPath, KeyReadWrite)>,
     ) -> anyhow::Result<(Node, Witness, WitnessedOperations)> {
-        // Wait for all warmup tasks to finish. That way, we can be sure that all terminal
-        // information is available and that `terminals` would be the only reference.
         let mut compact_actuals = Vec::with_capacity(actuals.len());
         for (path, read_write) in &actuals {
             compact_actuals.push((path.clone(), read_write.to_compact()));


### PR DESCRIPTION
Currently, the `committer` sends "signals" to the `CommitPool`. It starts using a round-robin approach to send `warm_up` signals. Once it is time to `commit_and_prove`, the `committer` sends a `Prepare`, followed by a `Commit`, to all `CommitPool`'s threads.

The comments that I removed were, if I'm not mistaken, still referring to the old implementations where there was only a commit thread that needed to wait on all `fetch_tp`'s threads to finish fetching all pages. Now there could be commit threads that start committing while others are still waiting to finish a `warm_up` signal.

All of this is to explain why I think this comment should be removed and to double-check my understanding of the new commit mechanism