### PR TITLE
opt: avoid hashmap in page walker page diffs

### DIFF
--- a/nomt/src/commit/mod.rs
+++ b/nomt/src/commit/mod.rs
@@ -11,7 +11,6 @@ use nomt_core::{
     trie_pos::TriePosition,
 };
 
-use std::collections::HashMap;
 use std::sync::{Arc, Barrier};
 
 use threadpool::ThreadPool;
@@ -302,7 +301,7 @@ pub struct Output {
     /// The new root.
     pub root: Node,
     /// All page-diffs from all worker threads. The covered sets of pages are disjoint.
-    pub page_diffs: Vec<HashMap<PageId, PageDiff>>,
+    pub page_diffs: Vec<Vec<(PageId, PageDiff)>>,
     /// Optional witness
     pub witness: Option<Witness>,
     /// Optional list of all witnessed operations.
@@ -337,7 +336,7 @@ enum RootPagePending {
 struct WorkerOutput {
     root: Option<Node>,
     witnessed_paths: Option<Vec<(WitnessedPath, Option<trie::LeafData>, usize)>>,
-    page_diffs: HashMap<PageId, PageDiff>,
+    page_diffs: Vec<(PageId, PageDiff)>,
 }
 
 impl WorkerOutput {
@@ -345,7 +344,7 @@ impl WorkerOutput {
         WorkerOutput {
             root: None,
             witnessed_paths: if witness { Some(Vec::new()) } else { None },
-            page_diffs: HashMap::new(),
+            page_diffs: Vec::new(),
         }
     }
 }

--- a/nomt/src/commit/worker.rs
+++ b/nomt/src/commit/worker.rs
@@ -215,10 +215,7 @@ fn commit<H: NodeHasher>(
     loop {
         let page = match root_page_committer.conclude(&mut write_pass) {
             Ok(Output::Root(new_root, diffs)) => {
-                for (page_id, page_diff) in diffs {
-                    output.page_diffs.insert(page_id, page_diff);
-                }
-
+                output.page_diffs.extend(diffs);
                 output.root = Some(new_root);
                 break;
             }
@@ -538,7 +535,7 @@ impl<H: NodeHasher> RangeCommitter<H> {
                 }
             };
 
-            assert!(!diffs.contains_key(&ROOT_PAGE_ID));
+            assert!(!diffs.iter().any(|item| item.0 == ROOT_PAGE_ID));
             output.page_diffs = diffs;
 
             self.shared.push_pending_root_nodes(new_nodes);

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -209,7 +209,7 @@ impl fmt::Debug for Page {
 /// leaf data for a leaf at `trie_pos` should be stored.
 pub fn locate_leaf_data<E>(
     trie_pos: &TriePosition,
-    current_page: Option<&(PageId, Page)>,
+    current_page: Option<(&PageId, &Page)>,
     load: impl Fn(PageId) -> Result<Page, E>,
 ) -> Result<(Page, PageId, ChildNodeIndices), E> {
     Ok(match current_page {
@@ -218,7 +218,7 @@ pub fn locate_leaf_data<E>(
             let page = load(ROOT_PAGE_ID)?;
             (page, ROOT_PAGE_ID, ChildNodeIndices::from_left(0))
         }
-        Some((ref page_id, ref page)) => {
+        Some((page_id, page)) => {
             let depth_in_page = trie_pos.depth_in_page();
             if depth_in_page == DEPTH {
                 let child_page_id = page_id.child_page_id(trie_pos.child_page_index()).unwrap();


### PR DESCRIPTION
This doesn't currently show up in profiles in overall performance, since so much time is wasted in the seeker, but anecdotally this caused PageWalker::advance_and_replace to now 21% of its time hashing, instead of the previous 7.5%.
