### PR TITLE
feat: panic on sync.

### DIFF
--- a/nomt/src/options.rs
+++ b/nomt/src/options.rs
@@ -11,6 +11,7 @@ pub struct Options {
     /// Enable or disable metrics collection.
     pub(crate) metrics: bool,
     pub(crate) bitbox_num_pages: u32,
+    pub(crate) panic_on_sync: bool,
 }
 
 impl Default for Options {
@@ -21,6 +22,7 @@ impl Default for Options {
             io_workers: 3,
             metrics: false,
             bitbox_num_pages: 64_000,
+            panic_on_sync: false,
         }
     }
 }
@@ -63,5 +65,13 @@ impl Options {
     /// Set the number of hashtable buckets to use when creating the database.
     pub fn hashtable_buckets(&mut self, hashtable_buckets: u32) {
         self.bitbox_num_pages = hashtable_buckets;
+    }
+
+    /// Set to `true` to panic on sync after writing the WAL file and updating the manifest, but
+    /// before the data has been written to the HT file.
+    /// 
+    /// Useful to test WAL recovery.
+    pub fn panic_on_sync(&mut self, panic_on_sync: bool) {
+        self.panic_on_sync = panic_on_sync;
     }
 }

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -35,6 +35,7 @@ pub struct Store {
 struct Shared {
     bitbox_num_pages: u32,
     bitbox_seed: [u8; 16],
+    panic_on_sync: bool,
     values: beatree::Tree,
     pages: bitbox::DB,
     io_pool: IoPool,
@@ -115,6 +116,7 @@ impl Store {
             shared: Arc::new(Shared {
                 bitbox_num_pages: meta.bitbox_num_pages,
                 bitbox_seed: meta.bitbox_seed,
+                panic_on_sync: o.panic_on_sync,
                 values,
                 pages,
                 meta_fd,
@@ -222,6 +224,7 @@ impl Store {
             beatree_writeout_data.ln_extend_file_sz,
             bitbox_writeout_data.ht_pages,
             new_meta,
+            self.shared.panic_on_sync,
         );
 
         self.shared.values.finish_sync(

--- a/nomt/src/store/writeout.rs
+++ b/nomt/src/store/writeout.rs
@@ -28,6 +28,7 @@ pub fn run(
     ln_extend_file_sz: Option<u64>,
     ht: Vec<(u64, Box<Page>)>,
     new_meta: Meta,
+    panic_on_sync: bool,
 ) {
     let io = IoDmux::new(io_handle);
     do_run(
@@ -56,6 +57,7 @@ pub fn run(
                 new_meta: Some(new_meta),
                 should_fsync: false,
             }),
+            panic_on_sync,
         },
         io,
     );
@@ -102,6 +104,10 @@ fn do_run(mut cx: Cx, mut io: IoDmux) {
                 break;
             }
         }
+    }
+
+    if cx.panic_on_sync {
+        panic!("panic_on_sync triggered");
     }
 
     // Dump the metabits and bucket pages.
@@ -310,6 +316,7 @@ struct Cx {
     ln_write_out: LnWriteOut,
     ht_write_out: HtWriteOut,
     meta_swap: Option<MetaSwap>,
+    panic_on_sync: bool,
 }
 
 struct WalWriteOut {


### PR DESCRIPTION
introduce an option to panic in the middle of a sync: after updating the
manifest but before writing out the bucket and meta pages.