### PR TITLE
refactor: reorganize beatree update modules

### DIFF
--- a/nomt/src/beatree/benches.rs
+++ b/nomt/src/beatree/benches.rs
@@ -3,10 +3,7 @@
 use crate::beatree::{
     branch::node::benches::*,
     leaf::node::benches::*,
-    ops::{
-        benches::*,
-        update::{benches::*, branch::benches::*, leaf::benches::*},
-    },
+    ops::{benches::*, update::benches::*},
     Key,
 };
 use rand::RngCore;

--- a/nomt/src/beatree/ops/mod.rs
+++ b/nomt/src/beatree/ops/mod.rs
@@ -14,7 +14,7 @@ use super::{
 };
 
 mod reconstruction;
-pub(crate) mod update;
+mod update;
 
 pub use reconstruction::reconstruct;
 pub use update::update;

--- a/nomt/src/beatree/ops/update/branch_stage.rs
+++ b/nomt/src/beatree/ops/update/branch_stage.rs
@@ -1,0 +1,132 @@
+use std::collections::BTreeMap;
+
+use crate::beatree::{
+    allocator::PageNumber,
+    branch::{node::BranchNode, BranchNodePool},
+    index::Index,
+    Key,
+};
+
+use super::{
+    branch_updater::{BaseBranch, BranchUpdater, DigestResult as BranchDigestResult},
+    BranchId,
+};
+
+pub struct ChangedBranchEntry {
+    pub deleted: Option<(BranchId, PageNumber)>,
+    pub inserted: Option<(BranchId, BranchNode)>,
+}
+
+#[derive(Default)]
+pub struct BranchChanges {
+    inner: BTreeMap<Key, ChangedBranchEntry>,
+    fresh_released: Vec<BranchId>,
+}
+
+impl BranchChanges {
+    pub fn delete(&mut self, key: Key, branch_id: BranchId, pn: PageNumber) {
+        let entry = self.inner.entry(key).or_insert_with(|| ChangedBranchEntry {
+            deleted: None,
+            inserted: None,
+        });
+
+        // we can only delete a branch once.
+        assert!(entry.deleted.is_none());
+
+        entry.deleted = Some((branch_id, pn));
+    }
+
+    pub fn insert(&mut self, key: Key, branch_id: BranchId, node: BranchNode) {
+        let entry = self.inner.entry(key).or_insert_with(|| ChangedBranchEntry {
+            deleted: None,
+            inserted: None,
+        });
+
+        if let Some((prev_id, _)) = entry.inserted.replace((branch_id, node)) {
+            self.fresh_released.push(prev_id);
+        }
+    }
+}
+
+fn reset_branch_base(
+    bbn_index: &Index,
+    bnp: &BranchNodePool,
+    branch_changes: &mut BranchChanges,
+    branch_updater: &mut BranchUpdater,
+    key: Key,
+) {
+    let Some((separator, branch_id)) = bbn_index.lookup(key) else {
+        return;
+    };
+
+    // UNWRAP: all indexed branches exist.
+    let branch = bnp.checkout(branch_id).unwrap();
+    let cutoff = bbn_index.next_after(key).map(|(cutoff, _)| cutoff);
+
+    branch_changes.delete(separator, branch_id, branch.bbn_pn().into());
+
+    let base = BaseBranch {
+        node: branch,
+        iter_pos: 0,
+    };
+    branch_updater.reset_base(Some(base), cutoff);
+}
+
+pub fn run(
+    bbn_index: &Index,
+    bnp: &BranchNodePool,
+    changeset: Vec<(Key, Option<PageNumber>)>,
+) -> (BTreeMap<Key, ChangedBranchEntry>, Vec<BranchId>) {
+    if changeset.is_empty() {
+        return (BTreeMap::new(), Vec::new());
+    }
+    let mut branch_changes = BranchChanges::default();
+
+    let mut branch_updater = BranchUpdater::new(None, None);
+
+    // point branch updater at first branch.
+    reset_branch_base(
+        bbn_index,
+        &bnp,
+        &mut branch_changes,
+        &mut branch_updater,
+        // UNWRAP: size checked
+        changeset.first().unwrap().0,
+    );
+
+    for (key, op) in changeset {
+        // ensure key is in scope for branch updater. if not, digest it. merge rightwards until
+        //    done _or_ key is in scope.
+        while !branch_updater.is_in_scope(&key) {
+            let k = if let BranchDigestResult::NeedsMerge(cutoff) =
+                branch_updater.digest(&bnp, &mut branch_changes)
+            {
+                cutoff
+            } else {
+                key
+            };
+
+            reset_branch_base(bbn_index, &bnp, &mut branch_changes, &mut branch_updater, k);
+        }
+
+        branch_updater.ingest(key, op);
+    }
+
+    loop {
+        if let BranchDigestResult::NeedsMerge(cutoff) =
+            branch_updater.digest(&bnp, &mut branch_changes)
+        {
+            reset_branch_base(
+                bbn_index,
+                &bnp,
+                &mut branch_changes,
+                &mut branch_updater,
+                cutoff,
+            );
+            continue;
+        }
+        break;
+    }
+
+    (branch_changes.inner, branch_changes.fresh_released)
+}

--- a/nomt/src/beatree/ops/update/branch_updater.rs
+++ b/nomt/src/beatree/ops/update/branch_updater.rs
@@ -1,5 +1,3 @@
-use bitvec::prelude::*;
-
 use std::cmp::Ordering;
 
 use crate::beatree::{
@@ -11,8 +9,8 @@ use crate::beatree::{
 };
 
 use super::{
-    get_key, BranchChanges, BranchId, BRANCH_BULK_SPLIT_TARGET,
-    BRANCH_BULK_SPLIT_THRESHOLD, BRANCH_MERGE_THRESHOLD,
+    branch_stage::BranchChanges, prefix_len, get_key, separator_len, BranchId,
+    BRANCH_BULK_SPLIT_TARGET, BRANCH_BULK_SPLIT_THRESHOLD, BRANCH_MERGE_THRESHOLD,
 };
 
 pub struct BaseBranch {
@@ -86,7 +84,7 @@ impl BranchUpdater {
         }
     }
 
-    pub(super) fn digest(
+    pub fn digest(
         &mut self,
         bnp: &BranchNodePool,
         branch_changes: &mut BranchChanges,
@@ -417,23 +415,6 @@ impl BranchGauge {
     }
 }
 
-fn prefix_len(key_a: &Key, key_b: &Key) -> usize {
-    key_a
-        .view_bits::<Msb0>()
-        .iter()
-        .zip(key_b.view_bits::<Msb0>().iter())
-        .take_while(|(a, b)| a == b)
-        .count()
-}
-
-fn separator_len(key: &Key) -> usize {
-    if key == &[0u8; 32] {
-        return 1;
-    }
-    let key = &key.view_bits::<Msb0>();
-    key.len() - key.trailing_zeros()
-}
-
 #[derive(Default)]
 struct BranchBulkSplitter {
     items: Vec<(usize, BranchGauge)>,
@@ -444,43 +425,5 @@ impl BranchBulkSplitter {
     fn push(&mut self, count: usize, gauge: BranchGauge) {
         self.items.push((count, gauge));
         self.total_count += count;
-    }
-}
-
-#[cfg(feature = "benchmarks")]
-pub mod benches {
-    use crate::beatree::benches::get_key_pair;
-    use criterion::{BenchmarkId, Criterion};
-
-    pub fn separator_len_benchmark(c: &mut Criterion) {
-        let mut group = c.benchmark_group("separator_len");
-
-        // n_bytes represents the amount of bytes set to one
-        // from the beginning of the key
-        for n_bytes in [16, 20, 24, 28, 31].into_iter().rev() {
-            let mut separator = [0; 32];
-            for byte in separator.iter_mut().take(n_bytes) {
-                *byte = 255;
-            }
-
-            group.bench_function(BenchmarkId::new("zero_bytes", 32 - n_bytes), |b| {
-                b.iter(|| super::separator_len(&separator));
-            });
-        }
-
-        group.finish();
-    }
-
-    pub fn prefix_len_benchmark(c: &mut Criterion) {
-        let mut group = c.benchmark_group("prefix_len");
-
-        for prefix_len_bytes in [0, 4, 8, 12, 16] {
-            let (key1, key2) = get_key_pair(prefix_len_bytes);
-            group.bench_function(BenchmarkId::new("shared_bytes", prefix_len_bytes), |b| {
-                b.iter(|| super::prefix_len(&key1, &key2));
-            });
-        }
-
-        group.finish();
     }
 }

--- a/nomt/src/beatree/ops/update/leaf_stage.rs
+++ b/nomt/src/beatree/ops/update/leaf_stage.rs
@@ -1,0 +1,175 @@
+use std::collections::{BTreeMap, HashMap};
+
+use crate::beatree::{
+    allocator::PageNumber,
+    branch::BranchNodePool,
+    index::Index,
+    leaf::{node::LeafNode, store::LeafStoreReader},
+    ops::search_branch,
+    Key,
+};
+use crate::io::PagePool;
+
+use super::{
+    leaf_updater::{BaseLeaf, DigestResult as LeafDigestResult, LeafUpdater},
+    get_key,
+};
+
+pub struct ChangedLeafEntry {
+    pub deleted: Option<PageNumber>,
+    pub inserted: Option<LeafNode>,
+}
+
+#[derive(Default)]
+pub struct LeafChanges {
+    inner: BTreeMap<Key, ChangedLeafEntry>,
+    overflow_deleted: Vec<Vec<u8>>,
+}
+
+impl LeafChanges {
+    pub fn delete(&mut self, key: Key, pn: PageNumber) {
+        let entry = self.inner.entry(key).or_insert_with(|| ChangedLeafEntry {
+            deleted: None,
+            inserted: None,
+        });
+
+        // we can only delete a leaf once.
+        assert!(entry.deleted.is_none());
+
+        entry.deleted = Some(pn);
+    }
+
+    pub fn insert(&mut self, key: Key, node: LeafNode) {
+        let entry = self.inner.entry(key).or_insert_with(|| ChangedLeafEntry {
+            deleted: None,
+            inserted: None,
+        });
+
+        if let Some(_prev) = entry.inserted.replace(node) {
+            // TODO: this is where we'd clean up.
+        }
+    }
+
+    fn delete_overflow(&mut self, overflow_cell: &[u8]) {
+        self.overflow_deleted.push(overflow_cell.to_vec());
+    }
+}
+
+fn reset_leaf_base(
+    bbn_index: &Index,
+    bnp: &BranchNodePool,
+    leaf_cache: &mut HashMap<PageNumber, LeafNode>,
+    leaf_reader: &LeafStoreReader,
+    leaf_changes: &mut LeafChanges,
+    leaf_updater: &mut LeafUpdater,
+    key: Key,
+) {
+    let Some((_, branch_id)) = bbn_index.lookup(key) else {
+        return;
+    };
+
+    // UNWRAP: branches in index always exist.
+    let branch = bnp.checkout(branch_id).unwrap();
+    let Some((i, leaf_pn)) = search_branch(&branch, key) else {
+        return;
+    };
+    let separator = get_key(&branch, i);
+
+    // we intend to work on this leaf, therefore, we delete it. any new leaves produced by the
+    // updater will replace it.
+    leaf_changes.delete(separator, leaf_pn);
+
+    let cutoff = if i + 1 < branch.n() as usize {
+        Some(get_key(&branch, i + 1))
+    } else {
+        bbn_index.next_after(key).map(|(cutoff, _)| cutoff)
+    };
+
+    let base = BaseLeaf {
+        node: leaf_cache.remove(&leaf_pn).unwrap_or_else(|| LeafNode {
+            inner: leaf_reader.query(leaf_pn),
+        }),
+        iter_pos: 0,
+        separator,
+    };
+
+    leaf_updater.reset_base(Some(base), cutoff);
+}
+
+pub fn run(
+    bbn_index: &Index,
+    bnp: &BranchNodePool,
+    mut leaf_cache: HashMap<PageNumber, LeafNode>,
+    leaf_reader: &LeafStoreReader,
+    page_pool: PagePool,
+    changeset: Vec<(Key, Option<(Vec<u8>, bool)>)>,
+) -> (BTreeMap<Key, ChangedLeafEntry>, Vec<Vec<u8>>) {
+    if changeset.is_empty() {
+        return (BTreeMap::new(), Vec::new());
+    }
+    let mut leaf_changes = LeafChanges::default();
+
+    let mut leaf_updater = LeafUpdater::new(page_pool, None, None);
+
+    // point leaf updater at first leaf.
+    reset_leaf_base(
+        bbn_index,
+        &bnp,
+        &mut leaf_cache,
+        &leaf_reader,
+        &mut leaf_changes,
+        &mut leaf_updater,
+        // UNWRAP: size checked
+        changeset.first().unwrap().0,
+    );
+
+    for (key, op) in changeset {
+        // ensure key is in scope for leaf updater. if not, digest it. merge rightwards until
+        //    done _or_ key is in scope.
+        while !leaf_updater.is_in_scope(&key) {
+            let k = if let LeafDigestResult::NeedsMerge(cutoff) =
+                leaf_updater.digest(&mut leaf_changes)
+            {
+                cutoff
+            } else {
+                key
+            };
+
+            reset_leaf_base(
+                bbn_index,
+                &bnp,
+                &mut leaf_cache,
+                &leaf_reader,
+                &mut leaf_changes,
+                &mut leaf_updater,
+                k,
+            );
+        }
+
+        let (value_change, overflow) = match op {
+            None => (None, false),
+            Some((v, overflow)) => (Some(v), overflow),
+        };
+
+        let delete_overflow = |overflow_cell: &[u8]| leaf_changes.delete_overflow(overflow_cell);
+        leaf_updater.ingest(key, value_change, overflow, delete_overflow);
+    }
+
+    loop {
+        if let LeafDigestResult::NeedsMerge(cutoff) = leaf_updater.digest(&mut leaf_changes) {
+            reset_leaf_base(
+                bbn_index,
+                &bnp,
+                &mut leaf_cache,
+                &leaf_reader,
+                &mut leaf_changes,
+                &mut leaf_updater,
+                cutoff,
+            );
+            continue;
+        }
+        break;
+    }
+
+    (leaf_changes.inner, leaf_changes.overflow_deleted)
+}


### PR DESCRIPTION
1. extract update stages to their own modules.
2. rename branch and leaf updater modules to branch_updater and leaf_updater
3. nit: stop exporting branch_updater and leaf_updater publicly
