### PR TITLE
fix: truncate WAL after writing HT file

### DIFF
--- a/nomt/src/bitbox/writeout.rs
+++ b/nomt/src/bitbox/writeout.rs
@@ -21,6 +21,12 @@ pub fn write_wal(mut wal_fd: &File, wal_blob: &[u8]) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn truncate_wal(mut wal_fd: &File) -> anyhow::Result<()> {
+    wal_fd.set_len(0)?;
+    wal_fd.seek(SeekFrom::Start(0))?;
+    Ok(())
+}
+
 pub fn write_ht(io_handle: IoHandle, ht_fd: &File, ht: Vec<(u64, FatPage)>) -> anyhow::Result<()> {
     let mut sent = 0;
     for (pn, page) in ht {

--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -85,6 +85,7 @@ impl Sync {
 
         let HtWriteoutData { ht_pages } = bitbox_ht_wd.recv().unwrap();
         bitbox::writeout::write_ht(shared.io_pool.make_handle(), &shared.ht_fd, ht_pages)?;
+        bitbox::writeout::truncate_wal(&shared.wal_fd)?;
 
         beatree.finish_sync(beatree_meta_wd.bbn_index);
 


### PR DESCRIPTION
After the recent parallel refactor, we weren't truncating the WAL after successfully writing.

This caused start-up after init to take a very long time.

I added that back, but also am curious if we have a better way of detecting whether WAL changes are outdated.
