### PR TITLE
feat: overflow cells, writing overflow values

### DIFF
--- a/nomt/src/beatree/leaf/overflow.rs
+++ b/nomt/src/beatree/leaf/overflow.rs
@@ -73,6 +73,16 @@ pub fn chunk(value: &[u8], leaf_writer: &mut LeafStoreWriter) -> Vec<PageNumber>
     cell
 }
 
+/// Encode a list of page numbers into an overflow cell.
+pub fn encode_cell(pages: &[PageNumber]) -> Vec<u8> {
+    let mut v = vec![0u8; pages.len() * 4];
+    for (pn, slice) in pages.iter().zip(v.chunks_mut(4)) {
+        slice.copy_from_slice(&pn.0.to_le_bytes());
+    }
+
+    v
+}
+
 fn total_needed_pages(value_size: usize) -> usize {
     let mut encoded_size = value_size;
     let mut total_pages = needed_pages(encoded_size);

--- a/nomt/src/beatree/ops/mod.rs
+++ b/nomt/src/beatree/ops/mod.rs
@@ -45,7 +45,8 @@ pub fn lookup(
     };
 
     // TODO: handle overflow.
-    Ok(leaf.get(&key).map(|v| v.to_vec()))
+    let maybe_value = leaf.get(&key).map(|(v, _is_overflow)| v.to_vec());
+    Ok(maybe_value)
 }
 
 /// Binary search a branch node for the child node containing the key. This returns the last child


### PR DESCRIPTION
This handles the encoding of overflow cells and writing them in leaves.

In a leaf node, we use a 16-bit integer to encode the offset of each cell start. We take the high bit of this integer to encode whether the cell is an overflow cell or not.

When ingesting a value, if it's too large, we chunk it. Additionally, `LeafUpdater::ingest` has gained a callback for handling deletion of overflow cells. This will be fleshed out in the next PRs, along with loading of overflow values.

I am not focusing on optimization at all at the moment, as it's clear that the beatree update logic needs to be rewritten for parallelism in any case and any optimization at this stage would be wasted effort.
