### PR TITLE
opt: pre-sort writes

### DIFF
--- a/nomt/src/beatree/writeout.rs
+++ b/nomt/src/beatree/writeout.rs
@@ -55,13 +55,16 @@ pub fn write_bbn(
 pub fn write_ln(
     io_handle: IoHandle,
     ln_fd: &File,
-    ln: Vec<(PageNumber, FatPage)>,
-    ln_free_list_pages: Vec<(PageNumber, FatPage)>,
+    mut ln: Vec<(PageNumber, FatPage)>,
+    mut ln_free_list_pages: Vec<(PageNumber, FatPage)>,
     ln_extend_file_sz: Option<u64>,
 ) -> anyhow::Result<()> {
     if let Some(new_len) = ln_extend_file_sz {
         ln_fd.set_len(new_len)?;
     }
+
+    ln.sort_unstable_by_key(|item| item.0.0);
+    ln_free_list_pages.sort_unstable_by_key(|item| item.0.0);
 
     let mut sent = 0;
     for (pn, page) in ln {

--- a/nomt/src/bitbox/writeout.rs
+++ b/nomt/src/bitbox/writeout.rs
@@ -27,8 +27,10 @@ pub fn truncate_wal(mut wal_fd: &File) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn write_ht(io_handle: IoHandle, ht_fd: &File, ht: Vec<(u64, FatPage)>) -> anyhow::Result<()> {
+pub fn write_ht(io_handle: IoHandle, ht_fd: &File, mut ht: Vec<(u64, FatPage)>) -> anyhow::Result<()> {
     let mut sent = 0;
+
+    ht.sort_unstable_by_key(|item| item.0);
     for (pn, page) in ht {
         io_handle
             .send(IoCommand {


### PR DESCRIPTION
This optimization is a bit more tentative.

The overhead of sorting is relatively low, but it seems to help with the throughput of HT writes in particular.