### PR TITLE
hack: disable WAL pruning on non-linux platforms

### DIFF
--- a/nomt/src/bitbox/wal/mod.rs
+++ b/nomt/src/bitbox/wal/mod.rs
@@ -85,6 +85,9 @@ impl WalWriter {
             return;
         }
 
+        // TODO: other UNIXes are going to need not a WAL but a WAL
+        // file pool. FALLOC_FL_COLLAPSE_RANGE only works on Linux.
+        #[cfg(target_os="linux")]
         unsafe {
             let res = libc::fallocate(
                 self.wal_file.as_raw_fd(),


### PR DESCRIPTION
This is a dirty hack, but highlights an issue with macOS support that we need to address sooner rather than later.

Although the WAL will grow indefinitely on macOS, with this change I am happy to report that our integration test now works on my Mac!
