### PR TITLE
feat(benchtop): print mean throughput

### DIFF
--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -89,7 +89,7 @@ pub fn run(params: RunParams) -> Result<()> {
     }
 
     db.print_metrics();
-    timer.print();
+    timer.print(workload_params.size);
 
     Ok(())
 }

--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -96,10 +96,7 @@ impl NomtDB {
         });
 
         // absorb instrumented times from workload timers.
-        for (_, ref mut workload_timer) in results
-            .iter_mut()
-            .flatten()
-        {
+        for (_, ref mut workload_timer) in results.iter_mut().flatten() {
             if let (Some(ref mut t), Some(wt)) = (timer.as_mut(), workload_timer.take()) {
                 t.add(wt);
             }

--- a/benchtop/src/timer.rs
+++ b/benchtop/src/timer.rs
@@ -70,7 +70,7 @@ impl Timer {
         let h = self
             .spans
             .get("workload")
-            .ok_or(anyhow::anyhow!("`workload` span not recordered"))?;
+            .ok_or(anyhow::anyhow!("`workload` span not recorded"))?;
 
         Ok(h.borrow()
             .iter_recorded()
@@ -83,12 +83,12 @@ impl Timer {
         Ok(self
             .spans
             .get("workload")
-            .ok_or(anyhow::anyhow!("`workload` span not recordered"))?
+            .ok_or(anyhow::anyhow!("`workload` span not recorded"))?
             .borrow()
             .mean() as u64)
     }
 
-    pub fn print(&mut self) {
+    pub fn print(&mut self, workload_size: u64) {
         println!("{}", self.name);
 
         let expected_spans = ["workload", "read", "commit_and_prove"];
@@ -104,6 +104,11 @@ impl Timer {
                 ),
                 None => println!("{} not measured", span_name),
             };
+        }
+
+        if let Ok(workload_mean_ns) = self.get_mean_workload_duration() {
+            let ops_per_second = workload_size as f64 / (workload_mean_ns as f64 / 1_000_000_000.0);
+            println!("  mean throughput: {ops_per_second:.1} ops/s");
         }
 
         // print all other measured spans


### PR DESCRIPTION
Example output from benchtop following this PR:

```
nomt
  mean workload: 378 ms
  mean read: 92178 ns
  mean commit_and_prove: 222 ms
  throughput: 26388.9 ops/s
```
