### PR TITLE
opt: use aligned page in page cache and avoid some copies

### DIFF
--- a/nomt/src/seek.rs
+++ b/nomt/src/seek.rs
@@ -1,6 +1,7 @@
 //! Multiplexer for page requests.
 
 use crate::{
+    io::Page as AlignedPage,
     page_cache::{Page, PageCache, ShardIndex},
     rw_pass_cell::ReadPass,
     store::{BucketIndex, PageLoad, PageLoadAdvance, PageLoadCompletion, PageLoader},
@@ -455,7 +456,7 @@ impl Seeker {
         &mut self,
         read_pass: &ReadPass<ShardIndex>,
         slab_index: usize,
-        page_data: Option<(Vec<u8>, BucketIndex)>,
+        page_data: Option<(Box<AlignedPage>, BucketIndex)>,
     ) {
         let page_load = self.page_load_slab.remove(slab_index);
         let page = self


### PR DESCRIPTION
By switching page loads from `Vec<u8>` to aligned pages, I've eliminated all but one copy during page cache commit and hash table writes. This last copy can be elided by having writeout draw directly from the page cache, but that's a large piece of work that will require some discussion before diving into. 
