### PR TITLE
perf: use dashmap for preloading + some tweaks

### DIFF
--- a/benchtop/src/timer.rs
+++ b/benchtop/src/timer.rs
@@ -29,9 +29,11 @@ impl Timer {
             }
         }
 
-        let h = self.spans.entry(span_name).or_insert_with(|| Rc::new(RefCell::new(
-            hdrhistogram::Histogram::<u64>::new(3).unwrap(),
-        )));
+        let h = self.spans.entry(span_name).or_insert_with(|| {
+            Rc::new(RefCell::new(
+                hdrhistogram::Histogram::<u64>::new(3).unwrap(),
+            ))
+        });
 
         RecordSpan {
             h: h.clone(),

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use bitvec::prelude::*;
 use crossbeam_channel::{Receiver, Sender};
+use dashmap::DashMap;
 use threadpool::ThreadPool;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use crate::beatree::{
     allocator::PageNumber,
@@ -115,13 +116,14 @@ pub fn update(
     Ok(removed_branches)
 }
 
+// TODO: this should not be necessary with proper warm-ups.
 fn preload_leaves(
     leaf_reader: &LeafStoreReader,
     bbn_index: &Index,
     bnp: &BranchNodePool,
     keys: impl IntoIterator<Item = Key>,
-) -> Result<HashMap<PageNumber, LeafNode>> {
-    let mut leaf_pages = HashMap::new();
+) -> Result<DashMap<PageNumber, LeafNode>> {
+    let leaf_pages = DashMap::new();
     let mut last_pn = None;
 
     let mut submissions = 0;


### PR DESCRIPTION
The DashMap is a workaround for not having proper warm-ups of leaves. Beatree commit will get a lot faster once we just warm up and cache leaves somehow.

we were spending about 20% of the time dropping the changeset in the main thread. this gets that out of the way, just by having the last worker thread drop them (after sending results back to the main thread).
