### PR TITLE
chore: refactor WAL/PageDiff

### DIFF
--- a/nomt/src/commit/mod.rs
+++ b/nomt/src/commit/mod.rs
@@ -13,14 +13,14 @@ use nomt_core::{
 
 use std::sync::{Arc, Barrier};
 
-use threadpool::ThreadPool;
-
 use crate::{
-    page_cache::{PageCache, PageDiff, ShardIndex},
+    page_cache::{PageCache, ShardIndex},
+    page_diff::PageDiff,
     rw_pass_cell::WritePassEnvelope,
     store::Store,
     Witness, WitnessedOperations, WitnessedPath, WitnessedRead, WitnessedWrite,
 };
+use threadpool::ThreadPool;
 
 mod worker;
 

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -38,6 +38,7 @@ mod commit;
 mod metrics;
 mod options;
 mod page_cache;
+mod page_diff;
 mod page_region;
 mod page_walker;
 mod rw_pass_cell;

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -2,12 +2,12 @@ use crate::{
     bitbox::BucketIndex,
     io,
     metrics::{Metric, Metrics},
+    page_diff::PageDiff,
     page_region::PageRegion,
     rw_pass_cell::{ReadPass, Region, RegionContains, RwPassCell, RwPassDomain, WritePass},
     store::Transaction,
     Options,
 };
-use bitvec::prelude::*;
 use fxhash::FxBuildHasher;
 use lru::LruCache;
 use nomt_core::{
@@ -122,32 +122,6 @@ pub fn page_is_empty(page: &[u8]) -> bool {
     // 2. if both are empty, then the whole page is empty. this is because internal nodes
     //    with both children as terminals are not allowed to exist.
     &page[..64] == [0u8; 64].as_slice()
-}
-
-/// Tracks which nodes have changed within a page.
-#[derive(Debug, Default, Clone)]
-pub struct PageDiff {
-    /// A bitfield indicating the number of updated slots
-    updated_slots: BitArray<[u8; 16], Lsb0>,
-}
-
-impl PageDiff {
-    /// Note that some 32-byte slot in the page data has changed.
-    /// The acceptable range is 0..NODES_PER_PAGE
-    pub fn set_changed(&mut self, slot_index: usize) {
-        assert!(slot_index < NODES_PER_PAGE);
-        self.updated_slots.set(slot_index, true);
-    }
-
-    /// Get a vector containing the indexes of all changed nodes
-    pub fn get_changed(&self) -> Vec<usize> {
-        self.updated_slots.iter_ones().collect()
-    }
-
-    /// Get raw bytes representing the PageDiff
-    pub fn get_raw(&self) -> [u8; 16] {
-        self.updated_slots.data
-    }
 }
 
 /// A handle to the page.

--- a/nomt/src/page_diff.rs
+++ b/nomt/src/page_diff.rs
@@ -1,0 +1,72 @@
+use crate::{io, page_cache::NODES_PER_PAGE};
+use bitvec::prelude::*;
+
+/// A bitfield tracking which nodes have changed within a page.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PageDiff {
+    /// Each bit indicates whether the node at the corresponding index has changed.
+    /// Later bits are unused.
+    changed_nodes: BitArray<[u8; 16], Lsb0>,
+}
+
+impl PageDiff {
+    /// Create a new page diff from bytes.
+    ///
+    /// Returns `None` if any of unused bits are set to 1.
+    pub fn from_bytes(bytes: [u8; 16]) -> Option<Self> {
+        let changed_nodes = BitArray::<[u8; 16], Lsb0>::new(bytes);
+        // Check if the two last bits are set to 1
+        assert!(changed_nodes.len() == 128);
+        if changed_nodes[126] || changed_nodes[127] {
+            return None;
+        }
+        Some(Self { changed_nodes })
+    }
+
+    /// Note that some 32-byte slot in the page data has changed.
+    /// The acceptable range is 0..NODES_PER_PAGE
+    pub fn set_changed(&mut self, slot_index: usize) {
+        assert!(slot_index < NODES_PER_PAGE);
+        self.changed_nodes.set(slot_index, true);
+    }
+
+    /// Given the page data, collect the nodes that have changed according to this diff.
+    pub fn pack_changed_nodes<'a, 'b: 'a>(
+        &'b self,
+        page: &'a io::Page,
+    ) -> impl Iterator<Item = [u8; 32]> + 'a {
+        self.changed_nodes.iter_ones().map(|node_index| {
+            let start = node_index * 32;
+            let end = start + 32;
+            page[start..end].try_into().unwrap()
+        })
+    }
+
+    /// Given the changed nodes, apply them to the given page according to the diff.
+    ///
+    /// Panics if the number of changed nodes doesn't equal to the number of nodes
+    /// this diff recorded.
+    pub fn unpack_changed_nodes(&self, nodes: &[[u8; 32]], page: &mut io::Page) {
+        assert!(self.changed_nodes.count_ones() == nodes.len());
+        for (node_index, node) in self.changed_nodes.iter_ones().zip(nodes) {
+            let start = node_index * 32;
+            let end = start + 32;
+            page[start..end].copy_from_slice(&node[..]);
+        }
+    }
+
+    /// Returns the number of changed nodes. Capped at [NODES_PER_PAGE].
+    pub fn count(&self) -> usize {
+        self.changed_nodes.count_ones()
+    }
+
+    /// Get raw bytes representing the PageDiff
+    pub fn as_bytes(&self) -> [u8; 16] {
+        self.changed_nodes.data
+    }
+}
+
+#[test]
+fn ensure_cap() {
+    assert_eq!(NODES_PER_PAGE, 126);
+}

--- a/nomt/src/page_walker.rs
+++ b/nomt/src/page_walker.rs
@@ -51,7 +51,8 @@ use nomt_core::{
 };
 
 use crate::{
-    page_cache::{Page, PageCache, PageDiff, ShardIndex},
+    page_cache::{Page, PageCache, ShardIndex},
+    page_diff::PageDiff,
     rw_pass_cell::{ReadPass, RegionContains, WritePass},
 };
 

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -3,7 +3,7 @@
 use crate::{
     beatree, bitbox,
     io::{self, IoPool, Page},
-    page_cache::PageDiff,
+    page_diff::PageDiff,
 };
 use meta::Meta;
 use nomt_core::{page_id::PageId, trie::KeyPath};


### PR DESCRIPTION
This consolidates logic of packing and unpacking of the changed nodes
according to a diff. Incidentally, this ensures that we don't overwrite
the page ID in case of a skewed page diff.

It looked like PageDiff got sufficiently independent from PageCache so
it was promoted to have its own module.