### PR TITLE
opt: optimize shard_index_for

### DIFF
--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -119,6 +119,13 @@ impl PageId {
         Ok(PageId { path })
     }
 
+    /// Get the child index of the page at the given depth.
+    ///
+    /// This panics if the depth of the page is not at least `depth + 1`.
+    pub fn child_index_at_level(&self, depth: usize) -> u8 {
+        self.path[depth]
+    }
+
     /// Encode this page ID to its disambiguated (fixed-width) representation.
     pub fn encode(&self) -> [u8; 32] {
         let mut uint = Uint::<256, 4>::from(0);

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -230,7 +230,6 @@ impl<Node> NodesTracker<Node> {
         entry.inserted.replace(node);
     }
 
-
     #[cfg(test)]
     pub fn get(&self, key: Key) -> Option<&ChangedNodeEntry<Node>> {
         self.inner.get(&key)

--- a/nomt/src/commit/worker.rs
+++ b/nomt/src/commit/worker.rs
@@ -34,7 +34,7 @@ use crate::{
     io::PagePool,
     page_cache::{PageCache, ShardIndex},
     page_region::PageRegion,
-    page_walker::{NeedsPage, Output, PageWalker, PageSource},
+    page_walker::{NeedsPage, Output, PageSource, PageWalker},
     rw_pass_cell::{ReadPass, WritePass},
     seek::{Completion, Seek, Seeker},
     store::Store,
@@ -89,9 +89,7 @@ pub(super) fn run<H: NodeHasher>(comms: Comms, params: Params) {
             );
 
             let output = match commit::<H>(root, page_cache, page_pool, seeker, command, warm_ups) {
-                Err(_) => {
-                    return
-                }
+                Err(_) => return,
                 Ok(o) => o,
             };
             let _ = comms.output_tx.send(output);
@@ -201,8 +199,12 @@ fn commit<H: NodeHasher>(
     };
 
     let pending_ops = shared.take_root_pending();
-    let mut root_page_committer =
-        PageWalker::<H>::new(root, PageSource::PageCache(page_cache.clone()), page_pool.clone(), None);
+    let mut root_page_committer = PageWalker::<H>::new(
+        root,
+        PageSource::PageCache(page_cache.clone()),
+        page_pool.clone(),
+        None,
+    );
 
     for (trie_pos, pending_op) in pending_ops {
         match pending_op {
@@ -320,8 +322,7 @@ impl<H: NodeHasher> RangeCommitter<H> {
 
         let page_source = match write_pass.region() {
             ShardIndex::Root => PageSource::PageCache(page_cache.clone()),
-            ShardIndex::Shard(i) =>
-                PageSource::PageCacheShard(page_cache.get_shard(*i))
+            ShardIndex::Shard(i) => PageSource::PageCacheShard(page_cache.get_shard(*i)),
         };
 
         RangeCommitter {


### PR DESCRIPTION
`shard_index_for` was super slow. This replaces it with a simple approach based on how we allocate the shards in the first place.
