### PR TITLE
feat: stop branch prefix compression in extreme cases

### DIFF
--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -233,8 +233,8 @@ impl BranchNodeBuilder {
         }
 
         let separator = if self.index < self.prefix_compressed {
-            // There are cases, for example a separator made by all zeros, where the
-            // prefix_len could be bigger then the separator_len
+            // The first separator can have length less than prefix due to trailing zero
+            // compression.
             separator_len = separator_len.saturating_sub(self.prefix_len);
             &key.view_bits::<Msb0>()[self.prefix_len..][..separator_len]
         } else {


### PR DESCRIPTION
This uses Gabriele's previous work on limiting the number of prefix-compressed items in the branch.

This adapts the gauge and handles the degenerate cases where a node jumps from underfull to overfull with the addition of a single new item that collapses the shared prefix.

The test shows an extreme example of the type of issue that this is countering.
