### PR TITLE
refactor: better naming for allocator open fn

### DIFF
--- a/nomt/src/beatree/allocator/mod.rs
+++ b/nomt/src/beatree/allocator/mod.rs
@@ -100,8 +100,8 @@ impl AllocatorReader {
 }
 
 impl AllocatorWriter {
-    /// creates an AllocatorWriter over a possibly already existing File.
-    pub fn new(
+    /// creates an AllocatorWriter over an already existing File.
+    pub fn open(
         fd: File,
         free_list_head: Option<PageNumber>,
         bump: PageNumber,

--- a/nomt/src/beatree/bbn.rs
+++ b/nomt/src/beatree/bbn.rs
@@ -15,15 +15,15 @@ pub struct BbnStoreWriter {
     pending: Vec<BranchNode>,
 }
 
-/// Initializes a BbnStoreWriter over a possibly already existing File and returns all pages tracked
+/// Initializes a BbnStoreWriter over an already existing File and returns all pages tracked
 /// by the freelist (free + used by the list itself) to inform reconstruction.
-pub fn create(
+pub fn open(
     fd: File,
     free_list_head: Option<PageNumber>,
     bump: PageNumber,
     io_pool: &IoPool,
 ) -> (BbnStoreWriter, BTreeSet<PageNumber>) {
-    let allocator_writer = AllocatorWriter::new(fd, free_list_head, bump, io_pool.make_handle());
+    let allocator_writer = AllocatorWriter::open(fd, free_list_head, bump, io_pool.make_handle());
     let freelist = allocator_writer.free_list().all_tracked_pages();
 
     (

--- a/nomt/src/beatree/leaf/store.rs
+++ b/nomt/src/beatree/leaf/store.rs
@@ -20,8 +20,8 @@ pub struct LeafStoreWriter {
     pending: Vec<(PageNumber, Box<Page>)>,
 }
 
-/// creates a pair of LeafStoreReader and LeafStoreWriter over a possibly already existing File.
-pub fn create(
+/// creates a pair of LeafStoreReader and LeafStoreWriter over an already existing File.
+pub fn open(
     fd: File,
     free_list_head: Option<PageNumber>,
     bump: PageNumber,
@@ -37,7 +37,7 @@ pub fn create(
         io_pool.make_handle(),
     );
 
-    let allocator_writer = AllocatorWriter::new(fd, free_list_head, bump, io_pool.make_handle());
+    let allocator_writer = AllocatorWriter::open(fd, free_list_head, bump, io_pool.make_handle());
 
     (
         LeafStoreReader {

--- a/nomt/src/beatree/mod.rs
+++ b/nomt/src/beatree/mod.rs
@@ -87,12 +87,12 @@ impl Tree {
         let (leaf_store_rd_shared, leaf_store_rd_sync, leaf_store_wr) = {
             let ln_file = ln_file.try_clone().unwrap();
 
-            leaf::store::create(ln_file, ln_freelist_pn, ln_bump, &io_pool)
+            leaf::store::open(ln_file, ln_freelist_pn, ln_bump, &io_pool)
         };
 
         let (bbn_store_wr, bbn_freelist_tracked) = {
             let bbn_fd = bbn_file.try_clone().unwrap();
-            bbn::create(bbn_fd, bbn_freelist_pn, bbn_bump, &io_pool)
+            bbn::open(bbn_fd, bbn_freelist_pn, bbn_bump, &io_pool)
         };
         let mut bnp = branch::BranchNodePool::new();
         let index = ops::reconstruct(


### PR DESCRIPTION
this better reflects that it operates over an already opened file. `create` comes across as if this function participates in the creation of the database where in fact it actually doesn't.