### PR TITLE
feat: remove tentative_*_slot APIs, replace with read and warm-up

### DIFF
--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -132,7 +132,9 @@ impl<'a> Transaction for Tx<'a> {
         match self.access.entry(key_path) {
             Entry::Occupied(o) => o.get().last_value().map(|v| v.to_vec()),
             Entry::Vacant(v) => {
-                let value = self.session.tentative_read_slot(key_path).unwrap();
+                let value = self.session.read(key_path).unwrap();
+                self.session.warm_up(key_path);
+
                 v.insert(KeyReadWrite::Read(value.clone()));
                 value.map(|v| v.to_vec())
             }
@@ -152,6 +154,6 @@ impl<'a> Transaction for Tx<'a> {
             }
         }
 
-        self.session.tentative_write_slot(key_path);
+        self.session.warm_up(key_path);
     }
 }

--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -33,16 +33,13 @@ impl NomtDB {
 
         // First, read what is under key_path_1
         //
-        // `tentative_read_slot` will immediately return the value present in the database
-        let value = session.tentative_read_slot(key_path_1)?;
+        // `read` will immediately return the value present in the database
+        let value = session.read(key_path_1)?;
 
-        // Second, write the value to key_path_2 and delete key_path_1
-        //
-        // As we can observe, the value is not being written at the moment.
-        // NOMT is just advertised here to inform that those keys
-        // will be written during the commit and prove stage
-        session.tentative_write_slot(key_path_1);
-        session.tentative_write_slot(key_path_2);
+        // We are going to perform writes on both key-paths, so we have NOMT warm up the on-disk
+        // data for both.
+        session.warm_up(key_path_1);
+        session.warm_up(key_path_2);
 
         // Retrieve the previous value of the root before committing changes
         let prev_root = nomt.root();

--- a/fuzz/fuzz_targets/api_surface.rs
+++ b/fuzz/fuzz_targets/api_surface.rs
@@ -20,11 +20,12 @@ fuzz_target!(|run: Run| {
                             key_path,
                             expected_value,
                         } => {
-                            let actual_value = session.tentative_read_slot(key_path).unwrap();
+                            let actual_value = session.read(key_path).unwrap();
+                            session.warm_up(key_path);
                             assert_eq!(actual_value, expected_value);
                         }
                         SessionCall::TentativeWrite { key_path } => {
-                            session.tentative_write_slot(key_path);
+                            session.warm_up(key_path);
                         }
                         SessionCall::CommitAndProve { keys } => {
                             let _ = db.commit_and_prove(session, keys);

--- a/nomt/src/beatree/mod.rs
+++ b/nomt/src/beatree/mod.rs
@@ -1,15 +1,8 @@
 use allocator::{PageNumber, FREELIST_EMPTY};
 use anyhow::{Context, Result};
 use branch::{BranchNode, BRANCH_NODE_SIZE};
-use std::{
-    collections::BTreeMap,
-    fs::File,
-    mem,
-    ops::DerefMut,
-    path::Path,
-    sync::Arc,
-};
 use parking_lot::{Mutex, RwLock};
+use std::{collections::BTreeMap, fs::File, mem, ops::DerefMut, path::Path, sync::Arc};
 use threadpool::ThreadPool;
 
 use crate::io::{page_pool::FatPage, IoPool, PagePool};

--- a/nomt/src/commit/mod.rs
+++ b/nomt/src/commit/mod.rs
@@ -11,7 +11,10 @@ use nomt_core::{
     trie_pos::TriePosition,
 };
 
-use std::sync::{atomic::{AtomicUsize, Ordering}, Arc, Barrier};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Barrier,
+};
 
 use crate::{
     io::PagePool,

--- a/nomt/src/seglog/mod.rs
+++ b/nomt/src/seglog/mod.rs
@@ -266,7 +266,7 @@ impl SegmentedLog {
     /// Prunes segments that lie outside of the new live range, i.e. deletes the old segments.
     ///
     /// This function updates the live range.
-    /// 
+    ///
     /// It's possible to return remove all items from the log, i.e. to reset the log to an empty
     /// state, by setting the new live end to zero. That would update the live range to `(0, 0)`.
     ///

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -89,7 +89,7 @@ impl Test {
                 v.insert(KeyReadWrite::Write(value));
             }
         }
-        self.session.as_mut().unwrap().tentative_write_slot(key);
+        self.session.as_mut().unwrap().warm_up(key);
     }
 
     pub fn read_id(&mut self, id: u64) -> Option<Vec<u8>> {
@@ -100,12 +100,9 @@ impl Test {
         match self.access.entry(key) {
             Entry::Occupied(o) => o.get().last_value().map(|v| v.to_vec()),
             Entry::Vacant(v) => {
-                let value = self
-                    .session
-                    .as_mut()
-                    .unwrap()
-                    .tentative_read_slot(key)
-                    .unwrap();
+                let session = self.session.as_mut().unwrap();
+                let value = session.read(key).unwrap();
+                session.warm_up(key);
                 v.insert(KeyReadWrite::Read(value.clone()));
                 value
             }


### PR DESCRIPTION
This PR removes the `tentative_read_slot` and `tentative_write_slot` APIs from `Session` and replaces them with `read(key) -> value` and `warm_up(key)` APIs.

There are motivations for this change:
  1. Supporting warm-ups with app-level caching. If the user has an app-level value cache, they need some way to tell NOMT to warm up the path. This requires a `warm_up` function to exist.
  2. Avoiding redundant warm-ups with read-then-write patterns. In the current state of the API, we call `warm_up` twice for a key: once when we read it, and once when we write it.
    - This inefficiency might not be avoidable in general computation, but at least this way the user has the ability to elide redundant calls as far as their execution environment permits.
  3. Avoiding warm-ups for reads when not merkle-proving. If the user isn't generating merkle proofs, then only writes need to be warmed up. The current state of the API doesn't account for this.  
