### PR TITLE
refactor: use a single, global I/O pool for writeout, bitbox, beatree

### DIFF
--- a/nomt/src/beatree/mod.rs
+++ b/nomt/src/beatree/mod.rs
@@ -11,7 +11,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::io::Page;
+use crate::io::{IoPool, Page};
 
 use leaf::store::{LeafStoreReader, LeafStoreWriter};
 
@@ -63,6 +63,7 @@ impl Shared {
 
 impl Tree {
     pub fn open(
+        io_pool: &IoPool,
         ln_freelist_pn: u32,
         bbn_freelist_pn: u32,
         ln_bump: u32,
@@ -70,8 +71,6 @@ impl Tree {
         bbn_file: &File,
         ln_file: &File,
     ) -> Result<Tree> {
-        let io_pool = crate::io::start_io_pool(3);
-
         let ln_freelist_pn = Some(ln_freelist_pn)
             .map(PageNumber)
             .filter(|&x| x != FREELIST_EMPTY);

--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use threadpool::ThreadPool;
 
 use crate::{
-    io::{CompleteIo, IoCommand, IoHandle, IoKind, Page, PAGE_SIZE},
+    io::{CompleteIo, IoCommand, IoHandle, IoKind, IoPool, Page, PAGE_SIZE},
     page_cache::PageDiff,
 };
 
@@ -47,9 +47,9 @@ pub struct Shared {
 impl DB {
     /// Opens an existing bitbox database.
     pub fn open(
+        io_pool: &IoPool,
         sync_seqn: u32,
         num_pages: u32,
-        num_rings: usize,
         ht_fd: &std::fs::File,
         wal_fd: &std::fs::File,
     ) -> anyhow::Result<Self> {
@@ -98,9 +98,6 @@ impl DB {
                 anyhow::bail!("encountered error in opening wal: {e:?}")
             }
         };
-
-        // Spawn io pool.
-        let io_pool = crate::io::start_io_pool(num_rings);
 
         // Spawn PageRequest dispatcher
         let (get_page_tx, get_page_rx) = crossbeam::channel::unbounded();


### PR DESCRIPTION
say goodbye to having separate I/O pools for each component!
