### PR TITLE
chore: remove unnecessary double ht fsync

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -306,17 +306,6 @@ impl DB {
             },
         );
 
-        // sync meta page change.
-        submit_and_wait_one(
-            &self.shared.io_sender,
-            &self.shared.commit_page_receiver,
-            IoCommand {
-                kind: IoKind::Fsync(ht_fd.as_raw_fd()),
-                handle: COMMIT_HANDLE_INDEX,
-                user_data: 0, // unimportant
-            },
-        );
-
         Ok(prev_wal_size)
     }
 


### PR DESCRIPTION
in bitbox we were calling fsync twice in a row with no changes in-between because of the (now removed) meta page.
