### PR TITLE
fix: pre-box pages in bitbox sync

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -196,7 +196,7 @@ impl DB {
                 Some((raw_page, page_diff)) => {
                     // the page_id must be written into the page itself
                     assert!(raw_page.len() == PAGE_SIZE);
-                    let mut page = crate::bitbox::Page::zeroed();
+                    let mut page = Box::new(crate::bitbox::Page::zeroed());
                     page[..raw_page.len()].copy_from_slice(&raw_page);
                     page[PAGE_SIZE - 32..].copy_from_slice(&page_id.encode());
 
@@ -242,7 +242,7 @@ impl DB {
                 kind: IoKind::Write(
                     ht_fd.as_raw_fd(),
                     self.shared.store.data_page_index(bucket),
-                    Box::new(page),
+                    page,
                 ),
                 user_data: 0, // unimportant.
             };


### PR DESCRIPTION
Previously, we were building a `Vec<(BucketIndex, Page)>`. This allocated over a page of memory for each item. Then, when we iterated over it, we were boxing each page, allocating a second page of memory for each item, essentially doubling the resident memory usage during bitbox sync. This caused OOM with commits that should have taken "only" 50% of the system memory.

That said, this still isn't the "end-state". There are still a lot of unnecessary copies that are going to slow us down. View this as a quick fix for the moment.
