### PR TITLE
refactor: don't merge ln pages for writeout

### DIFF
--- a/nomt/src/beatree/leaf/store.rs
+++ b/nomt/src/beatree/leaf/store.rs
@@ -106,7 +106,8 @@ impl LeafStoreWriter {
         } = self.allocator_writer.commit();
 
         LeafStoreCommitOutput {
-            pages: pending.into_iter().chain(free_list_pages).collect(),
+            pending,
+            free_list_pages,
             bump,
             extend_file_sz,
             freelist_head,
@@ -115,7 +116,8 @@ impl LeafStoreWriter {
 }
 
 pub struct LeafStoreCommitOutput {
-    pub pages: Vec<(PageNumber, Box<Page>)>,
+    pub pending: Vec<(PageNumber, Box<Page>)>,
+    pub free_list_pages: Vec<(PageNumber, Box<Page>)>,
     pub bump: PageNumber,
     pub extend_file_sz: Option<u64>,
     pub freelist_head: PageNumber,

--- a/nomt/src/beatree/mod.rs
+++ b/nomt/src/beatree/mod.rs
@@ -214,14 +214,15 @@ impl Tree {
             .unwrap()
         };
 
-        let (ln, ln_freelist_pn, ln_bump, ln_extend_file_sz) = {
+        let (ln, ln_free_list_pages, ln_freelist_pn, ln_bump, ln_extend_file_sz) = {
             let LeafStoreCommitOutput {
-                pages,
+                pending,
+                free_list_pages,
                 extend_file_sz,
                 freelist_head,
                 bump,
             } = sync.leaf_store_wr.commit();
-            (pages, freelist_head.0, bump.0, extend_file_sz)
+            (pending, free_list_pages, freelist_head.0, bump.0, extend_file_sz)
         };
 
         let (bbn, bbn_freelist_pages, bbn_freelist_pn, bbn_bump, bbn_extend_file_sz) = {
@@ -246,6 +247,7 @@ impl Tree {
             bbn_freelist_pages,
             bbn_extend_file_sz,
             ln,
+            ln_free_list_pages,
             ln_extend_file_sz,
             ln_freelist_pn,
             ln_bump,
@@ -272,6 +274,7 @@ pub struct WriteoutData {
     pub bbn_freelist_pages: Vec<(PageNumber, Box<Page>)>,
     pub bbn_extend_file_sz: Option<u64>,
     pub ln: Vec<(PageNumber, Box<Page>)>,
+    pub ln_free_list_pages: Vec<(PageNumber, Box<Page>)>,
     pub ln_extend_file_sz: Option<u64>,
     pub ln_freelist_pn: u32,
     pub ln_bump: u32,

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -230,6 +230,7 @@ impl Store {
             beatree_writeout_data.bbn_freelist_pages,
             beatree_writeout_data.bbn_extend_file_sz,
             beatree_writeout_data.ln,
+            beatree_writeout_data.ln_free_list_pages,
             beatree_writeout_data.ln_extend_file_sz,
             bitbox_writeout_data.ht_pages,
             new_meta,


### PR DESCRIPTION
this is just for consistency. BBN right now doesn't merge pages[^1] and
I cannot see a good reason for doing this extra work. On the other hand,
for the future page pool implementation it *might* be better to
separate those in case those had different lifetimes.

[^1]: although technically BBNs are not `Page`, but the argument still
holds.