### PR TITLE
chore: use libc::fsync in writeout

### DIFF
--- a/nomt/src/store/writeout.rs
+++ b/nomt/src/store/writeout.rs
@@ -298,9 +298,8 @@ impl BbnWriteOut {
 
     fn fsync(&mut self) {
         unsafe {
-            let f = File::from_raw_fd(self.bbn_fd);
-            f.sync_all().expect("bnn file: error performing fsync");
-            let _ = f.into_raw_fd();
+            let fsync_res = libc::fsync(self.bbn_fd);
+            assert!(fsync_res == 0);
         }
     }
 }
@@ -361,9 +360,8 @@ impl LnWriteOut {
 
     fn fsync(&mut self) {
         unsafe {
-            let f = File::from_raw_fd(self.ln_fd);
-            f.sync_all().expect("ln file: error performing fsync");
-            let _ = f.into_raw_fd();
+            let fsync_res = libc::fsync(self.ln_fd);
+            assert!(fsync_res == 0);
         }
     }
 }


### PR DESCRIPTION
avoid creating a file from the raw file descriptor, instead, use `libc::fsync` directly

https://github.com/thrumdev/nomt/pull/308#discussion_r1727186977