### PR TITLE
fix: panic from calling 'record' on page cache misses

### DIFF
--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -389,7 +389,7 @@ impl PageCache {
                 inner: page.page_data.clone(),
             }),
             None => {
-                self.shared.metrics.record(Metric::PageCacheMisses);
+                self.shared.metrics.count(Metric::PageCacheMisses);
                 None
             }
         }


### PR DESCRIPTION
This is currently a part of the diff of #308 and #306. Separating out for clarity.

Calling `record` with a metric that's not a timer causes a runtime panic when pages are not cached.
