### PR TITLE
chore: clean up unused imports

### DIFF
--- a/nomt/src/beatree/ops/bit_ops.rs
+++ b/nomt/src/beatree/ops/bit_ops.rs
@@ -1,5 +1,3 @@
-use bitvec::{order::Msb0, view::BitView};
-
 use crate::beatree::{
     branch::node::{RawPrefix, RawSeparator},
     Key,


### PR DESCRIPTION
Noticed this on master after `gt sync`.