### PR TITLE
chore: fix check-cfg warnings

### DIFF
--- a/core/src/multi_proof.rs
+++ b/core/src/multi_proof.rs
@@ -7,7 +7,7 @@ use crate::{
     trie::Node,
 };
 
-#[cfg(not(features = "std"))]
+#[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 
 /// This struct includes the terminal node and its depth

--- a/core/src/multi_proof_verification.rs
+++ b/core/src/multi_proof_verification.rs
@@ -6,7 +6,7 @@ use crate::{
 use bitvec::prelude::*;
 use core::cmp::Ordering;
 
-#[cfg(not(features = "std"))]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 /// Errors in multi-proof verification.

--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -6,7 +6,7 @@ use crate::trie::{
 
 use bitvec::prelude::*;
 
-#[cfg(not(features = "std"))]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 /// Wrapper for a terminal node, it will store the LeafData if it is a leaf node,

--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -4,7 +4,7 @@ use crate::trie::{self, KeyPath, LeafData, Node, NodeHasher, NodeHasherExt, Valu
 
 use bitvec::prelude::*;
 
-#[cfg(not(features = "std"))]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 // TODO: feels extremely out of place.

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -38,3 +38,6 @@ loom = { version = "0.7", features = ["checkpoint"] }
 [dev-dependencies]
 rand_pcg = "0.3.1"
 hex-literal = "0.4"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }


### PR DESCRIPTION
Fix typo `features` to `feature` in `cfg` predicates. Also whitelist the
`cfg(loom)`.

See also:

https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html
https://doc.rust-lang.org/nightly/rustc/check-cfg.html