### PR TITLE
fix: avoid removing cutoff from base leaf

### DIFF
--- a/nomt/src/beatree/ops/update/leaf_stage.rs
+++ b/nomt/src/beatree/ops/update/leaf_stage.rs
@@ -424,7 +424,7 @@ fn reset_leaf_base(
                 separator: *new_key,
             };
             leaf_updater.reset_base(Some(base), new_entry.next_separator);
-            break;
+            return;
         }
     }
 


### PR DESCRIPTION
The cutoff needs to be removed only if all right neighbors have deleted all their leaves, and thus the current worker needs to create the new last leaf, which is done by removing the cutoff of the base leaf.

If the new_entry received from the request_range_extension is going to be the new base, it never requires removal of the cutoff. If the received entry is the last one, then new_entry.next_separator will already be None
