### PR TITLE
refactor: decouple page cache and store

### DIFF
--- a/benchtop/src/backend.rs
+++ b/benchtop/src/backend.rs
@@ -15,10 +15,10 @@ impl Backend {
     // If reset is true, then erase any previous backend's database
     // and restart from an empty database.
     // Otherwise, use the already present database.
-    pub fn instantiate(&self, reset: bool, fetch_concurrency: usize, num_rings: usize) -> DB {
+    pub fn instantiate(&self, reset: bool, commit_concurrency: usize, num_rings: usize) -> DB {
         match self {
             Backend::SovDB => DB::Sov(SovDB::open(reset)),
-            Backend::Nomt => DB::Nomt(NomtDB::open(reset, fetch_concurrency, num_rings)),
+            Backend::Nomt => DB::Nomt(NomtDB::open(reset, commit_concurrency, num_rings)),
             Backend::SpTrie => DB::SpTrie(SpTrieDB::open(reset)),
         }
     }

--- a/benchtop/src/bench.rs
+++ b/benchtop/src/bench.rs
@@ -23,7 +23,7 @@ pub fn bench(bench_type: BenchType) -> Result<()> {
             .unwrap_or(0),
         common_params.workload.percentage_cold,
     )?;
-    let fetch_concurrency = common_params.workload.fetch_concurrency;
+    let commit_concurrency = common_params.workload.commit_concurrency;
     let num_rings = common_params.workload.num_rings;
 
     let backends = if common_params.backends.is_empty() {
@@ -39,7 +39,7 @@ pub fn bench(bench_type: BenchType) -> Result<()> {
             backends,
             params.iterations,
             true,
-            fetch_concurrency,
+            commit_concurrency,
             num_rings,
         )
         .map(|_| ()),
@@ -50,7 +50,7 @@ pub fn bench(bench_type: BenchType) -> Result<()> {
             params.op_limit,
             params.time_limit,
             true,
-            fetch_concurrency,
+            commit_concurrency,
             num_rings,
         )
         .map(|_| ()),
@@ -68,7 +68,7 @@ pub fn bench_isolate(
     backends: Vec<Backend>,
     iterations: u64,
     print: bool,
-    fetch_concurrency: usize,
+    commit_concurrency: usize,
     num_rings: usize,
 ) -> Result<Vec<u64>> {
     let mut mean_results = vec![];
@@ -76,7 +76,7 @@ pub fn bench_isolate(
         let mut timer = Timer::new(format!("{}", backend));
 
         for _ in 0..iterations {
-            let mut db = backend.instantiate(true, fetch_concurrency, num_rings);
+            let mut db = backend.instantiate(true, commit_concurrency, num_rings);
             db.execute(None, &mut init);
             db.execute(Some(&mut timer), &mut *workload);
             db.print_metrics();
@@ -104,7 +104,7 @@ pub fn bench_sequential(
     op_limit: Option<u64>,
     time_limit: Option<u64>,
     print: bool,
-    fetch_concurrency: usize,
+    commit_concurrency: usize,
     num_rings: usize,
 ) -> Result<Vec<u64>> {
     if let (None, None) = (op_limit, time_limit) {
@@ -115,7 +115,7 @@ pub fn bench_sequential(
 
     for backend in backends {
         let mut timer = Timer::new(format!("{}", backend));
-        let mut db = backend.instantiate(true, fetch_concurrency, num_rings);
+        let mut db = backend.instantiate(true, commit_concurrency, num_rings);
 
         let mut elapsed_time = 0;
         let mut op_count = 0;

--- a/benchtop/src/cli.rs
+++ b/benchtop/src/cli.rs
@@ -113,7 +113,7 @@ pub struct WorkloadParams {
     /// Default value is 1
     #[arg(long = "fetch-concurrency", short)]
     #[clap(default_value = "1")]
-    pub fetch_concurrency: usize,
+    pub commit_concurrency: usize,
 
     /// Number of io_uring instances. Only used with Nomt backend.
     ///

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -37,7 +37,7 @@ pub fn init(params: InitParams) -> Result<()> {
 
     let mut db = params.backend.instantiate(
         true,
-        workload_params.fetch_concurrency,
+        workload_params.commit_concurrency,
         workload_params.num_rings,
     );
     db.execute(None, &mut *init);
@@ -60,7 +60,7 @@ pub fn run(params: RunParams) -> Result<()> {
 
     let mut db = params.backend.instantiate(
         params.reset,
-        workload_params.fetch_concurrency,
+        workload_params.commit_concurrency,
         workload_params.num_rings,
     );
     if params.reset {

--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -11,7 +11,7 @@ pub struct NomtDB {
 }
 
 impl NomtDB {
-    pub fn open(reset: bool, fetch_concurrency: usize, num_rings: usize) -> Self {
+    pub fn open(reset: bool, commit_concurrency: usize, num_rings: usize) -> Self {
         if reset {
             // Delete previously existing db
             let _ = std::fs::remove_dir_all(NOMT_DB_FOLDER);
@@ -19,7 +19,7 @@ impl NomtDB {
 
         let mut opts = Options::new();
         opts.path(NOMT_DB_FOLDER);
-        opts.fetch_concurrency(fetch_concurrency);
+        opts.commit_concurrency(commit_concurrency);
         opts.num_rings(num_rings);
         opts.metrics(true);
 

--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -11,7 +11,7 @@ impl NomtDB {
         // Define the options used to open NOMT
         let mut opts = Options::new();
         opts.path(NOMT_DB_FOLDER);
-        opts.fetch_concurrency(1);
+        opts.commit_concurrency(1);
 
         // Open NOMT database, it will create the folder if it does not exist
         let nomt = Nomt::open(opts)?;

--- a/examples/read_value/src/main.rs
+++ b/examples/read_value/src/main.rs
@@ -8,7 +8,7 @@ fn main() -> Result<()> {
     // Define the options used to open NOMT
     let mut opts = Options::new();
     opts.path(NOMT_DB_FOLDER);
-    opts.fetch_concurrency(1);
+    opts.commit_concurrency(1);
 
     // Open nomt database, it will create the folder if it does not exist
     let nomt = Nomt::open(opts)?;

--- a/fuzz/fuzz_targets/api_surface.rs
+++ b/fuzz/fuzz_targets/api_surface.rs
@@ -8,7 +8,7 @@ use libfuzzer_sys::fuzz_target;
 use nomt::{KeyPath, KeyReadWrite, Nomt, Options, Value};
 
 fuzz_target!(|run: Run| {
-    let db = open_db(run.fetch_concurrency);
+    let db = open_db(run.commit_concurrency);
 
     for call in run.calls.calls {
         match call {
@@ -90,14 +90,14 @@ impl Context {
 
 #[derive(Debug)]
 struct Run {
-    fetch_concurrency: usize,
+    commit_concurrency: usize,
     calls: NomtCalls,
 }
 
 impl<'a> Arbitrary<'a> for Run {
     fn arbitrary(input: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let run = Run {
-            fetch_concurrency: input.int_in_range(1..=4)?,
+            commit_concurrency: input.int_in_range(1..=4)?,
             calls: input.arbitrary()?,
         };
         Ok(run)
@@ -239,11 +239,11 @@ impl<'a> Arbitrary<'a> for NomtCalls {
     }
 }
 
-fn open_db(fetch_concurrency: usize) -> Nomt {
+fn open_db(commit_concurrency: usize) -> Nomt {
     let tempfile = tempfile::tempdir().unwrap();
     let db_path = tempfile.path().join("db");
     let mut options = Options::default();
     options.path(db_path);
-    options.fetch_concurrency(fetch_concurrency);
+    options.commit_concurrency(commit_concurrency);
     Nomt::open(options).unwrap()
 }

--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -94,7 +94,11 @@ impl BranchNode {
     }
 
     fn varbits_mut(&mut self) -> &mut BitSlice<u8, Msb0> {
-        let body_end = body_size(self.prefix_len() as _, self.separator_len() as _, self.n() as _) + 8;
+        let body_end = body_size(
+            self.prefix_len() as _,
+            self.separator_len() as _,
+            self.n() as _,
+        ) + 8;
         self.as_mut_slice()[8..body_end].view_bits_mut()
     }
 
@@ -165,7 +169,11 @@ impl<'a> BranchNodeView<'a> {
     }
 
     fn varbits(&self) -> &'a BitSlice<u8, Msb0> {
-        let body_end = body_size(self.prefix_len() as _, self.separator_len() as _, self.n() as _) + 8;
+        let body_end = body_size(
+            self.prefix_len() as _,
+            self.separator_len() as _,
+            self.n() as _,
+        ) + 8;
         self.inner[8..body_end].view_bits()
     }
 

--- a/nomt/src/beatree/ops/reconstruction.rs
+++ b/nomt/src/beatree/ops/reconstruction.rs
@@ -40,7 +40,12 @@ pub fn reconstruct(
             continue;
         }
 
-        ensure!(view.bbn_pn() == pn, "pn mismatch {} != {}", view.bbn_pn(), pn);
+        ensure!(
+            view.bbn_pn() == pn,
+            "pn mismatch {} != {}",
+            view.bbn_pn(),
+            pn
+        );
 
         let new_branch_id = bnp.allocate();
 
@@ -60,7 +65,10 @@ pub fn reconstruct(
         }
 
         if let Some(_) = index.insert(separator, new_branch_id) {
-            bail!("2 branch nodes with same separator, separator={:?}", separator);
+            bail!(
+                "2 branch nodes with same separator, separator={:?}",
+                separator
+            );
         }
     }
     Ok(index)

--- a/nomt/src/options.rs
+++ b/nomt/src/options.rs
@@ -4,9 +4,8 @@ use std::path::PathBuf;
 pub struct Options {
     /// The path to the directory where the trie is stored.
     pub(crate) path: PathBuf,
-    /// The maximum number of concurrent page fetches. Values over 64 will be rounded down to 64.
-    /// May not be zero.
-    pub(crate) fetch_concurrency: usize,
+    /// The number of commit workers. Values over 64 will be rounded down to 64.
+    pub(crate) commit_concurrency: usize,
     /// The number of io_uring instances
     pub(crate) num_rings: usize,
     /// Enable or disable metrics collection.
@@ -18,7 +17,7 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             path: PathBuf::from("nomt_db"),
-            fetch_concurrency: 1,
+            commit_concurrency: 1,
             num_rings: 3,
             metrics: false,
             bitbox_num_pages: 64_000,
@@ -37,13 +36,13 @@ impl Options {
         self.path = path.into();
     }
 
-    /// Set the maximum number of concurrent page fetches.
+    /// Set the maximum number of concurrent commit workers.
     ///
     /// Values over 64 will be rounded down to 64.
     ///
     /// May not be zero.
-    pub fn fetch_concurrency(&mut self, fetch_concurrency: usize) {
-        self.fetch_concurrency = fetch_concurrency;
+    pub fn commit_concurrency(&mut self, commit_concurrency: usize) {
+        self.commit_concurrency = commit_concurrency;
     }
 
     /// Set metrics collection on or off.

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -32,7 +32,7 @@ pub fn expected_root(accounts: u64) -> Node {
 fn opts(path: PathBuf) -> Options {
     let mut opts = Options::new();
     opts.path(path);
-    opts.fetch_concurrency(1);
+    opts.commit_concurrency(1);
     opts
 }
 


### PR DESCRIPTION
This comes with an extremely shitty but correct rewrite of `seek`, which I intend to replace with a fast io_uring bitbox prober in a follow-up.
