### PR TITLE
opt: have commit draw from warm-ups instead of seeking again

### DIFF
--- a/nomt/src/seek.rs
+++ b/nomt/src/seek.rs
@@ -207,6 +207,10 @@ impl Seeker {
         self.page_loads.len() < MAX_INFLIGHT
     }
 
+    pub fn first_key(&self) -> Option<&KeyPath> {
+        self.requests.front().map(|request| &request.key)
+    }
+
     /// Try to submit as many requests as possible. Returns `true` if blocked.
     pub fn submit_all(&mut self, read_pass: &ReadPass<ShardIndex>) -> anyhow::Result<bool> {
         let blocked = self.submit_idle_page_loads(read_pass)?


### PR DESCRIPTION
Rather than "re-seeking" key-paths which were already warmed up, we now account for these.

This brought commit times down by about 30% in the case that all key paths were warmed up already.
