### PR TITLE
refactor: create an IoHandle wrapper around sender/receiver

### DIFF
--- a/nomt/src/beatree/bbn.rs
+++ b/nomt/src/beatree/bbn.rs
@@ -1,8 +1,4 @@
-use crate::{
-    io::Page,
-    io::{CompleteIo, IoCommand},
-};
-use crossbeam_channel::{Receiver, Sender};
+use crate::io::{IoPool, Page};
 
 use std::{collections::BTreeSet, fs::File};
 
@@ -25,18 +21,9 @@ pub fn create(
     fd: File,
     free_list_head: Option<PageNumber>,
     bump: PageNumber,
-    io_handle_index: usize,
-    io_sender: Sender<IoCommand>,
-    io_receiver: Receiver<CompleteIo>,
+    io_pool: &IoPool,
 ) -> (BbnStoreWriter, BTreeSet<PageNumber>) {
-    let allocator_writer = AllocatorWriter::new(
-        fd,
-        free_list_head,
-        bump,
-        io_handle_index,
-        io_sender,
-        io_receiver,
-    );
+    let allocator_writer = AllocatorWriter::new(fd, free_list_head, bump, io_pool.make_handle());
     let freelist = allocator_writer.free_list().all_tracked_pages();
 
     (

--- a/nomt/src/bitbox/store.rs
+++ b/nomt/src/bitbox/store.rs
@@ -90,10 +90,7 @@ pub fn create(path: PathBuf, num_pages: u32) -> std::io::Result<()> {
 
     let start = std::time::Instant::now();
     let ht_path = path.join("ht");
-    let mut ht_file = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(ht_path)?;
+    let mut ht_file = OpenOptions::new().append(true).create(true).open(ht_path)?;
 
     // number of pages + pages required for meta bits.
     let page_count = num_pages + num_meta_byte_pages(num_pages);
@@ -112,10 +109,7 @@ pub fn create(path: PathBuf, num_pages: u32) -> std::io::Result<()> {
     drop(ht_file);
 
     let wal_path = path.join("wal");
-    let wal_file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(wal_path)?;
+    let wal_file = OpenOptions::new().write(true).create(true).open(wal_path)?;
     wal_file.sync_all()?;
     drop(wal_file);
 

--- a/nomt/src/bitbox/wal/mod.rs
+++ b/nomt/src/bitbox/wal/mod.rs
@@ -87,7 +87,7 @@ impl WalWriter {
 
         // TODO: other UNIXes are going to need not a WAL but a WAL
         // file pool. FALLOC_FL_COLLAPSE_RANGE only works on Linux.
-        #[cfg(target_os="linux")]
+        #[cfg(target_os = "linux")]
         unsafe {
             let res = libc::fallocate(
                 self.wal_file.as_raw_fd(),
@@ -150,9 +150,7 @@ impl WalChecker {
             .len();
 
         if wal_file_len == 0 {
-            return Self {
-                last_batch: None,
-            };
+            return Self { last_batch: None };
         }
 
         if last_records_position as u64 != wal_file_len {

--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_family = "unix"))]
 std::compile_error!("NOMT only supports Unix-based OSs");
 
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::{Receiver, RecvError, SendError, Sender, TryRecvError, TrySendError};
 use std::{
     ops::{Deref, DerefMut},
     os::fd::RawFd,
@@ -40,8 +40,6 @@ impl Page {
     }
 }
 
-pub type HandleIndex = usize;
-
 #[derive(Clone)]
 pub enum IoKind {
     Read(RawFd, u64, Box<Page>),
@@ -64,7 +62,6 @@ unsafe impl Send for IoKind {}
 
 pub struct IoCommand {
     pub kind: IoKind,
-    pub handle: HandleIndex,
     // note: this isn't passed to io_uring, it's higher-level userdata.
     pub user_data: u64,
 }
@@ -74,11 +71,91 @@ pub struct CompleteIo {
     pub result: std::io::Result<()>,
 }
 
+struct IoPacket {
+    command: IoCommand,
+    completion_sender: Sender<CompleteIo>,
+}
+
 /// Create an I/O worker managing an io_uring and sending responses back via channels to a number
 /// of handles.
-pub fn start_io_worker(
-    num_handles: usize,
-    num_rings: usize,
-) -> (Sender<IoCommand>, Vec<Receiver<CompleteIo>>) {
-    platform::start_io_worker(num_handles, num_rings)
+pub fn start_io_pool(num_rings: usize) -> IoPool {
+    let sender = platform::start_io_worker(num_rings);
+    IoPool { sender }
+}
+
+/// A manager for the broader I/O pool. This can be used to create new I/O handles.
+///
+/// Dropping this does not close any outstanding I/O handles or shut down I/O workers.
+pub struct IoPool {
+    sender: Sender<IoPacket>,
+}
+
+impl IoPool {
+    /// Create a new I/O handle.
+    pub fn make_handle(&self) -> IoHandle {
+        let (completion_sender, completion_receiver) = crossbeam_channel::unbounded();
+        IoHandle {
+            sender: self.sender.clone(),
+            completion_sender,
+            completion_receiver,
+        }
+    }
+}
+
+/// A handle for submitting I/O commands and receiving their completions.
+///
+/// Only completions for commands submitted on this handle or its clones will be received, and in
+/// no guaranteed order.
+///
+/// Clones, like normal channel clones, do not create a new handle but instead read from the same
+/// stream of completions.
+///
+/// This is safe to use across multiple threads, but care must be taken by the user for correctness.
+#[derive(Clone)]
+pub struct IoHandle {
+    sender: Sender<IoPacket>,
+    completion_sender: Sender<CompleteIo>,
+    completion_receiver: Receiver<CompleteIo>,
+}
+
+impl IoHandle {
+    /// Block the current thread to send an I/O command. This fails if the channel has hung up.
+    pub fn send(&self, command: IoCommand) -> Result<(), SendError<IoCommand>> {
+        self.sender
+            .send(IoPacket {
+                command,
+                completion_sender: self.completion_sender.clone(),
+            })
+            .map_err(|SendError(packet)| SendError(packet.command))
+    }
+
+    /// Try to send an I/O command without blocking. This fails if the channel is full or has
+    /// disconnected.
+    pub fn try_send(&self, command: IoCommand) -> Result<(), TrySendError<IoCommand>> {
+        self.sender
+            .try_send(IoPacket {
+                command,
+                completion_sender: self.completion_sender.clone(),
+            })
+            .map_err(|err| match err {
+                TrySendError::Full(packet) => TrySendError::Full(packet.command),
+                TrySendError::Disconnected(packet) => TrySendError::Disconnected(packet.command),
+            })
+    }
+
+    /// Block the current thread on receiving an I/O completion.
+    /// This fails if the channel has hung up.
+    pub fn recv(&self) -> Result<CompleteIo, RecvError> {
+        self.completion_receiver.recv()
+    }
+
+    /// Try to receive an I/O completion without blocking.
+    pub fn try_recv(&self) -> Result<CompleteIo, TryRecvError> {
+        self.completion_receiver.try_recv()
+    }
+
+    /// Get the underlying completion receiver for raw access.
+    pub fn receiver(&self) -> &Receiver<CompleteIo> {
+        &self.completion_receiver
+    }
 }


### PR DESCRIPTION
As part of this refactor, we also no longer have to specify the number of handles we wish to create ahead-of-time. This is maybe a slight pessimization, since it means that we send a clone of the completion receiver to the io worker threads with every command. That's an extra atomic add/sub pair. On the off chance this is actually relevant to workload performance, I am pretty confident we can apply another approach to creating handles without breaking this abstraction.
