### PR TITLE
io: retry read/write until complete

### DIFF
--- a/nomt/src/io/linux.rs
+++ b/nomt/src/io/linux.rs
@@ -1,8 +1,11 @@
-use super::{CompleteIo, IoCommand, IoKind, IoPacket, PAGE_SIZE};
+use super::{CompleteIo, IoCommand, IoKind, IoKindResult, IoPacket, PAGE_SIZE};
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use slab::Slab;
-use std::time::{Duration, Instant};
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
 
 const RING_CAPACITY: u32 = 128;
 
@@ -65,6 +68,7 @@ fn run_worker(command_rx: Receiver<IoPacket>) {
 
     let (submitter, mut submit_queue, mut complete_queue) = ring.split();
     let mut stats = Stats::new();
+    let mut retries = VecDeque::<IoPacket>::new();
 
     loop {
         stats.log();
@@ -84,11 +88,25 @@ fn run_worker(command_rx: Receiver<IoPacket>) {
 
                 stats.note_completion(start.elapsed().as_micros() as u64);
 
-                let result = if completion_event.result() == -1 {
-                    Err(std::io::Error::from_raw_os_error(completion_event.result()))
-                } else {
-                    Ok(())
+                // io_uring never uses errno to pass back error information.
+                // Instead, completion_event.result() will contain what the equivalent
+                // system call would have returned in case of success,
+                // and in case of error completion_event.result() will contain -errno
+                let io_uring_res = completion_event.result();
+                let syscall_result = if io_uring_res >= 0 { io_uring_res } else { -1 };
+
+                let result = match command.kind.get_result(syscall_result) {
+                    IoKindResult::Ok => Ok(()),
+                    IoKindResult::Err => Err(std::io::Error::from_raw_os_error(io_uring_res.abs())),
+                    IoKindResult::Retry => {
+                        retries.push_back(IoPacket {
+                            command,
+                            completion_sender,
+                        });
+                        continue;
+                    }
                 };
+
                 let complete = CompleteIo { command, result };
 
                 if let Err(_) = completion_sender.send(complete) {
@@ -103,7 +121,11 @@ fn run_worker(command_rx: Receiver<IoPacket>) {
 
         submit_queue.sync();
         while pending.len() < MAX_IN_FLIGHT && !submit_queue.is_full() {
-            let next_io = if pending.is_empty() {
+            let next_io = if !retries.is_empty() {
+                // re-apply partially failed reads and writes
+                // unwrap: known not empty
+                retries.pop_front().unwrap()
+            } else if pending.is_empty() {
                 // block on new I/O if nothing in-flight.
                 match command_rx.recv() {
                     Ok(command) => command,

--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -48,12 +48,40 @@ pub enum IoKind {
     Fsync(RawFd),
 }
 
+pub enum IoKindResult {
+    Ok,
+    Err,
+    Retry,
+}
+
 impl IoKind {
     pub fn unwrap_buf(self) -> Box<Page> {
         match self {
             IoKind::Read(_, _, buf) | IoKind::Write(_, _, buf) => buf,
             IoKind::WriteRaw(_, _, _, _) => panic!("attempted to extract buf from write_raw"),
             IoKind::Fsync(_) => panic!("attempted to extract buf from fsync"),
+        }
+    }
+
+    pub fn get_result(&self, res: i32) -> IoKindResult {
+        match self {
+            // fsync returns either -1 on failure or 0 on success
+            IoKind::Fsync(_) if res == 0 => IoKindResult::Ok,
+            // pread and pwrite return the number of bytes read or written
+            IoKind::Read(_, _, _) | IoKind::Write(_, _, _) | IoKind::Write(_, _, _)
+                if res == PAGE_SIZE as i32 =>
+            {
+                IoKindResult::Ok
+            }
+            // pread returns 0 if the file has been read till the end of file
+            //
+            // This could be a failure because the end of the file could be smaller than PAGE_SIZE.
+            // However, as each read operation follows a write operation,
+            // there should be no unexpected end-of-file that is not aligned with PAGE_SIZE
+            // when all previous writes have succeeded.
+            IoKind::Read(_, _, _) if res == 0 => IoKindResult::Ok,
+            _ if res == -1 => IoKindResult::Err,
+            _ => IoKindResult::Retry,
         }
     }
 }

--- a/nomt/src/io/unix.rs
+++ b/nomt/src/io/unix.rs
@@ -31,38 +31,40 @@ fn spawn_worker_thread(command_rx: Receiver<IoPacket>) {
 }
 
 fn execute(mut command: IoCommand) -> CompleteIo {
-    let err = match command.kind {
-        IoKind::Read(fd, page_index, ref mut page) => unsafe {
-            libc::pread(
-                fd,
-                page.as_mut_ptr() as *mut libc::c_void,
-                PAGE_SIZE as libc::size_t,
-                (page_index * PAGE_SIZE as u64) as libc::off_t,
-            ) == -1
-        },
-        IoKind::Write(fd, page_index, ref page) => unsafe {
-            libc::pwrite(
-                fd,
-                page.as_ptr() as *const libc::c_void,
-                PAGE_SIZE as libc::size_t,
-                (page_index * PAGE_SIZE as u64) as libc::off_t,
-            ) == -1
-        },
-        IoKind::WriteRaw(fd, page_index, ptr, size) => unsafe {
-            libc::pwrite(
-                fd,
-                ptr as *const libc::c_void,
-                size as libc::size_t,
-                (page_index * PAGE_SIZE as u64) as libc::off_t,
-            ) == -1
-        },
-        IoKind::Fsync(fd) => unsafe { libc::fsync(fd) == -1 },
-    };
+    let result = loop {
+        let res = match command.kind {
+            IoKind::Read(fd, page_index, ref mut page) => unsafe {
+                libc::pread(
+                    fd,
+                    page.as_mut_ptr() as *mut libc::c_void,
+                    PAGE_SIZE as libc::size_t,
+                    (page_index * PAGE_SIZE as u64) as libc::off_t,
+                )
+            },
+            IoKind::Write(fd, page_index, ref page) => unsafe {
+                libc::pwrite(
+                    fd,
+                    page.as_ptr() as *const libc::c_void,
+                    PAGE_SIZE as libc::size_t,
+                    (page_index * PAGE_SIZE as u64) as libc::off_t,
+                )
+            },
+            IoKind::WriteRaw(fd, page_index, ptr, size) => unsafe {
+                libc::pwrite(
+                    fd,
+                    ptr as *const libc::c_void,
+                    size as libc::size_t,
+                    (page_index * PAGE_SIZE as u64) as libc::off_t,
+                )
+            },
+            IoKind::Fsync(fd) => unsafe { libc::fsync(fd) },
+        };
 
-    let result = if err {
-        Err(std::io::Error::last_os_error())
-    } else {
-        Ok(())
+        match command.kind.get_result(res) {
+            IoKindResult::Ok => break Ok(()),
+            IoKindResult::Err => break Err(std::io::Error::last_os_error()),
+            _ => (),
+        }
     };
 
     CompleteIo { command, result }


### PR DESCRIPTION
If a read or write operation is not fully completed, the command is reapplied

Errors should now be properly handled. However, this has revealed a problem with the fsync command. Each fsync call performed through io_uring is failing with an "Invalid Argument" error message.

A fix will be included in a follow-up pr

closes #288