### PR TITLE
refactor: decouple BranchNode and FatPage

### DIFF
--- a/nomt/src/beatree/branch/mod.rs
+++ b/nomt/src/beatree/branch/mod.rs
@@ -1,4 +1,4 @@
-pub use node::{body_size, BranchNode, BranchNodeBuilder, BranchNodeView, BRANCH_NODE_BODY_SIZE};
+pub use node::{body_size, BranchNode, BranchNodeBuilder, BRANCH_NODE_BODY_SIZE};
 pub mod node;
 
 pub const BRANCH_NODE_SIZE: usize = 4096;

--- a/nomt/src/beatree/ops/mod.rs
+++ b/nomt/src/beatree/ops/mod.rs
@@ -134,7 +134,7 @@ pub mod benches {
                 .collect();
             separators.sort_by(|a, b| a.1.cmp(&b.1));
 
-            let branch_node = BranchNode::new_in(&page_pool);
+            let branch_node = BranchNode::new_fat(&page_pool);
             let mut branch_node_builder =
                 BranchNodeBuilder::new(branch_node, n, prefix_len_bits, 256);
 

--- a/nomt/src/beatree/ops/reconstruction.rs
+++ b/nomt/src/beatree/ops/reconstruction.rs
@@ -13,7 +13,7 @@ use std::{collections::BTreeSet, fs::File, os::fd::AsRawFd, ptr, sync::Arc};
 
 use crate::beatree::{
     allocator::PageNumber,
-    branch::{BranchNode, BranchNodeView, BRANCH_NODE_SIZE},
+    branch::{BranchNode, BRANCH_NODE_SIZE},
     index::Index,
 };
 use crate::io::PagePool;
@@ -30,7 +30,7 @@ pub fn reconstruct(
 
     let mut chunker = SeqFileReader::new(bn_fd, bump.0)?;
     while let Some((pn, node)) = chunker.next()? {
-        let view = BranchNodeView::from_slice(node);
+        let view = BranchNode::new(&node[..]);
 
         if view.n() == 0 && node == [0; BRANCH_NODE_SIZE] {
             // Just skip empty nodes.
@@ -48,7 +48,7 @@ pub fn reconstruct(
             pn
         );
 
-        let mut branch = BranchNode::new_in(&page_pool);
+        let mut branch = BranchNode::new_fat(&page_pool);
         branch.as_mut_slice().copy_from_slice(node);
 
         let mut separator = [0u8; 32];

--- a/nomt/src/beatree/ops/update/branch_updater.rs
+++ b/nomt/src/beatree/ops/update/branch_updater.rs
@@ -305,7 +305,7 @@ impl BranchUpdater {
     }
 
     fn build_branch(&self, ops: &[BranchOp], gauge: &BranchGauge) -> BranchNode {
-        let branch = BranchNode::new_in(&self.page_pool);
+        let branch = BranchNode::new_fat(&self.page_pool);
 
         // UNWRAP: freshly allocated branch can always be checked out.
         let mut builder = BranchNodeBuilder::new(
@@ -528,7 +528,7 @@ mod tests {
             prefix_len(&vs[0].0, &vs[vs.len() - 1].0)
         };
 
-        let branch = BranchNode::new_in(&PAGE_POOL);
+        let branch = BranchNode::new_fat(&PAGE_POOL);
         let mut builder = BranchNodeBuilder::new(branch, n, n, prefix_len);
         for (k, pn) in vs {
             builder.push(k, separator_len(&k), pn as u32);

--- a/nomt/src/io/page_pool.rs
+++ b/nomt/src/io/page_pool.rs
@@ -271,3 +271,87 @@ impl<'a> Deallocator<'a> {
         self.freelist.push(page);
     }
 }
+
+/// An immutable view into a raw page.
+pub struct UnsafePageView {
+    page: Page,
+}
+
+impl UnsafePageView {
+    /// Create a new view into a page.
+    ///
+    /// ## Safety
+    ///
+    /// The caller is responsible for ensuring that:
+    ///   - The page pool which originated the page will be alive for the lifetime of this view.
+    ///   - No mutable references are taken into the page for the duration of its lifetime.
+    ///   - The page will remain live for the duration of this lifetime.
+    pub unsafe fn new(page: Page) -> UnsafePageView {
+        UnsafePageView {
+            page,
+        }
+    }
+
+    /// Consume this view, accessing the inner page.
+    pub fn into_inner(self) -> Page {
+        self.page
+    }
+}
+
+impl Deref for UnsafePageView {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        // SAFETY: aliasing and liveness are guaranteed by this struct being 'unsafe'.
+        unsafe {
+            self.page.as_mut_slice()
+        }
+    }
+}
+
+/// A mutable view into a raw page.
+pub struct UnsafePageViewMut {
+    page: Page,
+}
+
+impl UnsafePageViewMut {
+    /// Create a new view into a page.
+    ///
+    /// ## Safety
+    ///
+    /// The caller is responsible for ensuring that:
+    ///   - The page pool which originated the page will be alive for the lifetime of this view.
+    ///   - No other references are taken into the page data for the duration of its lifetime.
+    ///   - The page will remain live for the duration of its lifetime.
+    pub unsafe fn new(page: Page) -> UnsafePageViewMut {
+        UnsafePageViewMut {
+            page,
+        }
+    }
+
+
+    /// Consume this view, accessing the inner page.
+    pub fn into_inner(self) -> Page {
+        self.page
+    }
+}
+
+impl Deref for UnsafePageViewMut {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        // SAFETY: aliasing and liveness are guaranteed by this struct being 'unsafe'.
+        unsafe {
+            self.page.as_mut_slice()
+        }
+    }
+}
+
+impl DerefMut for UnsafePageViewMut {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        // SAFETY: aliasing and liveness are guaranteed by this struct being 'unsafe'.
+        unsafe {
+            self.page.as_mut_slice()
+        }
+    }
+}


### PR DESCRIPTION
See the next PR - this sets the ground for not tightly coupling FatPage to branches, letting us have ~free page operations with manual memory management.

