### PR TITLE
opt(rollback): don't fetch read-then-write

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -462,9 +462,12 @@ impl Session {
     ///    not marked here but included in the final set will still be preserved.
     /// 3. While this function helps optimize I/O, it's not strictly necessary for correctness.
     ///    The commit process will ensure all required prior values are preserved.
+    /// 4. If the path is given to [`Nomt::commit`] with the `ReadThenWrite` operation, calling
+    ///    this function is not needed as the prior value will be taken from there.
     ///
     /// For best performance, call this function once for each key you expect to write during the
-    /// session. The earlier this call is issued, the better for efficiency.
+    /// session, except for those that will be part of a `ReadThenWrite` operation. The earlier
+    /// this call is issued, the better for efficiency.
     pub fn preserve_prior_value(&self, path: KeyPath) {
         if let Some(rollback) = &self.rollback_delta {
             rollback.tentative_preserve_prior(self.store.clone(), path);

--- a/nomt/src/rollback/tests.rs
+++ b/nomt/src/rollback/tests.rs
@@ -1,4 +1,4 @@
-use std::fs::OpenOptions;
+use std::{collections::BTreeSet, fs::OpenOptions};
 
 use super::{BTreeMap, KeyPath, KeyReadWrite, LoadValue, Rollback};
 use hex_literal::hex;
@@ -10,22 +10,43 @@ const MAX_ROLLBACK_LOG_LEN: u32 = 100;
 #[derive(Clone)]
 struct MockStore {
     values: BTreeMap<KeyPath, Option<Vec<u8>>>,
+    traps: BTreeSet<KeyPath>,
 }
 
 impl MockStore {
     fn new() -> Self {
         Self {
             values: BTreeMap::new(),
+            traps: BTreeSet::new(),
         }
     }
 
+    /// Insert a value into the store that will be served by `load_value`.
     fn insert(&mut self, key_path: KeyPath, value: Option<Vec<u8>>) {
+        assert!(
+            !self.traps.contains(&key_path),
+            "the caller is trying to insert a value that was trapped by the test"
+        );
         self.values.insert(key_path, value);
+    }
+
+    /// Mark a key path as being trapped. If `load_value` is called with a trapped key path, the
+    /// test will fail.
+    fn trap(&mut self, key_path: KeyPath) {
+        assert!(
+            !self.values.contains_key(&key_path),
+            "the caller is trying to trap a value that was already inserted by the test"
+        );
+        self.traps.insert(key_path);
     }
 }
 
 impl LoadValue for MockStore {
     fn load_value(&self, key_path: KeyPath) -> anyhow::Result<Option<Vec<u8>>> {
+        if self.traps.contains(&key_path) {
+            panic!("the caller requested a value that was trapped by the test");
+        }
+
         match self.values.get(&key_path) {
             Some(value) => return Ok(value.clone()),
             None => panic!("the caller requested a value that was not inserted by the test"),
@@ -167,5 +188,49 @@ fn without_tentative_preserve_prior() {
             .unwrap()
             .clone(),
         Some(b"old_value2".to_vec())
+    );
+}
+
+#[test]
+fn delta_builder_doesnt_load_read_then_write_priors() {
+    // This test ensures that the delta builder does not attempt to load the prior value for
+    // ReadThenWrite operations.
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_dir_path = temp_dir.path().join("db");
+    std::fs::create_dir_all(&db_dir_path).unwrap();
+    let db_dir_fd = OpenOptions::new()
+        .read(true)
+        .open(db_dir_path.clone())
+        .unwrap();
+
+    let key_1 = hex!("0101010101010101010101010101010101010101010101010101010101010101");
+
+    let mut store = MockStore::new();
+    store.trap(key_1);
+
+    let rollback = Rollback::read(MAX_ROLLBACK_LOG_LEN, db_dir_path, db_dir_fd, 0, 0).unwrap();
+    let builder = rollback.delta_builder();
+    rollback
+        .commit(
+            store,
+            &[(
+                key_1,
+                KeyReadWrite::ReadThenWrite(
+                    Some(b"prior_value".to_vec()),
+                    Some(b"new_value1".to_vec()),
+                ),
+            )],
+            builder,
+        )
+        // This will panic if the delta builder attempts to load from store the prior value for
+        // key_1.
+        .unwrap();
+
+    // We expect that the traceback will contain the specified prior value for key_1.
+    let traceback = rollback.truncate(1).unwrap().unwrap();
+    assert_eq!(
+        traceback.get(&key_1).unwrap(),
+        &Some(b"prior_value".to_vec())
     );
 }


### PR DESCRIPTION
This changeset implements an optimization suggested by @rphmeier to
elide fetches to the store for the keys that were passed in Nomt::commit
as ReadThenWrite.

Note that this doesn't check if that was the actual value and blindly
trusts the user to correctly specify the value, as doing so will
actually makes no sense performance-wise.