### PR TITLE
refactor: use only a single warm-up thread

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -240,7 +240,7 @@ impl Nomt {
         assert_eq!(prev, 0, "only one session could be active at a time");
         Session {
             store: self.store.clone(),
-            committer: Some(self.commit_pool.begin::<Blake3Hasher>(
+            committer: Some(self.commit_pool.begin(
                 self.page_cache.clone(),
                 self.page_pool.clone(),
                 self.store.clone(),
@@ -304,7 +304,7 @@ impl Nomt {
             .committer
             .take()
             .unwrap()
-            .commit(compact_actuals, witness);
+            .commit::<Blake3Hasher>(compact_actuals, witness);
 
         let mut tx = self.store.new_tx();
         for (path, read_write) in actuals {

--- a/nomt/src/seek.rs
+++ b/nomt/src/seek.rs
@@ -481,6 +481,7 @@ pub enum Completion {
 }
 
 /// The result of a seek.
+#[derive(Clone)]
 pub struct Seek {
     /// The key being sought.
     #[allow(dead_code)]


### PR DESCRIPTION
This is a refactor, and to some extent an optimization.

A single warm up thread is able to saturate all 3 I/O thread CPUs in my empirical tests.

It solves some problems, as well:
  1. Makes it easy to give each commit worker a list of everything that's been warmed up, which was a prior issue in the code (workers only had a list of what they had warmed up)
  2. potential for more simplification / modularization
  3. potential for less granular cache shard locking
  4. With many warm-up threads, threads were likely to be idle and blocking on `warmup_rx.recv()`. This meant that the sender (critical path workload threads) were paying a cost for waking up the receiver. In a cursory sample, this problem seems to have gone away. 
