### PR TITLE
opt: use TriePosition in witness rather than bitvec

### DIFF
--- a/core/src/multi_proof.rs
+++ b/core/src/multi_proof.rs
@@ -242,8 +242,10 @@ impl MultiProof {
 mod tests {
     use super::MultiProof;
 
-    use crate::proof::{PathProof, PathProofTerminal};
-    use bitvec::{order::Msb0, view::BitView};
+    use crate::{
+        proof::{PathProof, PathProofTerminal},
+        trie_pos::TriePosition,
+    };
 
     #[test]
     pub fn test_multiproof_creation_single_path_proof() {
@@ -252,7 +254,7 @@ mod tests {
         let sibling1 = [1; 32];
         let sibling2 = [2; 32];
         let path_proof = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path, 256)),
             siblings: vec![sibling1, sibling2],
         };
 
@@ -260,7 +262,7 @@ mod tests {
         assert_eq!(multi_proof.paths.len(), 1);
         assert_eq!(
             multi_proof.paths[0].terminal,
-            PathProofTerminal::Terminator(key_path.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path, 256))
         );
         assert_eq!(multi_proof.paths[0].depth, 2);
         assert_eq!(multi_proof.siblings.len(), 2);
@@ -285,11 +287,11 @@ mod tests {
         let sibling_x = [b'x'; 32];
 
         let path_proof_1 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_1.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_1, 256)),
             siblings: vec![sibling1, sibling2, sibling_x, sibling3, sibling4],
         };
         let path_proof_2 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_2.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_2, 256)),
             siblings: vec![sibling1, sibling2, sibling_x, sibling5, sibling6],
         };
 
@@ -300,11 +302,11 @@ mod tests {
 
         assert_eq!(
             multi_proof.paths[0].terminal,
-            PathProofTerminal::Terminator(key_path_1.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_1, 256))
         );
         assert_eq!(
             multi_proof.paths[1].terminal,
-            PathProofTerminal::Terminator(key_path_2.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_2, 256))
         );
 
         assert_eq!(multi_proof.paths[0].depth, 5);
@@ -330,11 +332,11 @@ mod tests {
         siblings_2.push([b'1'; 32]);
 
         let path_proof_1 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_1.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_1, 256)),
             siblings: siblings_1.clone(),
         };
         let path_proof_2 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_2.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_2, 256)),
             siblings: siblings_2,
         };
 
@@ -345,11 +347,11 @@ mod tests {
 
         assert_eq!(
             multi_proof.paths[0].terminal,
-            PathProofTerminal::Terminator(key_path_1.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_1, 256))
         );
         assert_eq!(
             multi_proof.paths[1].terminal,
-            PathProofTerminal::Terminator(key_path_2.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_2, 256))
         );
 
         assert_eq!(multi_proof.paths[0].depth, 256);
@@ -400,36 +402,36 @@ mod tests {
         let sibling19 = [19; 32];
 
         let path_proof_1 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_1.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_1, 256)),
             siblings: vec![sibling1, sibling2],
         };
 
         let path_proof_2 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_2.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_2, 256)),
             siblings: vec![sibling1, sibling3, sibling4, sibling5, sibling6, sibling7],
         };
 
         let path_proof_3 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_3.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_3, 256)),
             siblings: vec![sibling1, sibling3, sibling4, sibling5, sibling8, sibling9],
         };
 
         let path_proof_4 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_4.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_4, 256)),
             siblings: vec![
                 sibling10, sibling11, sibling12, sibling13, sibling14, sibling15,
             ],
         };
 
         let path_proof_5 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_5.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_5, 256)),
             siblings: vec![
                 sibling10, sibling11, sibling12, sibling16, sibling17, sibling18,
             ],
         };
 
         let path_proof_6 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_6.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_6, 256)),
             siblings: vec![sibling10, sibling11, sibling12, sibling16, sibling19],
         };
 
@@ -447,27 +449,27 @@ mod tests {
 
         assert_eq!(
             multi_proof.paths[0].terminal,
-            PathProofTerminal::Terminator(key_path_1.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_1, 256))
         );
         assert_eq!(
             multi_proof.paths[1].terminal,
-            PathProofTerminal::Terminator(key_path_2.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_2, 256))
         );
         assert_eq!(
             multi_proof.paths[2].terminal,
-            PathProofTerminal::Terminator(key_path_3.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_3, 256))
         );
         assert_eq!(
             multi_proof.paths[3].terminal,
-            PathProofTerminal::Terminator(key_path_4.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_4, 256))
         );
         assert_eq!(
             multi_proof.paths[4].terminal,
-            PathProofTerminal::Terminator(key_path_5.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_5, 256))
         );
         assert_eq!(
             multi_proof.paths[5].terminal,
-            PathProofTerminal::Terminator(key_path_6.view_bits::<Msb0>().into())
+            PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_6, 256))
         );
 
         assert_eq!(multi_proof.paths[0].depth, 2);
@@ -532,24 +534,24 @@ mod tests {
         let sibling24 = [24; 32];
 
         let path_proof_0 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_0.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_0, 256)),
             siblings: vec![sibling1, sibling2, sibling3, sibling4, sibling5],
         };
 
         let path_proof_1 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_1.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_1, 256)),
             siblings: vec![sibling1, sibling2, sibling3, sibling6, sibling7],
         };
 
         let path_proof_2 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_2.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_2, 256)),
             siblings: vec![
                 sibling8, sibling9, sibling10, sibling11, sibling12, sibling13, sibling14,
                 sibling15,
             ],
         };
         let path_proof_3 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_3.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_3, 256)),
             siblings: vec![
                 sibling8, sibling9, sibling10, sibling11, sibling12, sibling13, sibling16,
                 sibling17,
@@ -557,7 +559,7 @@ mod tests {
         };
 
         let path_proof_4 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_4.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_4, 256)),
             siblings: vec![
                 sibling8, sibling9, sibling10, sibling18, sibling19, sibling20, sibling21,
                 sibling22,
@@ -565,7 +567,7 @@ mod tests {
         };
 
         let path_proof_5 = PathProof {
-            terminal: PathProofTerminal::Terminator(key_path_5.view_bits::<Msb0>().into()),
+            terminal: PathProofTerminal::Terminator(TriePosition::from_path_and_depth(key_path_5, 256)),
             siblings: vec![
                 sibling8, sibling9, sibling10, sibling18, sibling19, sibling20, sibling23,
                 sibling24,

--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -3,6 +3,7 @@
 use crate::trie::{
     self, InternalData, KeyPath, LeafData, Node, NodeHasher, NodeHasherExt, NodeKind, TERMINATOR,
 };
+use crate::trie_pos::TriePosition;
 
 use bitvec::prelude::*;
 
@@ -14,7 +15,7 @@ use alloc::vec::Vec;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PathProofTerminal {
     Leaf(LeafData),
-    Terminator(BitVec<u8, Msb0>),
+    Terminator(TriePosition),
 }
 
 impl PathProofTerminal {
@@ -22,7 +23,7 @@ impl PathProofTerminal {
     pub fn path(&self) -> &BitSlice<u8, Msb0> {
         match self {
             Self::Leaf(leaf_data) => &leaf_data.key_path.view_bits(),
-            Self::Terminator(key_path) => key_path,
+            Self::Terminator(key_path) => key_path.path(),
         }
     }
 

--- a/examples/witness_verification/src/main.rs
+++ b/examples/witness_verification/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
         // Constructing the verified operations
         let verified = witnessed_path
             .inner
-            .verify::<Blake3Hasher>(&witnessed_path.path, prev_root)
+            .verify::<Blake3Hasher>(&witnessed_path.path.path(), prev_root)
             .unwrap();
 
         // Among all read operations performed the ones that interact

--- a/nomt/src/commit/worker.rs
+++ b/nomt/src/commit/worker.rs
@@ -376,11 +376,11 @@ impl<H: NodeHasher> RangeCommitter<H> {
                         terminal: match seek_result.terminal.clone() {
                             Some(leaf_data) => PathProofTerminal::Leaf(leaf_data),
                             None => PathProofTerminal::Terminator(
-                                seek_result.position.path().to_bitvec(),
+                                seek_result.position.clone(),
                             ),
                         },
                     },
-                    path: seek_result.position.path().to_bitvec(),
+                    path: seek_result.position,
                 };
                 witnessed_paths.push((path, seek_result.terminal, batch_size));
             }
@@ -451,11 +451,11 @@ impl<H: NodeHasher> RangeCommitter<H> {
                     terminal: match seek_result.terminal.clone() {
                         Some(leaf_data) => PathProofTerminal::Leaf(leaf_data),
                         None => {
-                            PathProofTerminal::Terminator(seek_result.position.path().to_bitvec())
+                            PathProofTerminal::Terminator(seek_result.position.clone())
                         }
                     },
                 },
-                path: seek_result.position.path().to_bitvec(),
+                path: seek_result.position,
             };
             witnessed_paths.push((path, seek_result.terminal, batch_size));
         }

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -15,6 +15,7 @@ use nomt_core::{
     page_id::ROOT_PAGE_ID,
     proof::PathProof,
     trie::{InternalData, NodeHasher, NodeHasherExt, ValueHash, TERMINATOR},
+    trie_pos::TriePosition,
 };
 use page_cache::PageCache;
 use parking_lot::Mutex;
@@ -79,7 +80,7 @@ pub struct WitnessedPath {
     /// Proof of a query path along the trie.
     pub inner: PathProof,
     /// The query path itself.
-    pub path: BitVec<u8, Msb0>,
+    pub path: TriePosition,
 }
 
 /// A witness of a read value.

--- a/nomt/tests/witness_check.rs
+++ b/nomt/tests/witness_check.rs
@@ -47,7 +47,7 @@ fn produced_witness_validity() {
     for (i, witnessed_path) in witness.path_proofs.iter().enumerate() {
         let verified = witnessed_path
             .inner
-            .verify::<Blake3Hasher>(&witnessed_path.path, prev_root)
+            .verify::<Blake3Hasher>(&witnessed_path.path.path(), prev_root)
             .unwrap();
         for read in witnessed
             .reads


### PR DESCRIPTION
also updates triepos to use a u16
