### PR TITLE
refactor: make NOMT values raw `Vec`s, not Rc

### DIFF
--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -89,7 +89,7 @@ impl<'a> Transaction for Tx<'a> {
 
     fn write(&mut self, key: &[u8], value: Option<&[u8]>) {
         let key_path = sha2::Sha256::digest(key).into();
-        let value = value.map(|v| std::rc::Rc::new(v.to_vec()));
+        let value = value.map(|v| v.to_vec());
 
         match self.access.entry(key_path) {
             Entry::Occupied(mut o) => {

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -7,7 +7,6 @@ use io::PagePool;
 use metrics::{Metric, Metrics};
 use std::{
     mem,
-    rc::Rc,
     sync::{atomic::AtomicUsize, Arc},
 };
 
@@ -52,7 +51,7 @@ mod io;
 const MAX_COMMIT_CONCURRENCY: usize = 64;
 
 /// A full value stored within the trie.
-pub type Value = Rc<Vec<u8>>;
+pub type Value = Vec<u8>;
 
 struct Shared {
     /// The current root of the trie.
@@ -117,10 +116,10 @@ pub enum KeyReadWrite {
 
 impl KeyReadWrite {
     /// Returns the last recorded value for the slot.
-    pub fn last_value(&self) -> Option<&Value> {
+    pub fn last_value(&self) -> Option<&[u8]> {
         match self {
             KeyReadWrite::Read(v) | KeyReadWrite::Write(v) | KeyReadWrite::ReadThenWrite(_, v) => {
-                v.as_ref()
+                v.as_deref()
             }
         }
     }
@@ -299,10 +298,10 @@ impl Nomt {
 
         let mut tx = self.store.new_tx();
         for (path, read_write) in actuals {
-            if let KeyReadWrite::Write(ref value) | KeyReadWrite::ReadThenWrite(_, ref value) =
+            if let KeyReadWrite::Write(value) | KeyReadWrite::ReadThenWrite(_, value) =
                 read_write
             {
-                tx.write_value(path, value.as_ref().map(|x| &x[..]));
+                tx.write_value(path, value);
             }
         }
 
@@ -347,7 +346,7 @@ impl Session {
 
         let _maybe_guard = self.metrics.record(Metric::ValueFetchTime);
 
-        let value = self.store.load_value(path)?.map(Rc::new);
+        let value = self.store.load_value(path)?;
         Ok(value)
     }
 

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -215,8 +215,8 @@ pub struct Transaction {
 
 impl Transaction {
     /// Write a value to flat storage.
-    pub fn write_value(&mut self, path: KeyPath, value: Option<&[u8]>) {
-        self.batch.push((path, value.map(|v| v.to_vec())))
+    pub fn write_value(&mut self, path: KeyPath, value: Option<Vec<u8>>) {
+        self.batch.push((path, value))
     }
 
     /// Write a page to storage in its entirety.

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -3,7 +3,6 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     mem,
     path::{Path, PathBuf},
-    rc::Rc,
 };
 
 pub fn account_path(id: u64) -> KeyPath {
@@ -77,7 +76,6 @@ impl Test {
 
     pub fn write(&mut self, id: u64, value: Option<Vec<u8>>) {
         let path = account_path(id);
-        let value = value.map(Rc::new);
         match self.access.entry(path) {
             Entry::Occupied(mut o) => {
                 o.get_mut().write(value);
@@ -90,10 +88,10 @@ impl Test {
     }
 
     #[allow(unused)]
-    pub fn read(&mut self, id: u64) -> Option<Rc<Vec<u8>>> {
+    pub fn read(&mut self, id: u64) -> Option<Vec<u8>> {
         let path = account_path(id);
         match self.access.entry(path) {
-            Entry::Occupied(o) => o.get().last_value().cloned(),
+            Entry::Occupied(o) => o.get().last_value().map(|v| v.to_vec()),
             Entry::Vacant(v) => {
                 let value = self
                     .session

--- a/nomt/tests/extend_range_protocol.rs
+++ b/nomt/tests/extend_range_protocol.rs
@@ -50,7 +50,7 @@ fn insert_delete_and_read(name: impl AsRef<Path>, to_delete: Vec<u8>) {
             let res = t.read(k as u64);
             assert_eq!(None, res);
         } else {
-            let value = std::rc::Rc::new(vec![k; value_size]);
+            let value = vec![k; value_size];
             let res = t.read(k as u64);
             assert_eq!(Some(value), res);
         }


### PR DESCRIPTION
We previously wanted to avoid cloning these values while updating RocksDB. This is no longer necessary, and it incurs no performance overhead to take these `Vec`s by-value, since we don't clone them at all. In fact, this PR removes a deep clone.

The impetus for this change is to alter NOMT's API to support threaded access to `Session`s.
