### PR TITLE
opt: use Select to avoid busy-looping in warm up

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -292,6 +292,11 @@ impl PageLoader {
             Err(_) => anyhow::bail!("I/O pool hangup"),
         }
     }
+
+    /// Get the underlying I/O handle.
+    pub fn io_handle(&self) -> &IoHandle {
+        &self.io_handle
+    }
 }
 
 /// Represents the completion of a page load.

--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -173,4 +173,9 @@ impl IoHandle {
     pub fn try_recv(&self) -> Result<CompleteIo, TryRecvError> {
         self.completion_receiver.try_recv()
     }
+
+    /// Get the underlying receiver.
+    pub fn receiver(&self) -> &Receiver<CompleteIo> {
+        &self.completion_receiver
+    }
 }

--- a/nomt/src/store/page_loader.rs
+++ b/nomt/src/store/page_loader.rs
@@ -59,4 +59,9 @@ impl PageLoader {
     pub fn complete(&self) -> anyhow::Result<PageLoadCompletion> {
         self.inner.complete()
     }
+
+    /// Get the underlying I/O handle.
+    pub fn io_handle(&self) -> &crate::io::IoHandle {
+        self.inner.io_handle()
+    }
 }


### PR DESCRIPTION
I had noticed that, due to the way `Seek` was written, warmup workers tended to use a full core.

This breaks up `Seeker::advance` into its constituent parts and has warm-up workers use a `Select` to avoid wasting CPU. I observed this using a lot less CPU now (20% in benchtop vs 100%)

Note that we do pay a cost here, though the effect wasn't measurably worse from what I saw. The cost is that sending warm-ups to the worker now has to wake up the thread, adding some overhead to reads and writes. 
