### PR TITLE
chore: clean up various warnings and TODOs after this stack

### DIFF
--- a/benchtop/Cargo.lock
+++ b/benchtop/Cargo.lock
@@ -2377,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",

--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -79,7 +79,6 @@ impl<'a> Transaction for Tx<'a> {
     fn write(&mut self, key: &[u8], value: Option<&[u8]>) {
         let key_path = sha2::Sha256::digest(key).into();
         let value = value.map(|v| std::rc::Rc::new(v.to_vec()));
-        let is_delete = value.is_none();
 
         match self.access.entry(key_path) {
             Entry::Occupied(mut o) => {
@@ -90,6 +89,6 @@ impl<'a> Transaction for Tx<'a> {
             }
         }
 
-        self.session.tentative_write_slot(key_path, is_delete);
+        self.session.tentative_write_slot(key_path);
     }
 }

--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -41,8 +41,8 @@ impl NomtDB {
         // As we can observe, the value is not being written at the moment.
         // NOMT is just advertised here to inform that those keys
         // will be written during the commit and prove stage
-        session.tentative_write_slot(key_path_1, true);
-        session.tentative_write_slot(key_path_2, false);
+        session.tentative_write_slot(key_path_1);
+        session.tentative_write_slot(key_path_2);
 
         // Retrieve the previous value of the root before committing changes
         let prev_root = nomt.root();

--- a/fuzz/fuzz_targets/api_surface.rs
+++ b/fuzz/fuzz_targets/api_surface.rs
@@ -23,8 +23,8 @@ fuzz_target!(|run: Run| {
                             let actual_value = session.tentative_read_slot(key_path).unwrap();
                             assert_eq!(actual_value, expected_value);
                         }
-                        SessionCall::TentativeWrite { key_path, delete } => {
-                            session.tentative_write_slot(key_path, delete);
+                        SessionCall::TentativeWrite { key_path } => {
+                            session.tentative_write_slot(key_path);
                         }
                         SessionCall::CommitAndProve { keys } => {
                             let _ = db.commit_and_prove(session, keys);
@@ -117,7 +117,6 @@ enum SessionCall {
     },
     TentativeWrite {
         key_path: KeyPath,
-        delete: bool,
     },
     /// Commit and prove the given keys.
     CommitAndProve {
@@ -203,10 +202,9 @@ impl<'a> Arbitrary<'a> for NomtCalls {
                             expected_value: v.clone(),
                         });
                     }
-                    KeyReadWrite::Write(v) => {
+                    KeyReadWrite::Write(_) => {
                         session_calls.push(SessionCall::TentativeWrite {
                             key_path: *key_path,
-                            delete: v.is_none(),
                         });
                     }
                 }

--- a/nomt/src/beatree/allocator/mod.rs
+++ b/nomt/src/beatree/allocator/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     io::{IoCommand, IoHandle, IoKind},
     io::{Page, PAGE_SIZE},
 };
-use crossbeam_channel::{Receiver, Sender, TrySendError};
+use crossbeam_channel::TrySendError;
 
 use std::{
     fs::File,

--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -1,15 +1,15 @@
-use crossbeam::channel::{Receiver, Sender, TryRecvError, TrySendError};
+use crossbeam::channel::{TryRecvError, TrySendError};
 use nomt_core::page_id::PageId;
 use parking_lot::{ArcRwLockReadGuard, RwLock};
 use std::{
     collections::{HashMap, HashSet},
     fs::File,
     os::fd::{AsRawFd, RawFd},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use crate::{
-    io::{CompleteIo, IoCommand, IoHandle, IoKind, IoPool, Page, PAGE_SIZE},
+    io::{IoCommand, IoHandle, IoKind, IoPool, Page, PAGE_SIZE},
     page_cache::PageDiff,
 };
 

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -351,7 +351,7 @@ impl Session {
     /// Returns `None` if the value is not stored under the given key. Fails only if I/O fails.
     pub fn tentative_read_slot(&mut self, path: KeyPath) -> anyhow::Result<Option<Value>> {
         // UNWRAP: committer always `Some` during lifecycle.
-        self.committer.as_mut().unwrap().warm_up(path, false);
+        self.committer.as_mut().unwrap().warm_up(path);
 
         let _maybe_guard = self.metrics.record(Metric::ValueFetchTime);
 
@@ -359,11 +359,10 @@ impl Session {
         Ok(value)
     }
 
-    /// Signals that the given key is going to be written to. Set `delete` to true when the
-    /// key is likely being deleted.
-    pub fn tentative_write_slot(&mut self, path: KeyPath, delete: bool) {
+    /// Signals that the given key is going to be written to.
+    pub fn tentative_write_slot(&mut self, path: KeyPath) {
         // UNWRAP: committer always `Some` during lifecycle.
-        self.committer.as_mut().unwrap().warm_up(path, delete);
+        self.committer.as_mut().unwrap().warm_up(path);
     }
 }
 

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -3,7 +3,7 @@ use crate::{
     metrics::{Metric, Metrics},
     page_region::PageRegion,
     rw_pass_cell::{ReadPass, Region, RegionContains, RwPassCell, RwPassDomain, WritePass},
-    store::{Store, Transaction},
+    store::Transaction,
     Options,
 };
 use bitvec::prelude::*;
@@ -16,7 +16,7 @@ use nomt_core::{
     trie_pos::{ChildNodeIndices, TriePosition},
 };
 use parking_lot::{Condvar, Mutex, RwLock};
-use std::{collections::hash_map::Entry, fmt, num::NonZeroUsize, sync::Arc};
+use std::{fmt, num::NonZeroUsize, sync::Arc};
 
 // Total number of nodes stored in one Page. It depends on the `DEPTH`
 // of the rootless sub-binary tree stored in a page following this formula:

--- a/nomt/src/seek.rs
+++ b/nomt/src/seek.rs
@@ -321,7 +321,7 @@ impl Seeker {
                     continue;
                 }
 
-                let mut vacant_entry = match self.page_loads.entry(page_id.clone()) {
+                let vacant_entry = match self.page_loads.entry(page_id.clone()) {
                     Entry::Occupied(mut occupied) => {
                         occupied.get_mut().push(request_index);
                         *is_requesting = true;

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -62,7 +62,6 @@ impl Test {
     pub fn write(&mut self, id: u64, value: Option<u64>) {
         let path = account_path(id);
         let value = value.map(|v| Rc::new(v.to_le_bytes().to_vec()));
-        let is_delete = value.is_none();
         match self.access.entry(path) {
             Entry::Occupied(mut o) => {
                 o.get_mut().write(value);
@@ -71,10 +70,7 @@ impl Test {
                 v.insert(KeyReadWrite::Write(value));
             }
         }
-        self.session
-            .as_mut()
-            .unwrap()
-            .tentative_write_slot(path, is_delete);
+        self.session.as_mut().unwrap().tentative_write_slot(path);
     }
 
     #[allow(unused)]


### PR DESCRIPTION
I cleaned up warnings related to the refactors and changes in this stack.

The only change worth pointing out is that `tentative_write_slot` no longer requires `is_delete` as a parameter. This was always an extremely imperfect heuristic that led us to fetch _all_ the sibling leaf child pages, regardless of whether they were needed. Since we no longer eagerly fetch such pages, but instead do it reactively, this parameter is no longer needed.
