### PR TITLE
refactor: have page walker explicitly zero new internal terminator children

### DIFF
--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -258,7 +258,7 @@ pub fn verify_update<H: NodeHasher>(
         };
 
         let ops = crate::update::leaf_ops_spliced(leaf, ops);
-        let sub_root = crate::update::build_trie::<H>(skip, ops, |_, _, _| {});
+        let sub_root = crate::update::build_trie::<H>(skip, ops, |_| {});
 
         let mut cur_node = sub_root;
         let mut cur_layer = skip;

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -27,7 +27,7 @@ pub fn expected_root(accounts: u64) -> Node {
         .map(|a| (a, *blake3::hash(&1000u64.to_le_bytes()).as_bytes()))
         .collect::<Vec<_>>();
     ops.sort_unstable_by_key(|(a, _)| *a);
-    nomt_core::update::build_trie::<nomt::Blake3Hasher>(0, ops, |_, _, _| {})
+    nomt_core::update::build_trie::<nomt::Blake3Hasher>(0, ops, |_| {})
 }
 
 fn opts(path: PathBuf) -> Options {


### PR DESCRIPTION
This loosens the assumptions of merklized page data.

We previously had a tacit assumption that all merkle pages were zeroed, so we had no need to explicitly write terminators.

Ongoing page pool refactors change that assumption and save us the cost of explicitly zeroing pages on alloc or release.

Now, when we create an internal node we explicitly zero the sibling if it's a terminator. This required some refactoring to pass the internal node data to the page walker.
