### PR TITLE
opt: do not materialize `changed` vec

### DIFF
--- a/nomt/src/bitbox/wal/mod.rs
+++ b/nomt/src/bitbox/wal/mod.rs
@@ -62,7 +62,7 @@ impl WalBlobBuilder {
         &mut self,
         page_id: [u8; 32],
         page_diff: [u8; 16],
-        changed: Vec<[u8; 32]>,
+        changed: impl Iterator<Item = [u8; 32]>,
         bucket_index: u64,
     ) {
         unsafe {

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -140,7 +140,7 @@ impl PageDiff {
     }
 
     /// Get raw bytes representing the PageDiff
-    pub fn get_raw(self) -> [u8; 16] {
+    pub fn get_raw(&self) -> [u8; 16] {
         self.updated_slots.data
     }
 }


### PR DESCRIPTION
As per
[this][https://github.com/thrumdev/nomt/pull/323#discussion_r1730422403]
comment, allocation in `get_changed` is not insignificant. This commit
avoids allocation of a vector by passing an iterator.