### PR TITLE
Link io to nomt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,13 +753,18 @@ dependencies = [
 name = "nomt"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "bitvec",
  "blake3",
  "crossbeam",
+ "crossbeam-channel",
  "dashmap",
  "fxhash",
  "hex-literal",
+ "im",
+ "io-uring",
+ "libc",
  "loom",
  "lru",
  "nomt-core",
@@ -767,6 +772,7 @@ dependencies = [
  "rand",
  "rand_pcg",
  "rocksdb",
+ "slab",
  "threadpool",
 ]
 

--- a/bitbox/src/beatree/allocator/free_list.rs
+++ b/bitbox/src/beatree/allocator/free_list.rs
@@ -1,7 +1,7 @@
 use crate::{
     beatree::allocator::PageNumber,
     io::{CompleteIo, IoCommand, IoKind},
-    store::{Page, PAGE_SIZE},
+    io::{Page, PAGE_SIZE},
 };
 use crossbeam_channel::{Receiver, Sender, TrySendError};
 use std::{collections::BTreeSet, fs::File, os::fd::AsRawFd};

--- a/bitbox/src/beatree/allocator/mod.rs
+++ b/bitbox/src/beatree/allocator/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     beatree::allocator::free_list::FreeList,
     io::{CompleteIo, IoCommand, IoKind},
-    store::{Page, PAGE_SIZE},
+    io::{Page, PAGE_SIZE},
 };
 use crossbeam_channel::{Receiver, Sender, TrySendError};
 

--- a/bitbox/src/beatree/bbn.rs
+++ b/bitbox/src/beatree/bbn.rs
@@ -4,7 +4,7 @@ use crate::{
         branch::BranchNode,
     },
     io::{CompleteIo, IoCommand},
-    store::Page,
+    io::Page,
 };
 use crossbeam_channel::{Receiver, Sender};
 

--- a/bitbox/src/beatree/leaf/node.rs
+++ b/bitbox/src/beatree/leaf/node.rs
@@ -27,7 +27,7 @@ use std::ops::Range;
 
 use crate::{
     beatree::Key,
-    store::{Page, PAGE_SIZE},
+    io::{Page, PAGE_SIZE},
 };
 
 pub const LEAF_NODE_BODY_SIZE: usize = PAGE_SIZE - 2;

--- a/bitbox/src/beatree/leaf/store.rs
+++ b/bitbox/src/beatree/leaf/store.rs
@@ -3,8 +3,7 @@ use crate::{
         allocator::{AllocatorCommitOutput, AllocatorReader, AllocatorWriter, PageNumber},
         leaf::node::LeafNode,
     },
-    io::{CompleteIo, IoCommand},
-    store::Page,
+    io::{Page, CompleteIo, IoCommand},
 };
 use crossbeam_channel::{Receiver, Sender};
 

--- a/bitbox/src/beatree/meta.rs
+++ b/bitbox/src/beatree/meta.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::{fs::File, io::Read as _};
 
-use crate::store::Page;
+use crate::io::Page;
 
 /// This data structure describes the state of the btree.
 pub struct Meta {

--- a/bitbox/src/beatree/writeout.rs
+++ b/bitbox/src/beatree/writeout.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::{Receiver, Sender, TrySendError};
 
 use crate::{
     io::{CompleteIo, IoCommand, IoKind},
-    store::Page,
+    io::Page,
 };
 
 use super::{allocator::PageNumber, branch::BranchNode, meta::Meta};

--- a/bitbox/src/io.rs
+++ b/bitbox/src/io.rs
@@ -3,11 +3,35 @@ use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use rand::prelude::SliceRandom;
 use slab::Slab;
 use std::{
+    ops::{Deref, DerefMut},
     os::fd::RawFd,
     time::{Duration, Instant},
 };
 
-use crate::store::{Page, PAGE_SIZE};
+pub const PAGE_SIZE: usize = 4096;
+
+#[derive(Clone)]
+#[repr(align(4096))]
+pub struct Page(pub [u8; PAGE_SIZE]);
+
+impl Deref for Page {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Page {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Page {
+    pub fn zeroed() -> Self {
+        Self([0; PAGE_SIZE])
+    }
+}
 
 const RING_CAPACITY: u32 = 128;
 

--- a/bitbox/src/sim/mod.rs
+++ b/bitbox/src/sim/mod.rs
@@ -25,9 +25,9 @@ use crossbeam_channel::{Receiver, Sender, TrySendError};
 use std::collections::HashSet;
 use std::sync::{Arc, Barrier, RwLock};
 
-use crate::io::{self, CompleteIo, IoCommand, IoKind, Mode as IoMode};
+use crate::io::{self, CompleteIo, IoCommand, IoKind, Mode as IoMode, Page};
 use crate::meta_map::MetaMap;
-use crate::store::{MetaPage, Page, Store};
+use crate::store::{MetaPage, Store};
 use crate::wal::{Batch as WalBatch, Entry as WalEntry, WalWriter};
 
 mod read;

--- a/bitbox/src/sim/read.rs
+++ b/bitbox/src/sim/read.rs
@@ -7,7 +7,8 @@ use std::sync::{Arc, Barrier, RwLock};
 
 use crate::io::{CompleteIo, IoCommand, IoKind};
 use crate::meta_map::MetaMap;
-use crate::store::{Page, Store};
+use crate::store::Store;
+use crate::io::Page;
 
 use super::{
     slot_range, BucketIndex, ChangedPage, Map, PageDiff, PageId, Params, ProbeSequence,

--- a/bitbox/src/store.rs
+++ b/bitbox/src/store.rs
@@ -2,40 +2,14 @@ use rand::Rng;
 use std::{
     fs::{File, OpenOptions},
     io::{Read, Write},
-    ops::{Deref, DerefMut},
     os::{
         fd::{AsRawFd, RawFd},
         unix::fs::OpenOptionsExt,
     },
     path::PathBuf,
 };
-
+use crate::io::{Page, PAGE_SIZE};
 use crate::meta_map::MetaMap;
-
-pub const PAGE_SIZE: usize = 4096;
-
-#[derive(Clone)]
-#[repr(align(4096))]
-pub struct Page([u8; PAGE_SIZE]);
-
-impl Deref for Page {
-    type Target = [u8];
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Page {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Page {
-    pub fn zeroed() -> Self {
-        Self([0; PAGE_SIZE])
-    }
-}
 
 /// The Store is an on disk array of [`Page`]
 pub struct Store {

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -21,12 +21,18 @@ blake3 = "1.5.1"
 fxhash = "0.2.1"
 dashmap = "5.5.3"
 crossbeam = "0.8.4"
+crossbeam-channel = "0.5.13"
+slab = "0.4.9"
+rand = "0.8.5"
+ahash = "0.8.11"
+im = "15.1.0"
 lru = "0.12.3"
+libc = "0.2.155"
+io-uring = "0.6.4"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }
 
 [dev-dependencies]
-rand = "0.8.5"
 rand_pcg = "0.3.1"
 hex-literal = "0.4"

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -35,6 +35,9 @@ mod rw_pass_cell;
 mod seek;
 mod store;
 
+#[path = "../../bitbox/src/io.rs"]
+mod io;
+
 const MAX_FETCH_CONCURRENCY: usize = 64;
 
 /// A full value stored within the trie.


### PR DESCRIPTION
Basically, we add the module io.rs to NOMT without actually moving it in-tree. The reasoning for this is that we are not yet ready to move this file, but there is still some work pending by R on the btree side.

This comes with some adjustments, like moving Page and PAGE_SIZE under io.rs rather than store.rs