### PR TITLE
chore: clean up seglog

### DIFF
--- a/nomt/src/seglog/mod.rs
+++ b/nomt/src/seglog/mod.rs
@@ -21,7 +21,7 @@
 //! There is a limit on the maximum size of a record payload, which is currently set to 1 GiB.
 //! However, this limit may be subject to change in future versions.
 
-#![allow(unused)]
+#![allow(dead_code)]
 
 use anyhow::{ensure, Context, Result};
 use std::{
@@ -433,7 +433,6 @@ impl Recovery {
                 let path = entry.path();
                 if filename.starts_with(&filename_prefix) {
                     let id = segment_filename::parse(filename_prefix, filename)?;
-                    let file_size = entry.metadata()?.len();
                     self.candidates.push(Segment {
                         id,
                         path,

--- a/nomt/src/seglog/segment_rw.rs
+++ b/nomt/src/seglog/segment_rw.rs
@@ -162,11 +162,6 @@ impl SegmentFileReader {
     pub fn pos(&mut self) -> Result<u64> {
         Ok(self.buf_reader.stream_position()?)
     }
-
-    /// Returns the file that the reader is reading from.
-    pub fn into_inner(self) -> File {
-        self.buf_reader.into_inner()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I've noticed some warnings coming out from the seglog even when the code is used by the rollback.

So here I fix those and add `allow(dead_code)` to seglog for now. This is already removed in the upcoming rollback PR.