### PR TITLE
refactor: expunge FatPage from beatree/branch

### DIFF
--- a/nomt/src/beatree/index.rs
+++ b/nomt/src/beatree/index.rs
@@ -3,16 +3,15 @@
 
 use std::iter::DoubleEndedIterator;
 use std::ops::{Bound, RangeBounds, RangeToInclusive};
-use std::sync::Arc;
 
 use im::OrdMap;
 
 use super::Key;
-use crate::beatree::branch::BranchNode;
+use crate::io::page_pool::Page;
 
 #[derive(Default, Clone)]
 pub struct Index {
-    first_key_map: OrdMap<Key, Arc<BranchNode>>,
+    first_key_map: OrdMap<Key, Page>,
 }
 
 impl Index {
@@ -20,7 +19,7 @@ impl Index {
     ///
     /// This is either a branch whose separator is exactly equal to this key or the branch with the
     /// highest separator less than the key.
-    pub fn lookup(&self, key: Key) -> Option<(Key, Arc<BranchNode>)> {
+    pub fn lookup(&self, key: Key) -> Option<(Key, Page)> {
         self.first_key_map
             .range(RangeToInclusive { end: key })
             .next_back()
@@ -28,7 +27,7 @@ impl Index {
     }
 
     /// Get the first branch with separator greater than the given key.
-    pub fn next_after(&self, key: Key) -> Option<(Key, Arc<BranchNode>)> {
+    pub fn next_after(&self, key: Key) -> Option<(Key, Page)> {
         self.first_key_map
             .range(RangeFromExclusive { start: key })
             .next()
@@ -36,13 +35,13 @@ impl Index {
     }
 
     /// Remove the branch with the given separator key.
-    pub fn remove(&mut self, separator: &Key) -> Option<Arc<BranchNode>> {
+    pub fn remove(&mut self, separator: &Key) -> Option<Page> {
         self.first_key_map.remove(separator)
     }
 
     /// Insert a branch with the given separator key.
-    pub fn insert(&mut self, separator: Key, branch: Arc<BranchNode>) -> Option<Arc<BranchNode>> {
-        self.first_key_map.insert(separator, branch)
+    pub fn insert(&mut self, separator: Key, branch_page: Page) -> Option<Page> {
+        self.first_key_map.insert(separator, branch_page)
     }
 }
 

--- a/nomt/src/io/page_pool.rs
+++ b/nomt/src/io/page_pool.rs
@@ -273,6 +273,7 @@ impl<'a> Deallocator<'a> {
 }
 
 /// An immutable view into a raw page.
+#[derive(Clone)]
 pub struct UnsafePageView {
     page: Page,
 }
@@ -287,9 +288,7 @@ impl UnsafePageView {
     ///   - No mutable references are taken into the page for the duration of its lifetime.
     ///   - The page will remain live for the duration of this lifetime.
     pub unsafe fn new(page: Page) -> UnsafePageView {
-        UnsafePageView {
-            page,
-        }
+        UnsafePageView { page }
     }
 
     /// Consume this view, accessing the inner page.
@@ -303,9 +302,7 @@ impl Deref for UnsafePageView {
 
     fn deref(&self) -> &[u8] {
         // SAFETY: aliasing and liveness are guaranteed by this struct being 'unsafe'.
-        unsafe {
-            self.page.as_mut_slice()
-        }
+        unsafe { self.page.as_mut_slice() }
     }
 }
 
@@ -324,15 +321,17 @@ impl UnsafePageViewMut {
     ///   - No other references are taken into the page data for the duration of its lifetime.
     ///   - The page will remain live for the duration of its lifetime.
     pub unsafe fn new(page: Page) -> UnsafePageViewMut {
-        UnsafePageViewMut {
-            page,
-        }
+        UnsafePageViewMut { page }
     }
-
 
     /// Consume this view, accessing the inner page.
     pub fn into_inner(self) -> Page {
         self.page
+    }
+
+    /// Make this into a shared view.
+    pub fn into_shared(self) -> UnsafePageView {
+        UnsafePageView { page: self.page }
     }
 }
 
@@ -341,17 +340,13 @@ impl Deref for UnsafePageViewMut {
 
     fn deref(&self) -> &[u8] {
         // SAFETY: aliasing and liveness are guaranteed by this struct being 'unsafe'.
-        unsafe {
-            self.page.as_mut_slice()
-        }
+        unsafe { self.page.as_mut_slice() }
     }
 }
 
 impl DerefMut for UnsafePageViewMut {
     fn deref_mut(&mut self) -> &mut [u8] {
         // SAFETY: aliasing and liveness are guaranteed by this struct being 'unsafe'.
-        unsafe {
-            self.page.as_mut_slice()
-        }
+        unsafe { self.page.as_mut_slice() }
     }
 }


### PR DESCRIPTION
This revives the original idea of having beatree::prepare_sync produce a list of pages to deallocate at the end. We didn't need that before, because FatPage did all the work.

All the `BranchNode<UnsafePageView>` stuff is kind of ugly and could be condensed, either with a typedef or by just separating the types `BranchNode` and `BranchNodeMut`.