### PR TITLE
refactor: page pool

### DIFF
--- a/nomt/src/beatree/leaf/node.rs
+++ b/nomt/src/beatree/leaf/node.rs
@@ -29,7 +29,7 @@ use std::ops::Range;
 
 use crate::{
     beatree::Key,
-    io::{Page, PAGE_SIZE},
+    io::{page_pool::FatPage, PagePool, PAGE_SIZE},
 };
 
 /// The size of the leaf node body: everything excluding the mandatory header.
@@ -47,7 +47,7 @@ pub const MAX_OVERFLOW_CELL_NODE_POINTERS: usize = 23;
 const OVERFLOW_BIT: u16 = 1 << 15;
 
 pub struct LeafNode {
-    pub inner: Box<Page>,
+    pub inner: FatPage,
 }
 
 impl LeafNode {
@@ -114,9 +114,9 @@ pub struct LeafBuilder {
 }
 
 impl LeafBuilder {
-    pub fn new(n: usize, total_value_size: usize) -> Self {
+    pub fn new(page_pool: &PagePool, n: usize, total_value_size: usize) -> Self {
         let mut leaf = LeafNode {
-            inner: Box::new(Page::zeroed()),
+            inner: page_pool.alloc_fat_page(),
         };
         leaf.set_n(n as u16);
         LeafBuilder {

--- a/nomt/src/beatree/leaf/overflow.rs
+++ b/nomt/src/beatree/leaf/overflow.rs
@@ -9,10 +9,7 @@
 /// pointers: [PageNumber; n_pointers]
 /// bytes: [u8; n_bytes]
 /// ```
-use crate::{
-    beatree::PageNumber,
-    io::{Page, PAGE_SIZE},
-};
+use crate::{beatree::PageNumber, io::{page_pool::FatPage, PAGE_SIZE}};
 
 use super::{
     node::MAX_OVERFLOW_CELL_NODE_POINTERS,
@@ -46,7 +43,7 @@ pub fn chunk(value: &[u8], leaf_writer: &mut LeafStoreWriter) -> Vec<PageNumber>
         assert!(!value.is_empty());
 
         // allocate a page.
-        let mut page = Box::new(Page::zeroed());
+        let mut page = leaf_writer.page_pool().alloc_fat_page();
         let mut pns_written = 0;
 
         // write as many page numbers as possible.
@@ -206,7 +203,7 @@ pub fn delete(cell: &[u8], leaf_reader: &LeafStoreReader, leaf_writer: &mut Leaf
     }
 }
 
-fn read_page<'a>(page: &'a Page) -> (impl Iterator<Item = PageNumber> + 'a, &'a [u8]) {
+fn read_page<'a>(page: &'a FatPage) -> (impl Iterator<Item = PageNumber> + 'a, &'a [u8]) {
     let n_pages = u16::from_le_bytes(page[0..2].try_into().unwrap()) as usize;
     let n_bytes = u16::from_le_bytes(page[2..4].try_into().unwrap()) as usize;
 

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -138,7 +138,11 @@ impl Updater {
         );
 
         // start with first leaf in first branch, cut-off second leaf key.
-        let leaf_updater = LeafUpdater::new(first_leaf, first_leaf_cutoff);
+        let leaf_updater = LeafUpdater::new(
+            ctx.leaf_writer.page_pool().clone(),
+            first_leaf,
+            first_leaf_cutoff,
+        );
 
         Updater {
             branch_updater,

--- a/nomt/src/commit/mod.rs
+++ b/nomt/src/commit/mod.rs
@@ -14,6 +14,7 @@ use nomt_core::{
 use std::sync::{Arc, Barrier};
 
 use crate::{
+    io::PagePool,
     page_cache::{PageCache, ShardIndex},
     page_diff::PageDiff,
     rw_pass_cell::WritePassEnvelope,
@@ -90,6 +91,7 @@ impl CommitPool {
     pub fn begin<H: NodeHasher>(
         &self,
         page_cache: PageCache,
+        page_pool: PagePool,
         store: Store,
         root: Node,
     ) -> Committer {
@@ -101,6 +103,7 @@ impl CommitPool {
             .map(|_| {
                 let params = worker::Params {
                     page_cache: page_cache.clone(),
+                    page_pool: page_pool.clone(),
                     store: store.clone(),
                     root,
                     barrier: barrier.clone(),

--- a/nomt/src/io/page_pool.rs
+++ b/nomt/src/io/page_pool.rs
@@ -1,0 +1,205 @@
+
+use super::PAGE_SIZE;
+use parking_lot::RwLock;
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+// Region is 256 MiB. The choice is mostly arbitrary, but:
+//
+// 1. it's big enough so that we don't have to allocate too often.
+// 2. it's a multiple of 2 MiB which is the size of huge-page on x86-64 and aarch64.
+// 3. it fits 65k 4 KiB pages which requires 2 bytes to address making it nice round number.
+//
+const REGION_SLOT_BITS: u32 = 16;
+const REGION_SLOT_MASK: u32 = (1 << REGION_SLOT_BITS) - 1;
+const REGION_SIZE: usize = (1 << REGION_SLOT_BITS) * PAGE_SIZE;
+
+#[derive(Clone, Copy)]
+struct PageIndex(u32);
+
+impl PageIndex {
+    /// Extracts the region index from the reference.
+    fn region(&self) -> usize {
+        (self.0 >> 16) as usize
+    }
+
+    /// Extracts the slot index within the region.
+    fn slot_index(&self) -> usize {
+        (self.0 & REGION_SLOT_MASK) as usize
+    }
+}
+
+/// A page reference to the pool.
+#[derive(Clone)]
+pub struct Page(PageIndex);
+
+impl Page {
+    /// Returns a pointer to the page.
+    pub fn as_ptr(&self, pool: &PagePool) -> *const u8 {
+        pool.data_ptr(self.0) as *const u8
+    }
+
+    /// Returns a mutable pointer to the page.
+    pub fn as_mut_ptr(&self, pool: &PagePool) -> *mut u8 {
+        pool.data_ptr(self.0)
+    }
+
+    /// This is a convenience function that uses [`std::slice::from_raw_parts_mut`] to create a
+    /// mutable slice.
+    ///
+    /// # Safety
+    ///
+    /// The caller is responsible for making sure:
+    ///
+    /// 1. that the page is not freed,
+    /// 2. that the [`PagePool`] is the same that was used to allocate the page.
+    /// 3. that the [`PagePool`] is not dropped while the slice is used.
+    /// 4. that there is only a single mutable slice into the page at any given time.
+    pub unsafe fn as_mut_slice(&self, pool: &PagePool) -> &mut [u8] {
+        std::slice::from_raw_parts_mut(self.as_mut_ptr(pool), PAGE_SIZE)
+    }
+}
+
+/// Provides a managed version of a [`Page`] by wrapping it and it's [`PagePool`].
+///
+/// Unlike [`Page`], this type handles deallocation for you upon dropping. It also provides a safe
+/// way to access the contents of the page. However, the price for this convenience is that it is
+/// heavier than the bare page type and it doesn't allow cloning.
+pub struct FatPage {
+    page_pool: PagePool,
+    page: Page,
+}
+
+impl FatPage {
+    /// See [`Page::as_ptr`].
+    pub fn as_ptr(&self, pool: &PagePool) -> *const u8 {
+        self.page.as_ptr(pool)
+    }
+
+    /// See [`Page::as_mut_ptr`].
+    pub fn as_mut_ptr(&self, pool: &PagePool) -> *mut u8 {
+        self.page.as_mut_ptr(pool)
+    }
+}
+
+impl Deref for FatPage {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.page.as_mut_slice(&self.page_pool) }
+    }
+}
+
+impl DerefMut for FatPage {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.page.as_mut_slice(&self.page_pool) }
+    }
+}
+
+impl Drop for FatPage {
+    fn drop(&mut self) {
+        self.page_pool.dealloc(self.page.clone());
+    }
+}
+
+/// [`PagePool`] is an efficient allocator for pages used in IO operations.
+///
+/// It allows for efficient allocation and deallocation of pages.
+#[derive(Clone)]
+pub struct PagePool {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    regions: RwLock<Vec<*mut libc::c_void>>,
+    freelist: RwLock<Vec<Page>>,
+}
+
+impl PagePool {
+    /// Creates a new empty page pool.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                regions: RwLock::new(vec![]),
+                freelist: RwLock::new(vec![]),
+            }),
+        }
+    }
+
+    /// Allocates a new [`FatPage`].
+    pub fn alloc_fat_page(&self) -> FatPage {
+        let page = self.alloc_zeroed();
+        FatPage {
+            page_pool: self.clone(),
+            page,
+        }
+    }
+
+    /// Allocates a new [`Page`] and fills it with zeroes.
+    pub fn alloc_zeroed(&self) -> Page {
+        let page = {
+            let mut freelist = self.inner.freelist.write();
+            if freelist.is_empty() {
+                self.grow(&mut *freelist)
+            } else {
+                freelist.pop().unwrap()
+            }
+        };
+        unsafe {
+            page.as_mut_slice(self).fill(0);
+        }
+        page
+    }
+
+    /// Deallocates a [`Page`].
+    pub fn dealloc(&self, page: Page) {
+        self.inner.freelist.write().push(page);
+    }
+
+    fn grow(&self, freelist: &mut Vec<Page>) -> Page {
+        assert!(freelist.is_empty());
+        let region_ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                REGION_SIZE,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                /* fd */ -1,
+                /* offset */ 0,
+            )
+        };
+        if region_ptr == libc::MAP_FAILED {
+            panic!("Failed to allocate memory");
+        }
+        let mut regions = self.inner.regions.write();
+        regions.push(region_ptr);
+
+        let region: u32 = ((regions.len() - 1) as u32) << 16;
+        for slot in 0..=REGION_SLOT_MASK {
+            freelist.push(Page(PageIndex(slot | region)));
+        }
+        // unwrap: we know that the freelist is not empty
+        freelist.pop().unwrap()
+    }
+
+    fn data_ptr(&self, page_index: PageIndex) -> *mut u8 {
+        let region_ptr = self.inner.regions.read()[page_index.region()];
+        unsafe { region_ptr.add(page_index.slot_index() * PAGE_SIZE) as *mut u8 }
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        let mut regions = self.regions.write();
+        for region_ptr in regions.drain(..) {
+            unsafe {
+                libc::munmap(region_ptr as *mut libc::c_void, REGION_SIZE);
+            }
+        }
+    }
+}
+
+unsafe impl Send for PagePool {}
+unsafe impl Sync for PagePool {}

--- a/nomt/src/io/unix.rs
+++ b/nomt/src/io/unix.rs
@@ -1,25 +1,25 @@
-use super::{CompleteIo, IoCommand, IoKind, IoKindResult, IoPacket, PAGE_SIZE};
+use super::{CompleteIo, IoCommand, IoKind, IoKindResult, IoPacket, PagePool, PAGE_SIZE};
 use crossbeam_channel::{Receiver, Sender};
 
 // max number of inflight requests is bounded by the threadpool.
 const MAX_IN_FLIGHT: usize = 64;
 
-pub fn start_io_worker(io_workers: usize) -> Sender<IoPacket> {
+pub fn start_io_worker(io_workers: usize, page_pool: PagePool) -> Sender<IoPacket> {
     let (command_tx, command_rx) = crossbeam_channel::bounded(MAX_IN_FLIGHT);
 
     for _ in 0..io_workers {
-        spawn_worker_thread(command_rx.clone());
+        spawn_worker_thread(command_rx.clone(), page_pool.clone());
     }
 
     command_tx
 }
 
-fn spawn_worker_thread(command_rx: Receiver<IoPacket>) {
+fn spawn_worker_thread(command_rx: Receiver<IoPacket>, page_pool: PagePool) {
     let work = move || loop {
         let Ok(packet) = command_rx.recv() else {
             break;
         };
-        let complete = execute(packet.command);
+        let complete = execute(packet.command, &page_pool);
         let _ = packet.completion_sender.send(complete);
     };
 
@@ -29,13 +29,13 @@ fn spawn_worker_thread(command_rx: Receiver<IoPacket>) {
         .unwrap();
 }
 
-fn execute(mut command: IoCommand) -> CompleteIo {
+fn execute(mut command: IoCommand, page_pool: &PagePool) -> CompleteIo {
     let result = loop {
         let res = match command.kind {
             IoKind::Read(fd, page_index, ref mut page) => unsafe {
                 libc::pread(
                     fd,
-                    page.as_mut_ptr() as *mut libc::c_void,
+                    page.as_mut_ptr(page_pool) as *mut libc::c_void,
                     PAGE_SIZE as libc::size_t,
                     (page_index * PAGE_SIZE as u64) as libc::off_t,
                 )
@@ -43,7 +43,7 @@ fn execute(mut command: IoCommand) -> CompleteIo {
             IoKind::Write(fd, page_index, ref page) => unsafe {
                 libc::pwrite(
                     fd,
-                    page.as_ptr() as *const libc::c_void,
+                    page.as_ptr(page_pool) as *const libc::c_void,
                     PAGE_SIZE as libc::size_t,
                     (page_index * PAGE_SIZE as u64) as libc::off_t,
                 )

--- a/nomt/src/page_diff.rs
+++ b/nomt/src/page_diff.rs
@@ -1,4 +1,4 @@
-use crate::{io, page_cache::NODES_PER_PAGE};
+use crate::page_cache::NODES_PER_PAGE;
 use bitvec::prelude::*;
 
 /// A bitfield tracking which nodes have changed within a page.
@@ -33,7 +33,7 @@ impl PageDiff {
     /// Given the page data, collect the nodes that have changed according to this diff.
     pub fn pack_changed_nodes<'a, 'b: 'a>(
         &'b self,
-        page: &'a io::Page,
+        page: &'a [u8],
     ) -> impl Iterator<Item = [u8; 32]> + 'a {
         self.changed_nodes.iter_ones().map(|node_index| {
             let start = node_index * 32;
@@ -46,7 +46,7 @@ impl PageDiff {
     ///
     /// Panics if the number of changed nodes doesn't equal to the number of nodes
     /// this diff recorded.
-    pub fn unpack_changed_nodes(&self, nodes: &[[u8; 32]], page: &mut io::Page) {
+    pub fn unpack_changed_nodes(&self, nodes: &[[u8; 32]], page: &mut [u8]) {
         assert!(self.changed_nodes.count_ones() == nodes.len());
         for (node_index, node) in self.changed_nodes.iter_ones().zip(nodes) {
             let start = node_index * 32;

--- a/nomt/src/store/meta.rs
+++ b/nomt/src/store/meta.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 use std::fs::File;
 
-use crate::io;
+use crate::io::{self, PagePool};
 
 /// This data structure describes the state of the btree.
 #[derive(Clone)]
@@ -62,8 +62,8 @@ impl Meta {
         }
     }
 
-    pub fn read(fd: &File) -> Result<Self> {
-        let page = io::read_page(fd, 0)?;
+    pub fn read(page_pool: &PagePool, fd: &File) -> Result<Self> {
+        let page = io::read_page(page_pool, fd, 0)?;
         let meta = Meta::decode(&page[..40]);
         Ok(meta)
     }


### PR DESCRIPTION
This changeset introduces a notion of page pool which changes the
approach we use to allocate the pages for IO. Instead of allocating
pages from the global allocator one-by-one, the page pool allocates a
big region of virtual memory from the system and slices it on pages
maintaining a freelist for efficient allocation.

This changeset is only a stepping stone and there is a bit of work to
do. Specifically, it introduces a concept of [`FatPage`] which is
relatively convenient to work with but at the cost of leaving some
performance on the table. Also, page pool's implementation is not the
most efficient out there. This is to be solved in future commits.

Suggestion for the review:

Most of the changes is plumbing: weaving the page pool into all the places page allocation happens. 