### PR TITLE
refactor: introduce io::read_page

### DIFF
--- a/nomt/src/beatree/bbn.rs
+++ b/nomt/src/beatree/bbn.rs
@@ -1,4 +1,4 @@
-use crate::io::{IoPool, Page};
+use crate::io::Page;
 
 use std::{collections::BTreeSet, fs::File};
 
@@ -21,9 +21,9 @@ pub fn open(
     fd: File,
     free_list_head: Option<PageNumber>,
     bump: PageNumber,
-    io_pool: &IoPool,
+    
 ) -> (BbnStoreWriter, BTreeSet<PageNumber>) {
-    let allocator_writer = AllocatorWriter::open(fd, free_list_head, bump, io_pool.make_handle());
+    let allocator_writer = AllocatorWriter::open(fd, free_list_head, bump);
     let freelist = allocator_writer.free_list().all_tracked_pages();
 
     (

--- a/nomt/src/beatree/leaf/store.rs
+++ b/nomt/src/beatree/leaf/store.rs
@@ -37,7 +37,7 @@ pub fn open(
         io_pool.make_handle(),
     );
 
-    let allocator_writer = AllocatorWriter::open(fd, free_list_head, bump, io_pool.make_handle());
+    let allocator_writer = AllocatorWriter::open(fd, free_list_head, bump);
 
     (
         LeafStoreReader {

--- a/nomt/src/beatree/mod.rs
+++ b/nomt/src/beatree/mod.rs
@@ -92,7 +92,7 @@ impl Tree {
 
         let (bbn_store_wr, bbn_freelist_tracked) = {
             let bbn_fd = bbn_file.try_clone().unwrap();
-            bbn::open(bbn_fd, bbn_freelist_pn, bbn_bump, &io_pool)
+            bbn::open(bbn_fd, bbn_freelist_pn, bbn_bump)
         };
         let mut bnp = branch::BranchNodePool::new();
         let index = ops::reconstruct(

--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -3,6 +3,7 @@ std::compile_error!("NOMT only supports Unix-based OSs");
 
 use crossbeam_channel::{Receiver, RecvError, SendError, Sender, TryRecvError, TrySendError};
 use std::{
+    fs::File,
     ops::{Deref, DerefMut},
     os::fd::RawFd,
 };
@@ -178,4 +179,12 @@ impl IoHandle {
     pub fn receiver(&self) -> &Receiver<CompleteIo> {
         &self.completion_receiver
     }
+}
+
+/// Read a page from the file at the given page number.
+pub fn read_page(fd: &File, pn: u64) -> std::io::Result<Box<Page>> {
+    use std::os::unix::fs::FileExt as _;
+    let mut page = Box::new(Page::zeroed());
+    fd.read_exact_at(&mut page, pn * PAGE_SIZE as u64)?;
+    Ok(page)
 }

--- a/nomt/src/store/meta.rs
+++ b/nomt/src/store/meta.rs
@@ -1,8 +1,8 @@
 /// The utility functions for handling the metadata file.
 use anyhow::Result;
-use std::{fs::File, io::Read as _};
+use std::fs::File;
 
-use crate::io::Page;
+use crate::io;
 
 /// This data structure describes the state of the btree.
 #[derive(Clone)]
@@ -62,11 +62,9 @@ impl Meta {
         }
     }
 
-    pub fn read(mut fd: &File) -> Result<Self> {
-        // The fd is expected to be opened with O_DIRECT and thus we have to satisfy the alignment
-        // requirements for the buffer. Use a Page for that.
-        let mut buf = Page::zeroed();
-        fd.read_exact(&mut buf)?;
-        Ok(Self::decode(&buf))
+    pub fn read(fd: &File) -> Result<Self> {
+        let page = io::read_page(fd, 0)?;
+        let meta = Meta::decode(&page[..40]);
+        Ok(meta)
     }
 }


### PR DESCRIPTION
This changeset replaces ad-hoc reading files with a single function in
the io module called `read_page`.

The reasoning behind this change is to minimize the number of places
where we create a page. This should make it easier to introduce a common
page creation mechanism later on.