### PR TITLE
fix: reset after splitting

### DIFF
--- a/nomt/src/beatree/ops/update/branch.rs
+++ b/nomt/src/beatree/ops/update/branch.rs
@@ -370,6 +370,10 @@ impl BranchUpdater {
             bbn_index.insert(right_separator, right_branch_id);
             bbn_writer.allocate(right_node);
 
+            self.ops.clear();
+            self.gauge = BranchGauge::new();
+            self.separator_override = None;
+
             DigestResult::Finished
         } else {
             // degenerate split: impossible to create two nodes with >50%. Merge remainder into

--- a/nomt/src/beatree/ops/update/leaf.rs
+++ b/nomt/src/beatree/ops/update/leaf.rs
@@ -337,6 +337,10 @@ impl LeafUpdater {
             let right_pn = leaf_writer.allocate(right_leaf);
             branch_updater.ingest(right_separator, right_pn);
 
+            self.ops.clear();
+            self.gauge = LeafGauge::default();
+            self.separator_override = None;
+
             DigestResult::Finished
         } else {
             // degenerate split: impossible to create two nodes with >50%. Merge remainder into


### PR DESCRIPTION
after a successful split, we previously weren't resetting the ops / separator override / gauge. this led to all ops carrying over to the next leaf / branch.
