### PR TITLE
feat: make merkle warm-ups configurable, off by default

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -216,7 +216,7 @@ impl Nomt {
         let page_cache = PageCache::new(root_page, &o, metrics.clone());
         let root = compute_root_node::<Blake3Hasher>(&page_cache);
         Ok(Self {
-            commit_pool: CommitPool::new(o.commit_concurrency),
+            commit_pool: CommitPool::new(o.commit_concurrency, o.warm_up),
             page_cache,
             page_pool,
             store,

--- a/nomt/src/options.rs
+++ b/nomt/src/options.rs
@@ -16,6 +16,7 @@ pub struct Options {
     pub(crate) rollback: bool,
     /// The maximum number of commits that can be rolled back.
     pub(crate) max_rollback_log_len: u32,
+    pub(crate) warm_up: bool,
 }
 
 impl Options {
@@ -35,6 +36,7 @@ impl Options {
             panic_on_sync: false,
             rollback: false,
             max_rollback_log_len: 100,
+            warm_up: false,
         }
     }
 
@@ -95,5 +97,12 @@ impl Options {
     /// Set the maximum number of commits that can be rolled back.
     pub fn max_rollback_log_len(&mut self, max_rollback_log_len: u32) {
         self.max_rollback_log_len = max_rollback_log_len;
+    }
+
+    /// Configure whether merkle page fetches should be warmed up while sessions are ongoing.
+    ///
+    /// Enabling this feature can pessimize performance.
+    pub fn warm_up(&mut self, warm_up: bool) {
+        self.warm_up = warm_up;
     }
 }


### PR DESCRIPTION
It doesn't seem to be a given that warm-ups improve performance. In fact, in all the tests I ran, warm-ups were a pessimization. I believe this is due to the added SSD queue depth due to warm-ups impacting state read latencies - merkle commit was getting faster, but the workload was getting slower by an even larger amount. Therefore, I've made running warm-ups configurable, and disabled it by default.
