### PR TITLE
feat: rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "fxhash",
+ "hex",
  "hex-literal",
  "im",
  "io-uring",

--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -169,5 +169,6 @@ impl<'a> Transaction for Tx<'a> {
         }
 
         self.session.warm_up(key_path);
+        self.session.preserve_prior_value(key_path);
     }
 }

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -42,6 +42,7 @@ hex-literal = "0.4"
 tempfile = "3.8.1"
 criterion = "0.3"
 lazy_static = "1.5.0"
+hex = "0.4.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/nomt/src/options.rs
+++ b/nomt/src/options.rs
@@ -13,6 +13,9 @@ pub struct Options {
     pub(crate) bitbox_num_pages: u32,
     pub(crate) bitbox_seed: [u8; 16],
     pub(crate) panic_on_sync: bool,
+    pub(crate) rollback: bool,
+    /// The maximum number of commits that can be rolled back.
+    pub(crate) max_rollback_log_len: u32,
 }
 
 impl Options {
@@ -30,6 +33,8 @@ impl Options {
             bitbox_num_pages: 64_000,
             bitbox_seed,
             panic_on_sync: false,
+            rollback: false,
+            max_rollback_log_len: 100,
         }
     }
 
@@ -80,5 +85,15 @@ impl Options {
     /// Useful to test WAL recovery.
     pub fn panic_on_sync(&mut self, panic_on_sync: bool) {
         self.panic_on_sync = panic_on_sync;
+    }
+
+    /// Set to `true` to enable rolling back committed sessions.
+    pub fn rollback(&mut self, rollback: bool) {
+        self.rollback = rollback;
+    }
+
+    /// Set the maximum number of commits that can be rolled back.
+    pub fn max_rollback_log_len(&mut self, max_rollback_log_len: u32) {
+        self.max_rollback_log_len = max_rollback_log_len;
     }
 }

--- a/nomt/src/rollback/delta.rs
+++ b/nomt/src/rollback/delta.rs
@@ -1,0 +1,137 @@
+use nomt_core::trie::KeyPath;
+use std::{
+    collections::HashMap,
+    io::{Cursor, Read as _},
+};
+
+/// A delta that should be applied to reverse a commit.
+#[derive(Debug)]
+pub struct Delta {
+    /// This map contains the prior value for each key that was written by the commit this delta
+    /// reverses. `None` indicates that the key did not exist before the commit.
+    pub(crate) priors: HashMap<KeyPath, Option<Vec<u8>>>,
+}
+
+impl Delta {
+    #[cfg(test)]
+    fn empty() -> Self {
+        Self {
+            priors: HashMap::new(),
+        }
+    }
+
+    /// Encode the delta into a buffer.
+    ///
+    /// Returns the number of bytes written.
+    pub fn encode(&self) -> Vec<u8> {
+        // The serialization format has the following layout.
+        //
+        // The keys are split into two groups and written as separate arrays. Those groups are:
+        //
+        // 1. erase: The keys that did not exist before the commit.
+        // 2. reinstateThe keys that had prior values.
+        //
+        // The keys that did not exist are written first. The keys that had prior values are
+        // written second.
+        //
+        // For each kind of key, we first write out the length of the array encoded as a u32.
+        // This is followed by the keys themselves, written contiguously in little-endian order.
+        //
+        // The keys are written as 32-byte big-endian values.
+
+        // Sort the keys into two groups.
+        let mut to_erase = Vec::with_capacity(self.priors.len());
+        let mut to_reinstate = Vec::with_capacity(self.priors.len());
+        for (key, value) in self.priors.iter() {
+            match value {
+                None => to_erase.push(key),
+                Some(value) => to_reinstate.push((key, value)),
+            }
+        }
+
+        let to_erase_len = to_erase.len() as u32;
+        let mut buf = Vec::with_capacity(4 + 32 * to_erase.len());
+        buf.extend_from_slice(&to_erase_len.to_le_bytes());
+        for key in to_erase {
+            buf.extend_from_slice(&key[..]);
+        }
+
+        let to_reinstate_len = to_reinstate.len() as u32;
+        buf.extend_from_slice(&to_reinstate_len.to_le_bytes());
+        for (key, value) in to_reinstate {
+            buf.extend_from_slice(&key[..]);
+            let value_len = value.len() as u32;
+            buf.extend_from_slice(&value_len.to_le_bytes());
+            buf.extend_from_slice(value);
+        }
+
+        buf
+    }
+
+    /// Decodes the delta from a buffer.
+    pub fn decode(reader: &mut Cursor<impl AsRef<[u8]>>) -> anyhow::Result<Self> {
+        let mut priors = HashMap::new();
+
+        // Read the number of keys to erase.
+        let mut buf = [0; 4];
+        reader.read_exact(&mut buf)?;
+        let to_erase_len = u32::from_le_bytes(buf);
+        // Read the keys to erase.
+        for _ in 0..to_erase_len {
+            let mut key_path = [0; 32];
+            reader.read_exact(&mut key_path)?;
+            let preemted = priors.insert(key_path, None).is_some();
+            if preemted {
+                anyhow::bail!("duplicate key path (erase): {:?}", key_path);
+            }
+        }
+
+        // Read the number of keys to reinstate.
+        reader.read_exact(&mut buf)?;
+        let to_reinsate_len = u32::from_le_bytes(buf);
+        // Read the keys to reinstate along with their values.
+        for _ in 0..to_reinsate_len {
+            // Read the key path.
+            let mut key_path = [0; 32];
+            reader.read_exact(&mut key_path)?;
+            // Read the value.
+            let mut value = Vec::new();
+            reader.read_exact(&mut buf)?;
+            let value_len = u32::from_le_bytes(buf);
+            value.resize(value_len as usize, 0);
+            reader.read_exact(&mut value)?;
+            let preempted = priors.insert(key_path, Some(value)).is_some();
+            if preempted {
+                anyhow::bail!("duplicate key path (reinstate): {:?}", key_path);
+            }
+        }
+        Ok(Delta { priors })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delta_roundtrip() {
+        let mut delta = Delta::empty();
+        delta.priors.insert([1; 32], Some(b"value1".to_vec()));
+        delta.priors.insert([2; 32], None);
+        delta.priors.insert([3; 32], Some(b"value3".to_vec()));
+
+        let mut buf = delta.encode();
+        let mut cursor = Cursor::new(&mut buf);
+        let delta2 = Delta::decode(&mut cursor).unwrap();
+        assert_eq!(delta.priors, delta2.priors);
+    }
+
+    #[test]
+    fn delta_roundtrip_empty() {
+        let delta = Delta::empty();
+        let mut buf = delta.encode();
+        let mut cursor = Cursor::new(&mut buf);
+        let delta2 = Delta::decode(&mut cursor).unwrap();
+        assert_eq!(delta.priors, delta2.priors);
+    }
+}

--- a/nomt/src/rollback/mod.rs
+++ b/nomt/src/rollback/mod.rs
@@ -1,0 +1,342 @@
+//! This module implements the rollback log.
+//!
+//! The rollback log maintains a list of reverse deltas. A reverse delta contains the prior value
+//! for every key that was modified or deleted.
+//!
+//! The deltas are stored in an in-memory ring buffer. When the buffer size reaches the limit, the
+//! oldest deltas are discarded to make space for new ones.
+//!
+//! The deltas are also persisted on disk in a [`seglog`].
+
+use std::{
+    collections::{BTreeMap, VecDeque},
+    fs::File,
+    io::Cursor,
+    path::PathBuf,
+    sync::Arc,
+};
+
+use dashmap::DashMap;
+use nomt_core::trie::KeyPath;
+use parking_lot::Mutex;
+use threadpool::ThreadPool;
+
+use self::delta::Delta;
+use crate::{
+    seglog::{self, RecordId, SegmentedLog},
+    KeyReadWrite,
+};
+
+mod delta;
+#[cfg(test)]
+mod tests;
+
+const MAX_SEGMENT_SIZE: u64 = 64 * 1024 * 1024; // 64 MiB
+
+struct InMemory {
+    /// The log of deltas that we have accumulated so far.
+    ///
+    /// The items are pushed onto the back and popped from the front. When the log reaches
+    /// [`Shared::max_rollback_log_len`], the oldest delta is discarded.
+    ///
+    /// The deltas are stored in-memory even after they are dumped on disk. Upon restart, the deltas
+    /// are re-read from disk and stored here.
+    log: VecDeque<(RecordId, Delta)>,
+
+    /// If this is set, then the next writeout will truncate the log at this offset.
+    pending_truncate: Option<u64>,
+}
+
+struct Shared {
+    worker_tp: ThreadPool,
+    in_memory: Mutex<InMemory>,
+    seglog: Mutex<SegmentedLog>,
+    /// The number of items that we should keep in the log. Deltas that are past this limit are
+    /// discarded.
+    max_rollback_log_len: usize,
+}
+
+impl InMemory {
+    fn new() -> Self {
+        Self {
+            log: VecDeque::new(),
+            pending_truncate: None,
+        }
+    }
+
+    /// Push a delta into the in-memory cache.
+    fn push_back(&mut self, record_id: RecordId, delta: Delta) {
+        self.log.push_back((record_id, delta));
+    }
+
+    fn pop_back(&mut self) -> Option<(RecordId, Delta)> {
+        self.log.pop_back()
+    }
+
+    // Returns the total number of deltas, including the staged one.
+    fn total_len(&self) -> usize {
+        self.log.len()
+    }
+}
+
+/// This structure manages the rollback log. Modifications to the rollback log are made using
+/// [`ReverseDeltaBuilder`] supplied to [`Rollback::commit`].
+#[derive(Clone)]
+pub struct Rollback {
+    shared: Arc<Shared>,
+}
+
+impl Rollback {
+    pub fn read(
+        max_rollback_log_len: u32,
+        db_dir_path: PathBuf,
+        db_dir_fd: File,
+        rollback_start_active: u64,
+        rollback_end_active: u64,
+    ) -> anyhow::Result<Self> {
+        let mut in_memory = InMemory::new();
+        let seglog = seglog::open(
+            db_dir_path,
+            db_dir_fd,
+            "rollback".to_string(),
+            MAX_SEGMENT_SIZE,
+            rollback_start_active.into(),
+            rollback_end_active.into(),
+            |record_id, payload| {
+                let mut cursor = Cursor::new(payload);
+                let delta = Delta::decode(&mut cursor)?;
+                in_memory.push_back(record_id, delta);
+                Ok(())
+            },
+        )?;
+        let shared = Arc::new(Shared {
+            worker_tp: ThreadPool::new(4),
+            in_memory: Mutex::new(in_memory),
+            seglog: Mutex::new(seglog),
+            max_rollback_log_len: max_rollback_log_len as usize,
+        });
+        Ok(Self { shared })
+    }
+
+    /// Begin a rollback delta.
+    pub fn delta_builder(&self) -> ReverseDeltaBuilder {
+        ReverseDeltaBuilder {
+            tp: self.shared.worker_tp.clone(),
+            priors: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Saves the delta into the log.
+    ///
+    /// This function accepts the final list of operations that should be performed sorted by the
+    /// key paths in ascending order.
+    pub fn commit(
+        &self,
+        store: impl LoadValue,
+        actuals: &[(KeyPath, KeyReadWrite)],
+        delta: ReverseDeltaBuilder,
+    ) -> anyhow::Result<()> {
+        let delta = delta.finalize(store, actuals);
+        let delta_bytes = delta.encode();
+
+        let mut in_memory = self.shared.in_memory.lock();
+        let mut seglog = self.shared.seglog.lock();
+
+        let record_id = seglog.append(&delta_bytes)?;
+        in_memory.push_back(record_id, delta);
+        Ok(())
+    }
+
+    /// Truncates the rollback log by removing the last `n` deltas.
+    ///
+    /// This function returns the keys and values that we should apply to the database to restore
+    /// the state as it was before the last `n` deltas were applied.
+    ///
+    /// This function is destructive and consumes the rollback log.
+    pub fn truncate(
+        &self,
+        mut n: usize,
+    ) -> anyhow::Result<Option<BTreeMap<KeyPath, Option<Vec<u8>>>>> {
+        assert!(n > 0);
+        let mut in_memory = self.shared.in_memory.lock();
+        if n > in_memory.total_len() {
+            return Ok(None);
+        }
+
+        let mut traceback = BTreeMap::new();
+        let mut earliest_record_id = None;
+        while n > 0 {
+            // Pop the most recent delta from the log and add its original values to the traceback,
+            // potentially overwriting some of the values that were added in previous iterations.
+            //
+            // UNWRAP: we checked above that `n` is greater or equal to the total number of deltas
+            //         and `n` is strictly decreasing.
+            let (record_id, delta) = in_memory.pop_back().unwrap();
+            earliest_record_id = Some(record_id);
+            for (key, value) in delta.priors {
+                traceback.insert(key, value);
+            }
+            n -= 1;
+        }
+        // UNWRAP: we checked above that `n` is greater than 0 and that means that there is at
+        //         least one delta that we will remove.
+        let earliest_record_id = earliest_record_id.unwrap();
+
+        // We got the earliest record ID that we will remove. To obtain the new live range start
+        // we need to get the ID of the element prior to that, hence `prev`.
+        //
+        // UNWRAP: `prev` returns `None` iff the record ID is nil. We know that `earliest_record_id`
+        //         can't be nil because there were some elements in the log that we removed.
+        let new_end_live = earliest_record_id.prev().unwrap();
+
+        // Set pending truncate to the new end live.
+        //
+        // We cannot prune the log right away. If we did, and the process crashed, the log could
+        // get truncated but the manifest would still reference the old, longer, range.
+        in_memory.pending_truncate = Some(new_end_live.0);
+
+        Ok(Some(traceback))
+    }
+
+    /// Dumps the contents of the staging to the rollback.
+    pub fn writeout_start(&self) -> anyhow::Result<WriteoutData> {
+        let mut in_memory = self.shared.in_memory.lock();
+        let seglog = self.shared.seglog.lock();
+
+        let pending_truncate = in_memory.pending_truncate.take();
+
+        // NOTE: for now, if there is a pending truncate, we ignore everything else.
+        if let Some(pending_truncate) = pending_truncate {
+            return Ok(WriteoutData {
+                rollback_start_live: seglog.live_range().0 .0,
+                rollback_end_live: pending_truncate,
+                prune_to_new_start_live: None,
+                prune_to_new_end_live: Some(pending_truncate),
+            });
+        }
+
+        let prune_to_new_start_live = if in_memory.total_len() > self.shared.max_rollback_log_len {
+            Some(in_memory.pop_back().unwrap().0.next().0)
+        } else {
+            None
+        };
+
+        let (rollback_start_live, rollback_end_live) = seglog.live_range();
+
+        Ok(WriteoutData {
+            rollback_start_live: rollback_start_live.0,
+            rollback_end_live: rollback_end_live.0,
+            prune_to_new_start_live,
+            prune_to_new_end_live: None,
+        })
+    }
+
+    /// Finalizes the writeout.
+    ///
+    /// This should be called after the manifest has been updated with the new rollback log live
+    /// range.
+    ///
+    /// We use this point in time to prune the rollback log, by removing the deltas that are no
+    /// longer needed.
+    pub fn writeout_end(
+        &self,
+        new_start_live: Option<u64>,
+        new_end_live: Option<u64>,
+    ) -> anyhow::Result<()> {
+        if let Some(new_start_live) = new_start_live {
+            let mut seglog = self.shared.seglog.lock();
+            seglog.prune_back(new_start_live.into())?;
+        }
+        if let Some(new_end_live) = new_end_live {
+            let mut seglog = self.shared.seglog.lock();
+            seglog.prune_front(new_end_live.into())?;
+        }
+        Ok(())
+    }
+}
+
+pub struct WriteoutData {
+    pub rollback_start_live: u64,
+    pub rollback_end_live: u64,
+    /// If this is `Some`, then the [`Rollback::writeout_end`] should be called with this value.
+    pub prune_to_new_start_live: Option<u64>,
+    /// If this is `Some`, then the [`Rollback::writeout_end`] should be called with this value.
+    pub prune_to_new_end_live: Option<u64>,
+}
+
+pub struct ReverseDeltaBuilder {
+    tp: ThreadPool,
+    /// The values of the keys that should be preserved at commit time for this delta.
+    ///
+    /// Before the commit takes place, the set contains tentative values.
+    priors: Arc<DashMap<KeyPath, Option<Vec<u8>>>>,
+}
+
+/// A trait for loading values from the store.
+///
+/// This seam allows us to mock the store in tests.
+pub trait LoadValue: Clone + Send + Sync + 'static {
+    fn load_value(&self, key_path: KeyPath) -> anyhow::Result<Option<Vec<u8>>>;
+}
+
+impl LoadValue for crate::store::Store {
+    fn load_value(&self, key_path: KeyPath) -> anyhow::Result<Option<Vec<u8>>> {
+        self.load_value(key_path)
+    }
+}
+
+impl ReverseDeltaBuilder {
+    /// Note that a write might be made to a key and that the rollback should preserve the prior
+    /// value. This function is speculative; the rollback delta may later be committed with a
+    /// different set of operations, and some of the tentative operations may be discarded.
+    ///
+    /// This function doesn't block.
+    pub fn tentative_preserve_prior(&self, store: impl LoadValue, key_path: KeyPath) {
+        self.tp.execute({
+            let priors = self.priors.clone();
+            move || {
+                let value = store.load_value(key_path).unwrap();
+                priors.insert(key_path, value);
+            }
+        });
+    }
+
+    /// Finalize the delta.
+    fn finalize(self, store: impl LoadValue, actuals: &[(KeyPath, KeyReadWrite)]) -> Delta {
+        // Wait for all tentative writes issued so far to complete.
+        //
+        // NB: This doesn't take into account other users of `tp`. If there are any, we will be
+        // needlessly blocking on them.
+        self.tp.join();
+
+        let tentative_priors = Arc::clone(&self.priors);
+        let final_priors = Arc::new(DashMap::with_capacity(tentative_priors.len() * 2));
+
+        for (path, read_write) in actuals {
+            if read_write.is_write() {
+                if let Some((path, value)) = tentative_priors.remove(path) {
+                    // Tentative speculation was a hit. Keep the entry.
+                    final_priors.insert(path, value);
+                } else {
+                    // The delta builder was not aware of this write. Initiate a fetch from the store
+                    // and record the result as a prior.
+                    let store = store.clone();
+                    let path = path.clone();
+                    let final_priors = final_priors.clone();
+                    self.tp.execute(move || {
+                        let value = store.load_value(path).unwrap();
+                        final_priors.insert(path, value);
+                    });
+                }
+            }
+        }
+
+        // Wait for all the fetches to complete. After this point, priors contains the final set of
+        // values to be preserved.
+        self.tp.join();
+
+        Delta {
+            priors: Arc::into_inner(final_priors).unwrap().into_iter().collect(),
+        }
+    }
+}

--- a/nomt/src/rollback/tests.rs
+++ b/nomt/src/rollback/tests.rs
@@ -1,0 +1,171 @@
+use std::fs::OpenOptions;
+
+use super::{BTreeMap, KeyPath, KeyReadWrite, LoadValue, Rollback};
+use hex_literal::hex;
+
+const MAX_ROLLBACK_LOG_LEN: u32 = 100;
+
+/// A mock implementation of `LoadValue` for testing. Describes the "current" state of the
+/// database.
+#[derive(Clone)]
+struct MockStore {
+    values: BTreeMap<KeyPath, Option<Vec<u8>>>,
+}
+
+impl MockStore {
+    fn new() -> Self {
+        Self {
+            values: BTreeMap::new(),
+        }
+    }
+
+    fn insert(&mut self, key_path: KeyPath, value: Option<Vec<u8>>) {
+        self.values.insert(key_path, value);
+    }
+}
+
+impl LoadValue for MockStore {
+    fn load_value(&self, key_path: KeyPath) -> anyhow::Result<Option<Vec<u8>>> {
+        match self.values.get(&key_path) {
+            Some(value) => return Ok(value.clone()),
+            None => panic!("the caller requested a value that was not inserted by the test"),
+        }
+    }
+}
+
+#[test]
+fn truncate_works() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_dir_path = temp_dir.path().join("db");
+    std::fs::create_dir_all(&db_dir_path).unwrap();
+    let db_dir_fd = OpenOptions::new()
+        .read(true)
+        .open(db_dir_path.clone())
+        .unwrap();
+
+    let mut store = MockStore::new();
+    store.insert(
+        hex!("0101010101010101010101010101010101010101010101010101010101010101"),
+        Some(b"old_value1".to_vec()),
+    );
+    store.insert(
+        hex!("0202020202020202020202020202020202020202020202020202020202020202"),
+        Some(b"old_value2".to_vec()),
+    );
+    store.insert(
+        hex!("0303030303030303030303030303030303030303030303030303030303030303"),
+        Some(b"old_value3".to_vec()),
+    );
+
+    let rollback = Rollback::read(MAX_ROLLBACK_LOG_LEN, db_dir_path, db_dir_fd, 0, 0).unwrap();
+    let builder = rollback.delta_builder();
+    builder.tentative_preserve_prior(store.clone(), [1; 32]);
+    builder.tentative_preserve_prior(store.clone(), [2; 32]);
+    builder.tentative_preserve_prior(store.clone(), [3; 32]);
+    rollback
+        .commit(
+            store.clone(),
+            &[
+                (
+                    hex!("0101010101010101010101010101010101010101010101010101010101010101"),
+                    KeyReadWrite::Write(Some(b"new_value1".to_vec())),
+                ),
+                (
+                    hex!("0202020202020202020202020202020202020202020202020202020202020202"),
+                    KeyReadWrite::Write(Some(b"new_value2".to_vec())),
+                ),
+            ],
+            builder,
+        )
+        .unwrap();
+
+    // We want to see the old values for all the keys that have been changed during the commit.
+    let traceback = rollback.truncate(1).unwrap().unwrap();
+    assert_eq!(traceback.len(), 2);
+    assert_eq!(
+        traceback
+            .get(&hex!(
+                "0101010101010101010101010101010101010101010101010101010101010101"
+            ))
+            .unwrap()
+            .clone(),
+        Some(b"old_value1".to_vec())
+    );
+    assert_eq!(
+        traceback
+            .get(&hex!(
+                "0202020202020202020202020202020202020202020202020202020202020202"
+            ))
+            .unwrap()
+            .clone(),
+        Some(b"old_value2".to_vec())
+    );
+}
+
+#[test]
+fn without_tentative_preserve_prior() {
+    // A test where we don't call tentative_preserve_prior and expect that the commit will
+    // fetch the values itself.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_dir_path = temp_dir.path().join("db");
+    std::fs::create_dir_all(&db_dir_path).unwrap();
+    let db_dir_fd = OpenOptions::new()
+        .read(true)
+        .open(db_dir_path.clone())
+        .unwrap();
+
+    let mut store = MockStore::new();
+    store.insert(
+        hex!("0101010101010101010101010101010101010101010101010101010101010101"),
+        Some(b"old_value1".to_vec()),
+    );
+    store.insert(
+        hex!("0202020202020202020202020202020202020202020202020202020202020202"),
+        Some(b"old_value2".to_vec()),
+    );
+    store.insert(
+        hex!("0303030303030303030303030303030303030303030303030303030303030303"),
+        Some(b"old_value3".to_vec()),
+    );
+
+    let rollback = Rollback::read(MAX_ROLLBACK_LOG_LEN, db_dir_path, db_dir_fd, 0, 0).unwrap();
+    let builder = rollback.delta_builder();
+    rollback
+        .commit(
+            store.clone(),
+            &[
+                (
+                    hex!("0101010101010101010101010101010101010101010101010101010101010101"),
+                    KeyReadWrite::Write(Some(b"new_value1".to_vec())),
+                ),
+                (
+                    hex!("0202020202020202020202020202020202020202020202020202020202020202"),
+                    KeyReadWrite::Write(Some(b"new_value2".to_vec())),
+                ),
+            ],
+            builder,
+        )
+        .unwrap();
+
+    // We want to see the old values for all the keys that have been changed during the commit.
+    let traceback = rollback.truncate(1).unwrap().unwrap();
+    assert_eq!(traceback.len(), 2);
+    assert_eq!(
+        traceback
+            .get(&hex!(
+                "0101010101010101010101010101010101010101010101010101010101010101"
+            ))
+            .unwrap()
+            .clone(),
+        Some(b"old_value1".to_vec())
+    );
+    assert_eq!(
+        traceback
+            .get(&hex!(
+                "0202020202020202020202020202020202020202020202020202020202020202"
+            ))
+            .unwrap()
+            .clone(),
+        Some(b"old_value2".to_vec())
+    );
+}

--- a/nomt/src/seglog/mod.rs
+++ b/nomt/src/seglog/mod.rs
@@ -21,8 +21,6 @@
 //! There is a limit on the maximum size of a record payload, which is currently set to 1 GiB.
 //! However, this limit may be subject to change in future versions.
 
-#![allow(dead_code)]
-
 use anyhow::{ensure, Context, Result};
 use std::{
     fmt,
@@ -267,7 +265,10 @@ impl SegmentedLog {
     ///
     /// Prunes segments that lie outside of the new live range, i.e. deletes the old segments.
     ///
-    /// This function updates the live range.
+    /// This function updates the live range. Note, that this function is destructive, it deletes
+    /// segments from the file system. Should a crash happen after this function was executed but
+    /// before the manifest was updated, the recovery will fail. Therefore, you must ensure that
+    /// the manifest was updated before calling this function.
     ///
     /// It's possible to return remove all items from the log, i.e. to reset the log to an empty
     /// state, by setting the new live end to zero. That would update the live range to `(0, 0)`.
@@ -324,7 +325,10 @@ impl SegmentedLog {
     /// Prunes segments that lie outside of the new live range, i.e. deletes and truncates the
     /// segments to not include the items that lie after the new live end.
     ///
-    /// This function updates the live range.
+    /// This function updates the live range. Note, that this function is destructive, it deletes
+    /// segments from the file system. Should a crash happen after this function was executed but
+    /// before the manifest was updated, the recovery will fail. Therefore, you must ensure that
+    /// the manifest was updated before calling this function.
     ///
     /// It's possible to return remove all items from the log, i.e. to reset the log to an empty
     /// state, by setting the new live end to zero. That would update the live range to `(0, 0)`.

--- a/nomt/tests/rollback.rs
+++ b/nomt/tests/rollback.rs
@@ -1,0 +1,417 @@
+use hex_literal::hex;
+use nomt::{KeyPath, KeyReadWrite, Nomt, Options, Value};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
+
+/// Setup a NOMT with the given path, rollback enabled, and the given commit concurrency.
+///
+/// It's important that tests that run in parallel don't use the same path.
+fn setup_nomt(
+    path: &str,
+    rollback_enabled: bool,
+    commit_concurrency: usize,
+    should_clean_up: bool,
+) -> Nomt {
+    let path = {
+        let mut p = PathBuf::from("test");
+        p.push(path);
+        p
+    };
+    if should_clean_up && path.exists() {
+        std::fs::remove_dir_all(&path).unwrap();
+    }
+    let mut o = Options::new();
+    o.path(path);
+    o.commit_concurrency(commit_concurrency);
+    o.panic_on_sync(false);
+    o.bitbox_seed([0; 16]);
+    o.rollback(rollback_enabled);
+    Nomt::open(o).unwrap()
+}
+
+#[test]
+fn test_rollback_disabled() {
+    let nomt = setup_nomt(
+        "test_rollback_disabled",
+        /* enable_rollback */ false,
+        /* commit_concurrency */ 1,
+        /* should_clean_up */ true,
+    );
+
+    let session = nomt.begin_session();
+    nomt.commit(
+        session,
+        vec![(
+            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+            KeyReadWrite::Write(Some(vec![1])),
+        )],
+    )
+    .unwrap();
+
+    let result = nomt.rollback(1);
+    // we expect this to fail, because rollback is disabled
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_rollback_to_initial() {
+    let nomt = setup_nomt(
+        "test_rollback_to_initial",
+        /* enable_rollback */ true,
+        /* commit_concurrency */ 1,
+        /* should_clean_up */ true,
+    );
+
+    let session = nomt.begin_session();
+    nomt.commit(
+        session,
+        vec![(
+            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+            KeyReadWrite::Write(Some(vec![1])),
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        nomt.root(),
+        hex!("c6e25744545ddabdaf0a95201f8285e670ee9b3e0c1ced4a3006baafd1ac2fdf")
+    );
+
+    let result = nomt.rollback(1);
+    assert!(result.is_ok());
+    assert_eq!(
+        nomt.root(),
+        hex!("0000000000000000000000000000000000000000000000000000000000000000")
+    );
+}
+
+struct TestPlan {
+    /// Every key that will be inserted at some point.
+    ///
+    /// This is needed for exhaustive verification that no unexpected data is left in the tree.
+    every_key: BTreeSet<KeyPath>,
+    /// Keys to insert at the i-th commit.
+    to_insert: Vec<BTreeMap<KeyPath, Value>>,
+    /// Keys to remove at the i-th commit.
+    to_remove: Vec<BTreeSet<KeyPath>>,
+    /// Expected root before and after applying the i-th commit.
+    expected_roots: Vec<[u8; 32]>,
+    /// Expected values after applying the i-th commit.
+    expected_values: Vec<BTreeMap<KeyPath, Value>>,
+}
+
+impl TestPlan {
+    /// Generate a test plan for a NOMT with `n` commits. The zero-th commit always corresponds
+    /// to the initial empty tree.
+    fn generate(name: &'static str, n: usize) -> Self {
+        let mut every_key = BTreeSet::new();
+        let mut to_insert = Vec::new();
+        let mut to_remove = Vec::new();
+        let mut expected_roots = Vec::new();
+        let mut expected_values = Vec::new();
+
+        // Zero-th commit, or initial state: empty
+        expected_values.push(BTreeMap::new());
+        expected_roots.push([0; 32]);
+
+        let mut state_emu = BTreeMap::new();
+
+        for commit_ix in 1..(n + 1) {
+            let mut per_commit_insert = BTreeMap::new();
+            let mut per_commit_remove = BTreeSet::new();
+
+            // Add 3 new keys each iteration
+            for j in 0..3 {
+                let mut key = [0u8; 32];
+                key[30] = commit_ix as u8;
+                key[31] = j as u8;
+                let key = *blake3::hash(&key).as_bytes();
+                let value: Vec<u8> = blake3::hash(&key).as_bytes().to_vec();
+                // vec![commit_ix as u8, j as u8];
+
+                per_commit_insert.insert(key, value.clone());
+                every_key.insert(key);
+                state_emu.insert(key.clone(), value.clone());
+            }
+
+            // Remove 1 key (if possible) each iteration
+            if commit_ix > 1 {
+                let mut key = [0u8; 32];
+                key[30] = (commit_ix - 1) as u8;
+                key[31] = 0;
+
+                let key = *blake3::hash(&key).as_bytes();
+                per_commit_remove.insert(key);
+                every_key.insert(key);
+                state_emu.remove(&key);
+            }
+
+            expected_values.push(state_emu.clone());
+            to_insert.push(per_commit_insert);
+            to_remove.push(per_commit_remove);
+        }
+
+        // Compute expected roots for each commit. We do that using the NOMT with a temporary
+        // directory.
+        let nomt = setup_nomt(
+            &format!("tmp_{name}"),
+            /* enable_rollback */ false,
+            /* commit_concurrency */ 1,
+            /* should_clean_up */ true,
+        );
+
+        for commit_no in 0..n {
+            println!("commit_no: {}", commit_no);
+            println!(
+                "adding keys: {}",
+                display_keys_and_values(to_insert[commit_no].iter())
+            );
+            println!(
+                "removing keys: {}",
+                display_keys(to_remove[commit_no].iter())
+            );
+            let session = nomt.begin_session();
+            let mut operations = Vec::new();
+            for (key, value) in to_insert[commit_no].iter() {
+                operations.push((key.clone(), KeyReadWrite::Write(Some(value.clone()))));
+            }
+            for key in to_remove[commit_no].iter() {
+                operations.push((key.clone(), KeyReadWrite::Write(None)));
+            }
+            operations.sort_by_key(|(key, _)| key.clone());
+            nomt.commit(session, operations).unwrap();
+            let post_root = nomt.root();
+            expected_roots.push(post_root);
+        }
+
+        Self {
+            every_key,
+            to_insert,
+            to_remove,
+            expected_roots,
+            expected_values,
+        }
+    }
+
+    fn apply_forward(&self, nomt: &mut Nomt) {
+        for commit_no in 0..self.to_insert.len() {
+            let session = nomt.begin_session();
+            let mut operations = Vec::new();
+            for (key, value) in self.to_insert[commit_no].iter() {
+                operations.push((key.clone(), KeyReadWrite::Write(Some(value.clone()))));
+            }
+            for key in self.to_remove[commit_no].iter() {
+                operations.push((key.clone(), KeyReadWrite::Write(None)));
+            }
+            operations.sort_by_key(|(key, _)| key.clone());
+            nomt.commit(session, operations).unwrap();
+        }
+    }
+
+    fn verify_restored_state(&self, nomt: &mut Nomt, commit_ix: usize) {
+        let mut errors: Vec<String> = vec![];
+
+        let expected: BTreeMap<KeyPath, Value> = self.expected_values[commit_ix].clone();
+        let unexpected: BTreeSet<KeyPath> = self
+            .every_key
+            .difference(&expected.keys().copied().collect())
+            .copied()
+            .collect();
+
+        // Verify that all expected keys are in place and have the correct value.
+        for (key, expected_value) in expected {
+            let actual_value = nomt.read(key).unwrap();
+            if actual_value.is_none() {
+                errors.push(format!(
+                    "missing: the key {:x?} is not present",
+                    hex::encode(key)
+                ));
+            } else if actual_value.as_ref() != Some(&expected_value) {
+                errors.push(format!(
+                    "wrong value: the key {:x?} has the wrong value. Expected {:x?}, found {:x?}",
+                    key,
+                    hex::encode(expected_value),
+                    hex::encode(actual_value.unwrap())
+                ));
+            }
+        }
+
+        // Verify that no unexpected keys are in the tree.
+        for key in unexpected {
+            let actual_value = nomt.read(key).unwrap();
+            if let Some(value) = actual_value {
+                errors.push(format!(
+                    "unexpected: the key {:x?} is present in the tree with the value {:x?}",
+                    hex::encode(key),
+                    hex::encode(value)
+                ));
+            }
+        }
+
+        if nomt.root() != self.expected_roots[commit_ix] {
+            errors.push(format!(
+                "wrong root: expected {:x?}, found {:x?}",
+                hex::encode(self.expected_roots[commit_ix]),
+                hex::encode(nomt.root())
+            ));
+        }
+
+        if !errors.is_empty() {
+            panic!(
+                "verification failed of commit {}: \n{}",
+                commit_ix,
+                errors.join("\n")
+            );
+        }
+    }
+}
+
+fn display_keys<'a>(keys: impl IntoIterator<Item = &'a KeyPath>) -> String {
+    let mut keys: Vec<_> = keys.into_iter().collect();
+    keys.sort();
+    keys.iter()
+        .map(|k| hex::encode(k))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn display_keys_and_values<'a>(kv: impl IntoIterator<Item = (&'a KeyPath, &'a Value)>) -> String {
+    let mut kv: Vec<_> = kv.into_iter().collect();
+    kv.sort();
+    kv.iter()
+        .map(|(k, v)| format!("{} -> {}", hex::encode(k), hex::encode(v)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn test_rollback_all() {
+    let n = 10;
+    let plan = TestPlan::generate("all", n);
+    let mut nomt = setup_nomt(
+        "test_rollback_all",
+        /* enable_rollback */ true,
+        /* commit_concurrency */ 10,
+        /* should_clean_up */ true,
+    );
+
+    plan.apply_forward(&mut nomt);
+    nomt.rollback(n).unwrap();
+    plan.verify_restored_state(&mut nomt, 0);
+}
+
+#[test]
+fn test_rollback_one_by_one() {
+    let n = 10;
+    let plan = TestPlan::generate("one_by_one", n);
+    let mut nomt = setup_nomt(
+        "one_by_one",
+        /* enable_rollback */ true,
+        /* commit_concurrency */ 10,
+        /* should_clean_up */ true,
+    );
+
+    plan.apply_forward(&mut nomt);
+
+    for i in (0..n).rev() {
+        nomt.rollback(1).unwrap();
+        plan.verify_restored_state(&mut nomt, i);
+    }
+}
+
+#[test]
+fn test_rollback_multiple_equivalence() {
+    let n = 10;
+    let plan = TestPlan::generate("multiple_equivalence", n);
+    let mut nomt = setup_nomt(
+        "multiple_equivalence",
+        /* rollback_enabled */ true,
+        /* commit_concurrency */ 10,
+        /* should_clean_up */ true,
+    );
+    plan.apply_forward(&mut nomt);
+
+    // Rollback 2 commits at a time
+    nomt.rollback(2).unwrap();
+    plan.verify_restored_state(&mut nomt, 8);
+
+    nomt.rollback(2).unwrap();
+    plan.verify_restored_state(&mut nomt, 6);
+
+    nomt.rollback(2).unwrap();
+    plan.verify_restored_state(&mut nomt, 4);
+
+    nomt.rollback(2).unwrap();
+    plan.verify_restored_state(&mut nomt, 2);
+
+    nomt.rollback(2).unwrap();
+    plan.verify_restored_state(&mut nomt, 0);
+}
+
+#[test]
+fn test_rollback_reopen() {
+    // This test ensures that we can still rollback after restarting of NOMT.
+    let n = 10;
+    let plan = TestPlan::generate("rollback_reopen", n);
+    let mut nomt = setup_nomt(
+        "rollback_reopen",
+        /* rollback_enabled */ true,
+        /* commit_concurrency */ 10,
+        /* should_clean_up */ true,
+    );
+
+    plan.apply_forward(&mut nomt);
+    nomt.rollback(2).unwrap();
+    plan.verify_restored_state(&mut nomt, 8);
+
+    // Reopen the NOMT and rollback again.
+    let mut nomt = setup_nomt(
+        "rollback_reopen",
+        /* rollback_enabled */ true,
+        /* commit_concurrency */ 10,
+        /* should_clean_up */ false, // <<<<<
+    );
+    nomt.rollback(2).unwrap();
+    plan.verify_restored_state(&mut nomt, 6);
+}
+
+#[test]
+fn test_rollback_change_history() {
+    let n = 10;
+    let plan = TestPlan::generate("rollback_change_history", n);
+    let mut nomt = setup_nomt(
+        "rollback_change_history",
+        /* rollback_enabled */ true,
+        /* commit_concurrency */ 10,
+        /* should_clean_up */ true,
+    );
+
+    // 1. Do some commits
+    plan.apply_forward(&mut nomt);
+    plan.verify_restored_state(&mut nomt, n);
+
+    // 2. Rollback some commits
+    nomt.rollback(3).unwrap();
+    plan.verify_restored_state(&mut nomt, 7);
+
+    // 3. Create new commits
+    let session = nomt.begin_session();
+    let new_key = KeyPath::from([0xAA; 32]);
+    let new_value = vec![0xBB; 32];
+    nomt.commit(
+        session,
+        vec![(new_key, KeyReadWrite::Write(Some(new_value.clone())))],
+    )
+    .unwrap();
+
+    // Verify the new state
+    assert_eq!(nomt.read(new_key).unwrap(), Some(new_value));
+
+    // 4. Rollback to the original history
+    nomt.rollback(1).unwrap();
+    plan.verify_restored_state(&mut nomt, 7);
+
+    // Verify that the new key is gone
+    assert_eq!(nomt.read(new_key).unwrap(), None);
+}


### PR DESCRIPTION
This changeset implements a rollback feature.

The rollback feature allows NOMT to roll back to
a previous commit state.

It is implemented by storing a reverse delta for
each commit. When rolling back, we apply the reverse
delta to the current state to restore the previous
state.

To gather the reverse delta NOMT collects the
prior values of the keys that are being modified
or removed. When committing, it uses this information
to create a reverse delta. To that end,
the Session object has a `preserve_prior_value` method
that the caller should call for each key that they wish
to preserve.

The definitive set of values to be committed is
determined by the `Nomt::commit` call. As such,
there is no issue with invoking this function for
values that may not ultimately be written.
Similarly, values that were not marked for
preservation during the session but are included
in the final set will still be preserved. However,
if the user does not call `preserve_prior_value`
then the prior values will be fetched during the
commit process which degrades performance.