### PR TITLE
feat: avoid OS page cache on macOS

### DIFF
--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -98,6 +98,16 @@ impl Store {
             options.custom_flags(libc::O_DIRECT);
             options.open(&o.path.join("wal"))?
         };
+
+        #[cfg(target_os = "macos")]
+        unsafe {
+            libc::fcntl(meta_fd.as_raw_fd(), libc::F_NOCACHE, 1);
+            libc::fcntl(ln_fd.as_raw_fd(), libc::F_NOCACHE, 1);
+            libc::fcntl(bbn_fd.as_raw_fd(), libc::F_NOCACHE, 1);
+            libc::fcntl(ht_fd.as_raw_fd(), libc::F_NOCACHE, 1);
+            libc::fcntl(wal_fd.as_raw_fd(), libc::F_NOCACHE, 1);
+        }
+
         let meta = meta::Meta::read(&meta_fd)?;
         let values = beatree::Tree::open(
             &io_pool,


### PR DESCRIPTION
This adds `F_NOCACHE` to all the FDs on mac.

It's not clear whether this is a good idea as it doesn't seem to actually be more performant. But it'll give us more consistency with any app-level caching we implement cross-platform.
