### PR TITLE
fix: WAL and HT

### DIFF
--- a/nomt/src/bitbox/wal/mod.rs
+++ b/nomt/src/bitbox/wal/mod.rs
@@ -42,14 +42,14 @@ pub struct WalBlobBuilder {
 
 impl WalBlobBuilder {
     pub fn new() -> Self {
-        // 128 GiB / 4 KiB = 33554432.
+        // 128 GiB = 17179869184 bytes. 
         //
         // 128 GiB is the maximum size of a single commit in WAL after which we panic. This seems
         // to be enough for now. We should explore making this elastic in the future.
         //
         // Note that here we allocate virtual memory unbacked by physical pages. Those pages will
         // become backed by physical pages on first write to each page.
-        let mmap = Mmap::new(33554432);
+        let mmap = Mmap::new(17179869184);
         Self {
             mmap: Arc::new(mmap),
             cur: 0,

--- a/nomt/src/store/writeout.rs
+++ b/nomt/src/store/writeout.rs
@@ -551,6 +551,7 @@ impl HtWriteOut {
                 {
                     // That's alright. We will retry after trying to get something out of the cqueue
                     io.recv_ht_write();
+                    self.ht_remaining = self.ht_remaining.checked_sub(1).unwrap();
                     self.ht.push((pn, page));
                 }
             }


### PR DESCRIPTION
1. Fixes the size of backing mmap. It was passing pages but accepting
   bytes.
2. Decreases `ht_remaining` after waiting for a completion in
   `send_writes`.