### PR TITLE
chore: run CI only on pull requests and pushes to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 env:


### PR DESCRIPTION
this gets more important with #482 since it adds more jobs and that gets the total number of jobs to 4 when we only need 2 per PR.