### PR TITLE
feat: implement a basic page loader for bitbox pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,9 +636,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 [dependencies]
 anyhow = { version = "1.0.81", features = ["backtrace"] }
 nomt-core = { path = "../core", features = ["std"] }
-parking_lot = { version = "0.12.1", features = ["arc_lock", "send_guard"] }
+parking_lot = { version = "0.12.3", features = ["arc_lock", "send_guard"] }
 threadpool = "1.8.1"
 bitvec = { version = "1" }
 blake3 = "1.5.1"

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -144,7 +144,8 @@ impl Store {
 
     /// Loads the given page.
     pub fn load_page(&self, page_id: PageId) -> anyhow::Result<Option<(Vec<u8>, BucketIndex)>> {
-        self.shared.pages.get(&page_id)
+        let page_loader = bitbox::PageLoader::new(&self.shared.pages, self.io_pool().make_handle());
+        page_loader.load_sync(self.shared.ht_fd.as_raw_fd(), &page_id)
     }
 
     /// Access the underlying IoPool.


### PR DESCRIPTION
this lays the groundwork for exposing a thin wrapper for io_uring to NOMT commit workers.

it's not totally clear where this logic should live in the end. I'd like to encapsulate all probing logic in `bitbox` but managing the ht file descriptor is a little rough currently.
