### PR TITLE
chore: de-glob imports

### DIFF
--- a/core/src/multi_proof_verification.rs
+++ b/core/src/multi_proof_verification.rs
@@ -251,7 +251,10 @@ fn verify_range<H: NodeHasher>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        verify, InternalData, LeafData, MultiProof, NodeHasher, NodeHasherExt, PathProofTerminal,
+        TERMINATOR,
+    };
     use crate::{proof::PathProof, trie};
 
     /// Hash nodes with blake3.

--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -267,7 +267,11 @@ impl Iterator for PageIdsIterator {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        ChildPageIdError, ChildPageIndex, InvalidPageIdBytes, Msb0, PageId, PageIdsIterator, Uint,
+        HIGHEST_ENCODED_42, MAX_CHILD_INDEX, ROOT_PAGE_ID,
+    };
+    use bitvec::prelude::*;
 
     const LOWEST_ENCODED_42: Uint<256, 4> = Uint::from_be_bytes([
         0, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16, 65, 4, 16,

--- a/core/src/trie_pos.rs
+++ b/core/src/trie_pos.rs
@@ -337,7 +337,7 @@ impl ChildNodeIndices {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::TriePosition;
 
     #[test]
     fn path_can_go_deeper_255_bit() {

--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -252,7 +252,10 @@ pub fn build_trie<H: NodeHasher>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        bitvec, build_trie, trie, BitVec, LeafData, Msb0, Node, NodeHasher, NodeHasherExt,
+        WriteNode,
+    };
 
     struct DummyNodeHasher;
 

--- a/nomt/src/beatree/allocator/free_list.rs
+++ b/nomt/src/beatree/allocator/free_list.rs
@@ -401,7 +401,7 @@ impl<'a> FreeListPageMut<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{FreeList, PageNumber, PagePool, MAX_PNS_PER_PAGE};
 
     #[test]
     fn pop_into_next_portion_one_page_needed() {

--- a/nomt/src/beatree/leaf/overflow.rs
+++ b/nomt/src/beatree/leaf/overflow.rs
@@ -220,7 +220,9 @@ fn read_page<'a>(page: &'a FatPage) -> (impl Iterator<Item = PageNumber> + 'a, &
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        needed_pages, total_needed_pages, BODY_SIZE, MAX_OVERFLOW_CELL_NODE_POINTERS, MAX_PNS,
+    };
 
     #[test]
     fn total_needed_pages_all_in_cell() {

--- a/nomt/src/beatree/ops/update/branch_updater.rs
+++ b/nomt/src/beatree/ops/update/branch_updater.rs
@@ -462,7 +462,11 @@ impl BranchBulkSplitter {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        get_key, prefix_len, Arc, BaseBranch, BranchGauge, BranchNode, BranchNodeBuilder,
+        BranchUpdater, BranchesTracker, DigestResult, Key, PageNumber, PagePool,
+        BRANCH_MERGE_THRESHOLD, BRANCH_NODE_BODY_SIZE,
+    };
     use crate::beatree::ops::bit_ops::separator_len;
 
     lazy_static::lazy_static! {

--- a/nomt/src/beatree/ops/update/leaf_updater.rs
+++ b/nomt/src/beatree/ops/update/leaf_updater.rs
@@ -431,7 +431,10 @@ impl LeafGauge {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        separate, BaseLeaf, DigestResult, Key, LeafBuilder, LeafNode, LeafOp, LeafUpdater,
+        LeavesTracker, PagePool,
+    };
 
     lazy_static::lazy_static! {
         static ref PAGE_POOL: PagePool = PagePool::new();

--- a/nomt/src/bitbox/wal/mod.rs
+++ b/nomt/src/bitbox/wal/mod.rs
@@ -282,9 +282,8 @@ impl WalBlobReader {
 
 #[cfg(test)]
 mod tests {
+    use super::{PageDiff, PagePool, WalBlobBuilder, WalBlobReader, WalEntry};
     use std::{fs::OpenOptions, io::Write as _, os::unix::fs::OpenOptionsExt as _};
-
-    use super::*;
 
     #[test]
     fn test_write_read() {

--- a/nomt/src/page_region.rs
+++ b/nomt/src/page_region.rs
@@ -175,7 +175,7 @@ unsafe impl RegionContains<PageId> for PageRegion {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{ChildPageIndex, PageRegion, ROOT_PAGE_ID};
     use nomt_core::page_id::MAX_CHILD_INDEX;
 
     // test that exclusivity is bidirectional doesn't affect the result, then return the result.

--- a/nomt/src/page_walker.rs
+++ b/nomt/src/page_walker.rs
@@ -781,8 +781,12 @@ fn get_page(page_source: &PageSource, page_id: PageId) -> Option<Page> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        trie, Node, NodeHasherExt, Output, PageCache, PagePool, PageSource, PageWalker,
+        TriePosition, ROOT_PAGE_ID,
+    };
     use crate::Blake3Hasher;
+    use bitvec::prelude::*;
     use nomt_core::page_id::ChildPageIndex;
 
     macro_rules! trie_pos {

--- a/nomt/src/seglog/segment_rw.rs
+++ b/nomt/src/seglog/segment_rw.rs
@@ -166,7 +166,10 @@ impl SegmentFileReader {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        File, RecordId, SegmentFileReader, SegmentFileWriter, HEADER_SIZE, MAX_RECORD_PAYLOAD_SIZE,
+        RECORD_ALIGNMENT,
+    };
     use tempfile::NamedTempFile;
 
     #[test]


### PR DESCRIPTION
avoid using glob imports for tests. Only one exception: prelude.