### PR TITLE
refactor: expunge FatPage from beatree/leaf

### DIFF
--- a/nomt/src/beatree/writeout.rs
+++ b/nomt/src/beatree/writeout.rs
@@ -60,7 +60,7 @@ pub fn write_bbn(
 pub fn write_ln(
     io_handle: IoHandle,
     ln_fd: &File,
-    ln: Vec<(PageNumber, FatPage)>,
+    ln: &[(PageNumber, UnsafePageView)],
     ln_free_list_pages: Vec<(PageNumber, FatPage)>,
     ln_extend_file_sz: Option<u64>,
 ) -> anyhow::Result<()> {
@@ -72,7 +72,12 @@ pub fn write_ln(
     for (pn, page) in ln {
         io_handle
             .send(crate::io::IoCommand {
-                kind: crate::io::IoKind::Write(ln_fd.as_raw_fd(), pn.0 as u64, page),
+                kind: crate::io::IoKind::WriteRaw(
+                    ln_fd.as_raw_fd(),
+                    pn.0 as u64,
+                    page.as_ptr(),
+                    page.len(),
+                ),
                 user_data: 0,
             })
             .unwrap();

--- a/nomt/src/io/linux.rs
+++ b/nomt/src/io/linux.rs
@@ -135,6 +135,11 @@ fn submission_entry(command: &mut IoCommand) -> squeue::Entry {
                 .offset(page_index * PAGE_SIZE as u64)
                 .build()
         }
+        IoKind::ReadRaw(fd, page_index, ptr, size) => {
+            opcode::Read::new(types::Fd(fd), ptr, size as u32)
+                .offset(page_index * PAGE_SIZE as u64)
+                .build()
+        }
         IoKind::Write(fd, page_index, ref page) => {
             opcode::Write::new(types::Fd(fd), page.as_ptr(), PAGE_SIZE as u32)
                 .offset(page_index * PAGE_SIZE as u64)

--- a/nomt/src/io/unix.rs
+++ b/nomt/src/io/unix.rs
@@ -40,6 +40,14 @@ fn execute(mut command: IoCommand) -> CompleteIo {
                     (page_index * PAGE_SIZE as u64) as libc::off_t,
                 )
             },
+            IoKind::ReadRaw(fd, page_index, ptr, size) => unsafe {
+                libc::pread(
+                    fd,
+                    ptr as *mut libc::c_void,
+                    PAGE_SIZE as libc::size_t,
+                    (page_index * PAGE_SIZE as u64) as libc::off_t,
+                )
+            },
             IoKind::Write(fd, page_index, ref page) => unsafe {
                 libc::pwrite(
                     fd,


### PR DESCRIPTION
Similar to the previous PR, I replaced uses of `FatPage` with raw `Page`s in leaf logic.
