### PR TITLE
fix: support empty free-list properly in allocator commit

### DIFF
--- a/nomt/src/bitbox/beatree/allocator/mod.rs
+++ b/nomt/src/bitbox/beatree/allocator/mod.rs
@@ -29,6 +29,9 @@ impl From<u32> for PageNumber {
     }
 }
 
+/// 0 is used to indicate that the free-list is empty.
+pub const FREELIST_EMPTY: PageNumber = PageNumber(0);
+
 /// The AllocatorReader enables fetching pages from the store.
 pub struct AllocatorReader {
     store_file: File,
@@ -176,8 +179,7 @@ impl AllocatorWriter {
             free_list_pages,
             bump: self.bump,
             extend_file_sz,
-            // after appending to the free list, the head will always be present
-            freelist_head: self.free_list.head_pn().unwrap(),
+            freelist_head: self.free_list.head_pn().unwrap_or(FREELIST_EMPTY),
         }
     }
 }

--- a/nomt/src/bitbox/beatree/mod.rs
+++ b/nomt/src/bitbox/beatree/mod.rs
@@ -1,4 +1,4 @@
-use allocator::PageNumber;
+use allocator::{PageNumber, FREELIST_EMPTY};
 use anyhow::{Context, Result};
 use branch::BRANCH_NODE_SIZE;
 use std::{
@@ -137,11 +137,12 @@ impl Tree {
 
         let meta = meta::Meta::read(&meta_fd)?;
         let ln_freelist_pn = Some(meta.ln_freelist_pn)
-            .filter(|&x| x != 0)
-            .map(PageNumber);
+            .map(PageNumber)
+            .filter(|&x| x != FREELIST_EMPTY);
         let bbn_freelist_pn = Some(meta.bbn_freelist_pn)
-            .filter(|&x| x != 0)
-            .map(PageNumber);
+            .map(PageNumber)
+            .filter(|&x| x != FREELIST_EMPTY);
+
         let ln_bump = PageNumber(meta.ln_bump);
         let bbn_bump = PageNumber(meta.bbn_bump);
 


### PR DESCRIPTION
I am not sure about the fix here, but it seems to work. The `unwrap` in `commit` was wrong, and now it returns the marker value of `0`. I also added a constant as a slight code quality improvement.