### PR TITLE
fix: leaf_stage sort worker changes

### DIFF
--- a/nomt/src/beatree/ops/update/leaf_stage.rs
+++ b/nomt/src/beatree/ops/update/leaf_stage.rs
@@ -424,7 +424,7 @@ fn reset_leaf_base(
                 separator: *new_key,
             };
             leaf_updater.reset_base(Some(base), new_entry.next_separator);
-            break;
+            return;
         }
     }
 

--- a/nomt/src/beatree/ops/update/leaf_stage.rs
+++ b/nomt/src/beatree/ops/update/leaf_stage.rs
@@ -161,6 +161,8 @@ pub fn run(
         deleted_overflow.extend(worker_deleted_overflow);
     }
 
+    changes.sort_by_key(|(k, _)| *k);
+
     (changes, deleted_overflow)
 }
 


### PR DESCRIPTION
The branch_stage requires a sorted vector of changes. Thus, the leaf_stage needs to sort them when receiving the output of all workers
