### PR TITLE
fix: use *mut u8 in BNP instead of *mut ()

### DIFF
--- a/nomt/src/beatree/branch/mod.rs
+++ b/nomt/src/beatree/branch/mod.rs
@@ -32,7 +32,7 @@ pub const BRANCH_NODE_SIZE: usize = 4096;
 /// Handle. Cheap to clone.
 pub struct BranchNodePool {
     /// The pointer to the beginning of the pool allocation.
-    pool_base_ptr: *mut (),
+    pool_base_ptr: *mut u8,
     inner: Arc<Mutex<BranchNodePoolInner>>,
 }
 
@@ -70,7 +70,7 @@ impl BranchNodePool {
         if pool_base_ptr == libc::MAP_FAILED {
             panic!("mmap failed");
         }
-        let pool_base_ptr = pool_base_ptr as *mut ();
+        let pool_base_ptr = pool_base_ptr as *mut u8;
         BranchNodePool {
             pool_base_ptr,
             inner: Arc::new(Mutex::new(BranchNodePoolInner {

--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -31,7 +31,7 @@ pub const BRANCH_NODE_BODY_SIZE: usize = BRANCH_NODE_SIZE - (4 + 2 + 1 + 1);
 pub struct BranchNode {
     pub(super) pool: Arc<Mutex<BranchNodePoolInner>>,
     pub(super) id: BranchId,
-    pub(super) ptr: *mut (),
+    pub(super) ptr: *mut u8,
 }
 
 impl BranchNode {


### PR DESCRIPTION
Since `()` is a ZST, `checkout` was broken as `(*mut ()).offset(X)` is a no-op. All the branches being handled out pointed to the beginning of the mapped region. Changing the type to `*mut u8` fixes that.
