### PR TITLE
fix: wal blob builder changes

### DIFF
--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -208,7 +208,7 @@ impl Store {
             bitbox_num_pages: self.shared.bitbox_num_pages,
         };
 
-        let bitbox_wal_blob = (sync.wal_blob_builder.ptr(), sync.wal_blob_builder.len());
+        let bitbox_wal_blob = sync.wal_blob_builder.finalize();
         writeout::run(
             sync.io_handle.clone(),
             self.shared.wal_fd.as_raw_fd(),
@@ -225,8 +225,6 @@ impl Store {
             bitbox_writeout_data.ht_pages,
             new_meta,
         );
-
-        sync.wal_blob_builder.reset();
 
         self.shared.values.finish_sync(
             beatree_writeout_data.bbn_index,


### PR DESCRIPTION
1. Change the WAL entry tags from 0 and 1 to 1 and 2. This is needed for
   distinguishing between actually written WAL entries and zeroed space.
2. Introduce `finalize` method that zeroes the WAL blob from the current
   write position to the end of the page. Without this WAL might
   possibly contain the leftover data from the previous syncs.
3. Fix the OOB condition from `cur > mmap_size` to `cur >= mmap_size`.