### PR TITLE
beatree: change writeout workflow

### DIFF
--- a/nomt/src/store.rs
+++ b/nomt/src/store.rs
@@ -5,6 +5,7 @@ use nomt_core::{
     page_id::PageId,
     trie::{KeyPath, Node, TERMINATOR},
 };
+use parking_lot::Mutex;
 use rocksdb::{self, ColumnFamilyDescriptor, WriteBatch};
 use std::sync::Arc;
 


### PR DESCRIPTION
This is not the final stage for the writeout module; it functions in tests, but this pull request should be followed by either #270 or a variation of the `MetaSwap` struct
