### PR TITLE
opt: reconstruct_key works on raw bytes

### DIFF
--- a/nomt/src/beatree/ops/bit_ops.rs
+++ b/nomt/src/beatree/ops/bit_ops.rs
@@ -1,6 +1,9 @@
-use bitvec::{order::Msb0, slice::BitSlice, view::BitView};
+use bitvec::{order::Msb0, view::BitView};
 
-use crate::beatree::Key;
+use crate::beatree::{
+    branch::node::{RawPrefix, RawSeparator},
+    Key,
+};
 
 // separate two keys a and b where b > a
 pub fn separate(a: &Key, b: &Key) -> Key {
@@ -35,25 +38,124 @@ pub fn separator_len(key: &Key) -> usize {
     key.len() - key.trailing_zeros()
 }
 
-pub fn reconstruct_key(prefix: Option<&BitSlice<u8, Msb0>>, separator: &BitSlice<u8, Msb0>) -> Key {
+// Reconstruct a key starting from a prefix and a misaligned separator.
+// Note: bit offsets starts from 0 going to 7, and the most significant bit is the one with index 0
+pub fn reconstruct_key(maybe_prefix: Option<RawPrefix>, separator: RawSeparator) -> Key {
     let mut key = [0u8; 32];
-    match prefix {
-        Some(prefix) => {
-            key.view_bits_mut::<Msb0>()[..prefix.len()].copy_from_bitslice(prefix);
-            key.view_bits_mut::<Msb0>()[prefix.len()..][..separator.len()]
-                .copy_from_bitslice(separator);
-        }
-        None => {
-            key.view_bits_mut::<Msb0>()[..separator.len()].copy_from_bitslice(separator);
-        }
+
+    let prefix_bit_len = maybe_prefix.as_ref().map(|p| p.1).unwrap_or(0);
+    let prefix_byte_len = (prefix_bit_len + 7) / 8;
+    let prefix_end_bit_offset = prefix_bit_len % 8;
+    let (separator_bytes, separator_bit_init, separator_bit_len) = separator;
+
+    // where the separator will start to be stored
+    let mut key_offset = match prefix_byte_len {
+        0 => 0,
+        len if prefix_end_bit_offset == 0 => len,
+        // overlap between the end of the prefix and the beginning of the separator
+        len => len - 1,
+    };
+
+    enum Shift {
+        Left(usize),                          // amount
+        Right(usize, Option<u8>, Option<u8>), // amount, prev_remainder, curr_remainder
     }
+
+    let mut shift = match prefix_end_bit_offset as isize - separator_bit_init as isize {
+        0 => None,
+        shift if shift < 0 => Some(Shift::Left(shift.abs() as usize)),
+        shift => Some(Shift::Right(shift as usize, None, None)),
+    };
+
+    // chunk is an 8-byte slice of the separator which will be cast to a u64 to simplify shifting
+    let n_chunks = separator_bytes.len() / 8;
+    for chunk_index in 0..n_chunks {
+        let chunk_start = chunk_index * 8;
+
+        if let Some(Shift::Right(amount, _prev_remainder, curr_remainder)) = &mut shift {
+            // store bits that will be covered by the right shift
+            let mask = (1 << *amount) - 1;
+            let bits = separator_bytes[chunk_start + 7] & mask;
+            *curr_remainder = Some(bits << (8 - *amount));
+        }
+
+        let mut chunk = u64::from_be_bytes(
+            separator_bytes[chunk_start..chunk_start + 8]
+                .try_into()
+                .unwrap(),
+        );
+
+        if chunk_index == 0 {
+            // first chunk will probably have garbage at the beginning of the first byte
+            let mask_shift = (7 - separator.1) as u32 + 1 + (8 * 7);
+            let mask = 1u64
+                .checked_shl(mask_shift)
+                .map(|m| m - 1)
+                .unwrap_or(u64::MAX);
+
+            chunk &= mask;
+        }
+
+        if chunk_index == n_chunks - 1 {
+            // last chunk will probably have garbage at end
+            let unused_last_bits = separator_bit_init + separator_bit_len - ((n_chunks - 1) * 64);
+            let mask = 1u64
+                .checked_shl(64 - unused_last_bits as u32)
+                .map(|m| !(m - 1))
+                .unwrap_or(0);
+
+            chunk &= mask;
+        }
+
+        match &mut shift {
+            Some(Shift::Left(amount)) => chunk <<= *amount,
+            Some(Shift::Right(amount, _, _)) => chunk >>= *amount,
+            _ => (),
+        };
+
+        let mut chunk_shifted = chunk.to_be_bytes();
+
+        // move bits remainder between chunk bounderies
+        match &mut shift {
+            Some(Shift::Left(amount)) if chunk_index < n_chunks - 1 => {
+                let mask = !(1 << (8 - *amount) - 1);
+                let remainder_bits = (separator_bytes[(chunk_index + 1) * 8] & mask) >> *amount;
+                chunk_shifted[7] |= remainder_bits;
+            }
+            Some(Shift::Right(_, prev_remainder, curr_remainder)) => {
+                if let Some(bits) = prev_remainder {
+                    chunk_shifted[0] |= *bits;
+                }
+                *prev_remainder = *curr_remainder;
+            }
+            _ => (),
+        };
+
+        // store the shifted chunk into the key
+        let n_byte = std::cmp::min(8, 32 - key_offset);
+        key[key_offset..key_offset + n_byte].copy_from_slice(&chunk_shifted[..n_byte]);
+        key_offset += n_byte;
+    }
+
+    if prefix_byte_len != 0 {
+        // UNWRAP: prefix_byte_len can be different than 0 only if maybe_prefix is Some
+        let prefix = maybe_prefix.unwrap();
+
+        // copy the prefix into the key up to the penultimate byte
+        key[0..prefix_byte_len - 1].copy_from_slice(&prefix.0[0..prefix_byte_len - 1]);
+
+        // copy the last byte of the prefix without interfering with the separator
+        let mask_shift = 8 - (prefix_bit_len % 8) as u32;
+        let mask = 1u8.checked_shl(mask_shift).map(|m| !(m - 1)).unwrap_or(255);
+        key[prefix_byte_len - 1] |= prefix.0[prefix_byte_len - 1] & mask;
+    }
+
     key
 }
 
 #[cfg(feature = "benchmarks")]
 pub mod benches {
     use crate::beatree::benches::get_key_pair;
-    use bitvec::{prelude::Msb0, view::BitView};
     use criterion::{BenchmarkId, Criterion};
     use rand::RngCore;
 
@@ -80,17 +182,43 @@ pub mod benches {
 
             for prefix_bits in [0, 1, 4, 7, 8, 9, 12, 15, 18] {
                 let mut rand = rand::thread_rng();
-                let mut key = [0; 32];
+                // 50 to extract multiples of 8 bytes for the separator
+                let mut key = [0; 50];
                 rand.fill_bytes(&mut key);
 
-                let prefix = &key.view_bits::<Msb0>()[0..prefix_bits];
-                let mut separator = &key.view_bits::<Msb0>()[prefix_bits..];
-                if i == 0 {
-                    separator = &separator[..64];
-                }
+                let prefix_bytes = (prefix_bits + 7) / 8;
+                let separator_bit_init = prefix_bits % 8;
+                let separator_bit_len = if i == 0 {
+                    // ensure that the raw separator is made up of only 8 bytes
+                    57
+                } else {
+                    256 - prefix_bits
+                };
+
+                let separator_byte_init = if prefix_bytes == 0 {
+                    0
+                } else if prefix_bits % 8 == 0 {
+                    prefix_bytes
+                } else {
+                    prefix_bytes - 1
+                };
+                let separator_byte_len = ((separator_bit_len as usize + 7) / 8).next_multiple_of(8);
 
                 group.bench_function(BenchmarkId::new("prefix_len_bits", prefix_bits), |b| {
-                    b.iter(|| super::reconstruct_key(Some(prefix), separator))
+                    b.iter_batched(
+                        || {
+                            (
+                                (&key[0..prefix_bytes], prefix_bits),
+                                (
+                                    &key[separator_byte_init..][..separator_byte_len],
+                                    separator_bit_init,
+                                    separator_bit_len,
+                                ),
+                            )
+                        },
+                        |(prefix, separator)| super::reconstruct_key(Some(prefix), separator),
+                        criterion::BatchSize::SmallInput,
+                    )
                 });
             }
 

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -121,11 +121,11 @@ pub fn update(
 
 pub fn get_key(node: &BranchNode, index: usize) -> Key {
     let prefix = if index < node.prefix_compressed() as usize {
-        Some(node.prefix())
+        Some(node.raw_prefix())
     } else {
         None
     };
-    reconstruct_key(prefix, node.separator(index))
+    reconstruct_key(prefix, node.raw_separator(index))
 }
 
 // TODO: this should not be necessary with proper warm-ups.


### PR DESCRIPTION
After profiling #412 and #413, I have noticed a noticeable decrease in performance related to the struct introduced to wrap the branch node prefix and separator.

However, the more performant `reconstruct_key` function needed some raw data to work on. Thus, in contrast to previous PRs, this one introduces as little changes as possible to allow `reconstruct_key` to access raw bytes directly.
