### PR TITLE
fix: simplify writeout to block on send / recv

### DIFF
--- a/nomt/src/commit/worker.rs
+++ b/nomt/src/commit/worker.rs
@@ -485,12 +485,13 @@ impl<H: NodeHasher> RangeCommitter<H> {
 
         // 1. drive until work is done.
         while start_index < self.range_end || !seeker.is_empty() {
-            let completion = if self.saved_advance.is_none() && warmed_up.front()
-                .map_or(false, |res| match seeker.first_key() {
-                    None => true,
-                    Some(k) => &res.key < k,
-                })
-            {
+            let completion = if self.saved_advance.is_none()
+                && warmed_up
+                    .front()
+                    .map_or(false, |res| match seeker.first_key() {
+                        None => true,
+                        Some(k) => &res.key < k,
+                    }) {
                 // take a "completion" from our warm-ups instead.
                 // UNWRAP: checked front exists above.
                 Some(Completion::Seek(warmed_up.pop_front().unwrap()))

--- a/nomt/src/options.rs
+++ b/nomt/src/options.rs
@@ -68,7 +68,7 @@ impl Options {
     }
 
     /// Set the seed for the hash function used by the bitbox store.
-    /// 
+    ///
     /// Useful for reproducibility.
     pub fn bitbox_seed(&mut self, bitbox_seed: [u8; 16]) {
         self.bitbox_seed = bitbox_seed;
@@ -76,7 +76,7 @@ impl Options {
 
     /// Set to `true` to panic on sync after writing the WAL file and updating the manifest, but
     /// before the data has been written to the HT file.
-    /// 
+    ///
     /// Useful to test WAL recovery.
     pub fn panic_on_sync(&mut self, panic_on_sync: bool) {
         self.panic_on_sync = panic_on_sync;


### PR DESCRIPTION
The code here had some issues with busy-looping on `try_send` and `try_recv`.

This actually caused livelocks, since we were calling `try_recv_*` when we failed to submit a write. The sequence of events would be this:
  1. There would be no writes for e.g. the LN pending in the system but the I/O queue would be full.
  2. We'd fail to submit the next LN write.
  3. We'd then busy-loop on the next LN completion, which would never come because of (1).
   
It doesn't seem necessary to do this as a state machine per se. I might imagine that the inboxes could get pretty full, but we don't actually use the results and could easily just track the number of received items.
