### PR TITLE
feat: fetch needed sibling leaf-children pages on demand

### DIFF
--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -17,7 +17,7 @@ pub(crate) fn shared_bits(a: &BitSlice<u8, Msb0>, b: &BitSlice<u8, Msb0>) -> usi
 pub fn leaf_ops_spliced(
     leaf: Option<LeafData>,
     ops: &[(KeyPath, Option<ValueHash>)],
-) -> impl Iterator<Item = (KeyPath, ValueHash)> + '_ {
+) -> impl Iterator<Item = (KeyPath, ValueHash)> + Clone + '_ {
     let splice_index = leaf
         .as_ref()
         .and_then(|leaf| ops.binary_search_by_key(&leaf.key_path, |x| x.0).err());


### PR DESCRIPTION
This alters the `PageWalker`'s compact stage to bubble up an error when sibling leaf children are unavailable. Higher level code now reacts to this and fetches the page.

After this PR, we never request more pages than we need.

It's worth noting that we can only fetch a single page at a time this way, but the code is designed so there are many other page fetches ongoing at the same time. This ensures that I/O utilization is high unless this is one of the very last page fetches, in which case the lost potential I/O utilization of getting all the needed sibling pages at once is likely a rounding error.
