### PR TITLE
bitbox: init adjustments

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -36,7 +36,7 @@ mod rw_pass_cell;
 mod seek;
 mod store;
 
-#[path = "../../bitbox/src/io.rs"]
+#[path = "bitbox/io.rs"]
 mod io;
 
 const MAX_FETCH_CONCURRENCY: usize = 64;


### PR DESCRIPTION
solve dependency and imports problems and update wal entry to support 32 byte PageId
