### PR TITLE
io: separate fsync from io_uring

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -276,13 +276,7 @@ impl DB {
         }
 
         // sync all writes
-        submit_and_wait_one(
-            &self.shared.io_handle,
-            IoCommand {
-                kind: IoKind::Fsync(ht_fd.as_raw_fd()),
-                user_data: 0, // unimportant
-            },
-        );
+        ht_fd.sync_all().expect("ht file: error performing fsync");
 
         Ok(prev_wal_size)
     }
@@ -341,12 +335,6 @@ impl BucketAllocator {
     pub fn free(&mut self, bucket_index: BucketIndex) {
         self.changed_buckets.insert(bucket_index.0, false);
     }
-}
-
-// call only when I/O queue is totally empty.
-fn submit_and_wait_one(io_handle: &IoHandle, command: IoCommand) {
-    let _ = io_handle.send(command);
-    let _ = io_handle.recv();
 }
 
 fn get_changed(page: &Page, page_diff: &PageDiff) -> Vec<[u8; 32]> {

--- a/nomt/src/io/linux.rs
+++ b/nomt/src/io/linux.rs
@@ -138,6 +138,7 @@ fn run_worker(command_rx: Receiver<IoPacket>) {
                     Err(TryRecvError::Disconnected) => break, // TODO: wait on pending I/O?
                 }
             };
+
             stats.note_arrival();
 
             to_submit = true;
@@ -233,7 +234,6 @@ fn submission_entry(command: &mut IoCommand) -> squeue::Entry {
                 .offset(page_index * PAGE_SIZE as u64)
                 .build()
         }
-        IoKind::Fsync(fd) => opcode::Fsync::new(types::Fd(fd)).build(),
         IoKind::WriteRaw(fd, page_index, ptr, size) => {
             opcode::Write::new(types::Fd(fd), ptr, size as u32)
                 .offset(page_index * PAGE_SIZE as u64)

--- a/nomt/src/io/unix.rs
+++ b/nomt/src/io/unix.rs
@@ -57,7 +57,6 @@ fn execute(mut command: IoCommand) -> CompleteIo {
                     (page_index * PAGE_SIZE as u64) as libc::off_t,
                 )
             },
-            IoKind::Fsync(fd) => unsafe { libc::fsync(fd) },
         };
 
         match command.kind.get_result(res) {

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -59,10 +59,14 @@ impl Store {
 
         let io_pool = io::start_io_pool(o.io_workers);
 
-        let meta_fd = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&o.path.join("meta"))?;
+        let meta_fd = {
+            let mut options = OpenOptions::new();
+            options.read(true).write(true);
+            #[cfg(target_os = "linux")]
+            options.custom_flags(libc::O_DIRECT);
+            options.open(&o.path.join("meta"))?
+        };
+
         let ln_fd = {
             let mut options = OpenOptions::new();
             options.read(true).write(true);


### PR DESCRIPTION

From https://kernel.dk/io_uring.pdf, in the section 'POLLED IO,' we can read: "Only op-codes that make sense for polled completion may be used on an io_uring instance registered with IORING_SETUP_IOPOLL" and fsync is not a valid opcode due to it being a blocking syscall.

This solves the problem of performing each fsync with the standard syscall without passing through io_uring.

This PR also fixes how the meta file was opened (without `O_DIRECT`) and corrects the usage of the metric PageCacheMisses.
