### PR TITLE
feat: configurable rollback tp size

### DIFF
--- a/nomt/src/options.rs
+++ b/nomt/src/options.rs
@@ -17,6 +17,8 @@ pub struct Options {
     /// The maximum number of commits that can be rolled back.
     pub(crate) max_rollback_log_len: u32,
     pub(crate) warm_up: bool,
+    /// The number of threads to use for fetching prior values.
+    pub(crate) rollback_tp_size: usize,
 }
 
 impl Options {
@@ -37,6 +39,7 @@ impl Options {
             rollback: false,
             max_rollback_log_len: 100,
             warm_up: false,
+            rollback_tp_size: 4,
         }
     }
 
@@ -95,6 +98,10 @@ impl Options {
     }
 
     /// Set the maximum number of commits that can be rolled back.
+    ///
+    /// Only relevant if rollback is enabled.
+    ///
+    /// Default: 100.
     pub fn max_rollback_log_len(&mut self, max_rollback_log_len: u32) {
         self.max_rollback_log_len = max_rollback_log_len;
     }
@@ -104,5 +111,14 @@ impl Options {
     /// Enabling this feature can pessimize performance.
     pub fn warm_up(&mut self, warm_up: bool) {
         self.warm_up = warm_up;
+    }
+
+    /// Set the number of threads to use for fetching prior values.
+    ///
+    /// Only relevant if rollback is enabled.
+    ///
+    /// Default: 4.
+    pub fn rollback_tp_size(&mut self, rollback_tp_size: usize) {
+        self.rollback_tp_size = rollback_tp_size;
     }
 }

--- a/nomt/src/rollback/mod.rs
+++ b/nomt/src/rollback/mod.rs
@@ -89,6 +89,7 @@ pub struct Rollback {
 impl Rollback {
     pub fn read(
         max_rollback_log_len: u32,
+        rollback_tp_size: usize,
         db_dir_path: PathBuf,
         db_dir_fd: File,
         rollback_start_active: u64,
@@ -110,7 +111,7 @@ impl Rollback {
             },
         )?;
         let shared = Arc::new(Shared {
-            worker_tp: ThreadPool::new(4),
+            worker_tp: ThreadPool::new(rollback_tp_size),
             in_memory: Mutex::new(in_memory),
             seglog: Mutex::new(seglog),
             max_rollback_log_len: max_rollback_log_len as usize,

--- a/nomt/src/rollback/tests.rs
+++ b/nomt/src/rollback/tests.rs
@@ -4,6 +4,7 @@ use super::{BTreeMap, KeyPath, KeyReadWrite, LoadValue, Rollback};
 use hex_literal::hex;
 
 const MAX_ROLLBACK_LOG_LEN: u32 = 100;
+const ROLLBACK_TP_SIZE: usize = 4;
 
 /// A mock implementation of `LoadValue` for testing. Describes the "current" state of the
 /// database.
@@ -78,7 +79,15 @@ fn truncate_works() {
         Some(b"old_value3".to_vec()),
     );
 
-    let rollback = Rollback::read(MAX_ROLLBACK_LOG_LEN, db_dir_path, db_dir_fd, 0, 0).unwrap();
+    let rollback = Rollback::read(
+        MAX_ROLLBACK_LOG_LEN,
+        ROLLBACK_TP_SIZE,
+        db_dir_path,
+        db_dir_fd,
+        0,
+        0,
+    )
+    .unwrap();
     let builder = rollback.delta_builder();
     builder.tentative_preserve_prior(store.clone(), [1; 32]);
     builder.tentative_preserve_prior(store.clone(), [2; 32]);
@@ -149,7 +158,15 @@ fn without_tentative_preserve_prior() {
         Some(b"old_value3".to_vec()),
     );
 
-    let rollback = Rollback::read(MAX_ROLLBACK_LOG_LEN, db_dir_path, db_dir_fd, 0, 0).unwrap();
+    let rollback = Rollback::read(
+        MAX_ROLLBACK_LOG_LEN,
+        ROLLBACK_TP_SIZE,
+        db_dir_path,
+        db_dir_fd,
+        0,
+        0,
+    )
+    .unwrap();
     let builder = rollback.delta_builder();
     rollback
         .commit(
@@ -209,7 +226,15 @@ fn delta_builder_doesnt_load_read_then_write_priors() {
     let mut store = MockStore::new();
     store.trap(key_1);
 
-    let rollback = Rollback::read(MAX_ROLLBACK_LOG_LEN, db_dir_path, db_dir_fd, 0, 0).unwrap();
+    let rollback = Rollback::read(
+        MAX_ROLLBACK_LOG_LEN,
+        ROLLBACK_TP_SIZE,
+        db_dir_path,
+        db_dir_fd,
+        0,
+        0,
+    )
+    .unwrap();
     let builder = rollback.delta_builder();
     rollback
         .commit(

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -146,6 +146,7 @@ impl Store {
                 let db_dir_fd = db_dir_fd.try_clone().unwrap();
                 Rollback::read(
                     o.max_rollback_log_len,
+                    o.rollback_tp_size,
                     o.path.clone(),
                     db_dir_fd,
                     meta.rollback_start_live,


### PR DESCRIPTION
We discussed potentially changing the way we dispatch the loads to async IO which would obsolete this setting, but I decided to submit this anyway in case for the time being.