### PR TITLE
fix: left-shift bug in reconstruct_key

### DIFF
--- a/nomt/src/beatree/ops/bit_ops.rs
+++ b/nomt/src/beatree/ops/bit_ops.rs
@@ -115,11 +115,10 @@ pub fn reconstruct_key(maybe_prefix: Option<RawPrefix>, separator: RawSeparator)
 
         let mut chunk_shifted = chunk.to_be_bytes();
 
-        // move bits remainder between chunk bounderies
+        // move bits remainder between chunk boundaries
         match &mut shift {
             Some(Shift::Left(amount)) if chunk_index < n_chunks - 1 => {
-                let mask = !(1 << (8 - *amount) - 1);
-                let remainder_bits = (separator_bytes[(chunk_index + 1) * 8] & mask) >> *amount;
+                let remainder_bits = (separator_bytes[(chunk_index + 1) * 8]) >> (8 - *amount);
                 chunk_shifted[7] |= remainder_bits;
             }
             Some(Shift::Right(_, prev_remainder, curr_remainder)) => {


### PR DESCRIPTION
I was running into an issue where the separator was being shifted left by 5 bits but then only getting 3 bits from the next byte.

e.g. `11111111` was becoming `11100000` and then `11100111`, which was wrong. The initial fix just changed an `amount` to `(8 - amount)`.

But the `mask` didn't seem useful in this case (it was being generated as `11101111`) so I removed it. What was it for? Is it still necessary?
