### PR TITLE
feat: new branch node encoding

### DIFF
--- a/nomt/src/beatree/branch/mod.rs
+++ b/nomt/src/beatree/branch/mod.rs
@@ -154,7 +154,7 @@ fn test_branch_node_pool() {
     let pool = BranchNodePool::new();
     let id = pool.allocate();
     let mut node = pool.checkout(id).unwrap();
-    node.set_separator_len(10);
+    node.set_n(10);
 }
 
 #[test]

--- a/nomt/src/beatree/ops/mod.rs
+++ b/nomt/src/beatree/ops/mod.rs
@@ -69,8 +69,7 @@ fn search_branch(branch: &branch::BranchNode, key: Key) -> Option<(usize, PageNu
         }
     }
 
-    let total_separator_len = prefix.len() + branch.separator_len() as usize;
-    let post_key = &key.view_bits::<Msb0>()[prefix.len()..total_separator_len];
+    let post_key = &key.view_bits::<Msb0>()[prefix.len()..];
 
     let mut low = 0;
     let mut high = branch.n() as usize;


### PR DESCRIPTION
stop using a common prefix_len and instead use a vector of cells
to store different prefix_len values, one for each separator