### PR TITLE
fix: use MSB0 bit-order for separators and key comparisons

### DIFF
--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -89,21 +89,21 @@ impl BranchNode {
         slice[7] = len;
     }
 
-    fn varbits(&self) -> &BitSlice<u8> {
+    fn varbits(&self) -> &BitSlice<u8, Msb0> {
         self.view().varbits()
     }
 
-    fn varbits_mut(&mut self) -> &mut BitSlice<u8> {
+    fn varbits_mut(&mut self) -> &mut BitSlice<u8, Msb0> {
         let bit_cnt =
             self.prefix_len() as usize + (self.separator_len() as usize) * self.n() as usize;
         self.as_mut_slice()[8..(8 + bit_cnt)].view_bits_mut()
     }
 
-    pub fn prefix(&self) -> &BitSlice<u8> {
+    pub fn prefix(&self) -> &BitSlice<u8, Msb0> {
         self.view().prefix()
     }
 
-    pub fn separator(&self, i: usize) -> &BitSlice<u8> {
+    pub fn separator(&self, i: usize) -> &BitSlice<u8, Msb0> {
         self.view().separator(i)
     }
 
@@ -165,17 +165,17 @@ impl<'a> BranchNodeView<'a> {
         self.inner[7]
     }
 
-    fn varbits(&self) -> &'a BitSlice<u8> {
+    fn varbits(&self) -> &'a BitSlice<u8, Msb0> {
         let bit_cnt =
             self.prefix_len() as usize + (self.separator_len() as usize) * self.n() as usize;
         self.inner[8..(8 + bit_cnt)].view_bits()
     }
 
-    pub fn prefix(&self) -> &'a BitSlice<u8> {
+    pub fn prefix(&self) -> &'a BitSlice<u8, Msb0> {
         &self.varbits()[..self.prefix_len() as usize]
     }
 
-    pub fn separator(&self, i: usize) -> &'a BitSlice<u8> {
+    pub fn separator(&self, i: usize) -> &'a BitSlice<u8, Msb0> {
         let offset = self.prefix_len() as usize + i * self.separator_len() as usize;
         &self.varbits()[offset..offset + self.separator_len() as usize]
     }
@@ -229,11 +229,11 @@ impl BranchNodeBuilder {
 
         let varbits = self.branch.varbits_mut();
         if self.index == 0 {
-            let prefix = &key.view_bits::<Lsb0>()[..self.prefix_len];
+            let prefix = &key.view_bits::<Msb0>()[..self.prefix_len];
             varbits[..self.prefix_len].copy_from_bitslice(prefix);
         }
 
-        let separator = &key.view_bits::<Lsb0>()[self.prefix_len..][..self.separator_len];
+        let separator = &key.view_bits::<Msb0>()[self.prefix_len..][..self.separator_len];
 
         let cell_start = self.prefix_len + self.index * self.separator_len;
         let cell_end = cell_start + self.separator_len;

--- a/nomt/src/beatree/ops/mod.rs
+++ b/nomt/src/beatree/ops/mod.rs
@@ -48,20 +48,21 @@ pub fn lookup(
 fn search_branch(branch: &branch::BranchNode, key: Key) -> Option<(usize, PageNumber)> {
     let prefix = branch.prefix();
 
-    match key.view_bits::<Lsb0>()[..prefix.len()].cmp(prefix) {
+    match key.view_bits::<Msb0>()[..prefix.len()].cmp(prefix) {
         Ordering::Equal => {}
         Ordering::Less => return None,
         Ordering::Greater => {
             let i = branch.n() as usize - 1;
-            return Some((i, branch.node_pointer(i).into()))
+            return Some((i, branch.node_pointer(i).into()));
         }
     }
 
-    let post_key =
-        &key.view_bits::<Lsb0>()[prefix.len()..prefix.len() + branch.separator_len() as usize];
+    let total_separator_len = prefix.len() + branch.separator_len() as usize;
+    let post_key = &key.view_bits::<Msb0>()[prefix.len()..total_separator_len];
 
     let mut low = 0;
     let mut high = branch.n() as usize;
+
     while low < high {
         let mid = low + (high - low) / 2;
         if post_key < branch.separator(mid) {

--- a/nomt/src/beatree/ops/reconstruction.rs
+++ b/nomt/src/beatree/ops/reconstruction.rs
@@ -52,7 +52,7 @@ pub fn reconstruct(
         let mut separator = [0u8; 32];
         {
             let prefix = view.prefix();
-            let separator = separator.view_bits_mut::<Lsb0>();
+            let separator = separator.view_bits_mut::<Msb0>();
             separator[..prefix.len()].copy_from_bitslice(prefix);
             let first = view.separator(0);
             separator[prefix.len()..prefix.len() + first.len()].copy_from_bitslice(first);

--- a/nomt/src/beatree/ops/update/branch.rs
+++ b/nomt/src/beatree/ops/update/branch.rs
@@ -32,7 +32,7 @@ impl BaseBranch {
         }
     }
 
-    fn key(&self, i: usize) -> Key {
+    pub fn key(&self, i: usize) -> Key {
         reconstruct_key(self.node.prefix(), self.node.separator(i))
     }
 
@@ -40,7 +40,7 @@ impl BaseBranch {
         (self.key(i), self.node.node_pointer(i).into())
     }
 
-    fn separator(&self) -> Key {
+    pub fn separator(&self) -> Key {
         self.key(0)
     }
 
@@ -490,16 +490,19 @@ impl BranchGauge {
 
 fn prefix_len(key_a: &Key, key_b: &Key) -> usize {
     key_a
-        .view_bits::<Lsb0>()
+        .view_bits::<Msb0>()
         .iter()
-        .zip(key_b.view_bits::<Lsb0>().iter())
+        .zip(key_b.view_bits::<Msb0>().iter())
         .take_while(|(a, b)| a == b)
         .count()
 }
 
 fn separator_len(key: &Key) -> usize {
-    let key = &key.view_bits::<Lsb0>();
-    std::cmp::max(1, key.len() - key.trailing_zeros())
+    if key == &[0u8; 32] {
+        return 1;
+    }
+    let key = &key.view_bits::<Msb0>();
+    key.len() - key.trailing_zeros()
 }
 
 #[derive(Default)]

--- a/nomt/src/beatree/ops/update/leaf.rs
+++ b/nomt/src/beatree/ops/update/leaf.rs
@@ -382,10 +382,13 @@ impl LeafUpdater {
     }
 
     fn build_leaf(&self, ops: &[LeafOp]) -> LeafNode {
-        let total_value_size = ops.iter().map(|op| match op {
-            LeafOp::Keep(_, size) => *size,
-            LeafOp::Insert(_, v) => v.len(),
-        }).sum();
+        let total_value_size = ops
+            .iter()
+            .map(|op| match op {
+                LeafOp::Keep(_, size) => *size,
+                LeafOp::Insert(_, v) => v.len(),
+            })
+            .sum();
 
         let mut leaf_builder = LeafBuilder::new(ops.len(), total_value_size);
         for op in ops {
@@ -435,14 +438,14 @@ impl LeafGauge {
 fn separate(a: &Key, b: &Key) -> Key {
     // if b > a at some point b must have a 1 where a has a 0 and they are equal up to that point.
     let len = a
-        .view_bits::<Lsb0>()
+        .view_bits::<Msb0>()
         .iter()
-        .zip(b.view_bits::<Lsb0>().iter())
+        .zip(b.view_bits::<Msb0>().iter())
         .take_while(|(a, b)| a == b)
         .count()
         + 1;
 
     let mut separator = [0u8; 32];
-    separator.view_bits_mut::<Lsb0>()[..len].copy_from_bitslice(&b.view_bits::<Lsb0>()[..len]);
+    separator.view_bits_mut::<Msb0>()[..len].copy_from_bitslice(&b.view_bits::<Msb0>()[..len]);
     separator
 }

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -248,9 +248,9 @@ impl Updater {
     }
 }
 
-fn reconstruct_key(prefix: &BitSlice<u8>, separator: &BitSlice<u8>) -> Key {
+pub fn reconstruct_key(prefix: &BitSlice<u8, Msb0>, separator: &BitSlice<u8, Msb0>) -> Key {
     let mut key = [0u8; 32];
-    key.view_bits_mut::<Lsb0>()[..prefix.len()].copy_from_bitslice(prefix);
-    key.view_bits_mut::<Lsb0>()[prefix.len()..][..separator.len()].copy_from_bitslice(separator);
+    key.view_bits_mut::<Msb0>()[..prefix.len()].copy_from_bitslice(prefix);
+    key.view_bits_mut::<Msb0>()[prefix.len()..][..separator.len()].copy_from_bitslice(separator);
     key
 }


### PR DESCRIPTION
LSB0 was causing incorrect lexicographical comparisons, since it reversed the order of bits in the byte. This switches everything to MSB0.
