### PR TITLE
chore: move io module to NOMT main

### DIFF
--- a/nomt/src/bitbox/beatree/mod.rs
+++ b/nomt/src/bitbox/beatree/mod.rs
@@ -83,7 +83,7 @@ impl Tree {
         const IO_IX_SYNC: usize = 4;
         const NUM_IO_HANDLES: usize = 5;
 
-        let (io_sender, io_recv) = io::start_io_worker(NUM_IO_HANDLES, Mode::Real { num_rings: 3 });
+        let (io_sender, io_recv) = crate::io::start_io_worker(NUM_IO_HANDLES, Mode::Real { num_rings: 3 });
 
         if !db_dir.as_ref().exists() {
             use std::io::Write as _;

--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -9,23 +9,20 @@ use std::{
 use threadpool::ThreadPool;
 
 use crate::{
-    bitbox::io::{IoKind, PAGE_SIZE},
+    io::{CompleteIo, IoCommand, IoKind, Page, PAGE_SIZE},
     page_cache::PageDiff,
 };
 
 use self::{
-    io::{CompleteIo, IoCommand},
     meta_map::MetaMap,
     store::{MetaPage, Store},
     wal::{Batch as WalBatch, ConsistencyError, Entry as WalEntry, WalWriter},
 };
 
-mod io;
 mod meta_map;
 mod store;
 mod wal;
 
-pub use store::Page;
 
 const LOAD_PAGE_HANDLE_INDEX: usize = 0;
 const LOAD_VALUE_HANDLE_INDEX: usize = 1;
@@ -108,7 +105,7 @@ impl DB {
         };
 
         // Spawn io_workers
-        let (io_sender, io_receivers) = io::start_io_worker(N_WORKER, num_rings);
+        let (io_sender, io_receivers) = crate::io::start_io_worker(N_WORKER, num_rings);
 
         let load_page_sender = io_sender.clone();
         let load_page_receiver = io_receivers[LOAD_PAGE_HANDLE_INDEX].clone();

--- a/nomt/src/io.rs
+++ b/nomt/src/io.rs
@@ -1,6 +1,5 @@
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use io_uring::{cqueue, opcode, squeue, types, IoUring};
-use rand::prelude::SliceRandom;
 use slab::Slab;
 use std::{
     ops::{Deref, DerefMut},

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -36,7 +36,6 @@ mod rw_pass_cell;
 mod seek;
 mod store;
 
-#[path = "bitbox/io.rs"]
 mod io;
 
 const MAX_FETCH_CONCURRENCY: usize = 64;


### PR DESCRIPTION
The main point of this PR is that we shouldn't have two copies of the io module, one in NOMT and one in bitbox. I chose to use the main NOMT location, but maybe having it in bitbox makes more sense. Something for a follow-up.
