### PR TITLE
feat: flock db dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +682,7 @@ dependencies = [
  "crossbeam",
  "crossbeam-channel",
  "dashmap",
+ "fs2",
  "fxhash",
  "hex",
  "hex-literal",

--- a/benchtop/Cargo.lock
+++ b/benchtop/Cargo.lock
@@ -1350,6 +1350,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2217,7 @@ dependencies = [
  "crossbeam",
  "crossbeam-channel",
  "dashmap",
+ "fs2",
  "fxhash",
  "im",
  "io-uring",

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -29,6 +29,7 @@ lru = "0.12.3"
 libc = "0.2.155"
 criterion = { version = "0.3", optional = true }
 thread_local = "1.1.8"
+fs2 = "0.4.3"
 
 [target.'cfg(target_os="linux")'.dependencies]
 io-uring = "0.6.4"

--- a/nomt/src/store/flock.rs
+++ b/nomt/src/store/flock.rs
@@ -1,0 +1,41 @@
+//! This module provides a cross-platform advisory lock on a directory.
+
+use std::{
+    fs::{File, OpenOptions},
+    path::Path,
+};
+
+use fs2::FileExt as _;
+
+/// Represents a cross-platform advisory lock on a directory.
+pub struct Flock {
+    lock_fd: File,
+}
+
+impl Flock {
+    pub fn lock(db_dir: &Path, lock_filename: &str) -> anyhow::Result<Self> {
+        let lock_path = db_dir.join(lock_filename);
+
+        let lock_fd = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(lock_path)?;
+
+        match lock_fd.try_lock_exclusive() {
+            Ok(_) => Ok(Self { lock_fd }),
+            Err(_) => {
+                let err = fs2::lock_contended_error();
+                anyhow::bail!("Failed to lock directory: {err}");
+            }
+        }
+    }
+}
+
+impl Drop for Flock {
+    fn drop(&mut self) {
+        if let Err(e) = self.lock_fd.unlock() {
+            eprintln!("Failed to unlock directory lock: {e}");
+        }
+    }
+}

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -23,6 +23,7 @@ use std::os::unix::fs::OpenOptionsExt as _;
 pub use self::page_loader::{PageLoad, PageLoadAdvance, PageLoadCompletion, PageLoader};
 pub use bitbox::BucketIndex;
 
+mod flock;
 mod meta;
 mod page_loader;
 mod sync;
@@ -48,6 +49,8 @@ struct Shared {
     #[allow(unused)]
     wal_fd: File,
     #[allow(unused)]
+    flock: flock::Flock,
+    #[allow(unused)]
     db_dir_fd: File,
 }
 
@@ -58,19 +61,12 @@ impl Store {
             create(o)?;
         }
 
-        // TODO: fix TOCTOU race and lock the directory.
-        //
-        // We want to perform the opening of the directory in an atomic way, so it won't happen that
-        // between the check and the opening of the directory, another instance of the program
-        // creates the directory.
-        //
-        // At the moment of writing, we assume the exclusive access to the directory and it would be
-        // good to put some safeguards around it.
         let db_dir_fd = {
             let mut options = OpenOptions::new();
             options.read(true);
             options.open(&o.path)?
         };
+        let flock = flock::Flock::lock(&o.path, ".lock")?;
 
         let io_pool = io::start_io_pool(o.io_workers, page_pool.clone());
 
@@ -169,6 +165,7 @@ impl Store {
                 bbn_fd,
                 ht_fd,
                 wal_fd,
+                flock,
             }),
             sync: Arc::new(Mutex::new(sync::Sync::new(
                 meta.sync_seqn,

--- a/nomt/tests/exclusive_dir.rs
+++ b/nomt/tests/exclusive_dir.rs
@@ -1,0 +1,40 @@
+//! Tests the directory lock behavior.
+
+use std::path::PathBuf;
+
+use nomt::{Nomt, Options};
+
+fn setup_nomt(path: &str, should_clean_up: bool) -> anyhow::Result<Nomt> {
+    let path = {
+        let mut p = PathBuf::from("test");
+        p.push(path);
+        p
+    };
+    if should_clean_up && path.exists() {
+        std::fs::remove_dir_all(&path)?;
+    }
+    let mut o = Options::new();
+    o.path(path);
+    o.panic_on_sync(false);
+    o.bitbox_seed([0; 16]);
+    Nomt::open(o)
+}
+
+#[test]
+fn smoke() {
+    let _nomt = setup_nomt("smoke", true).unwrap();
+}
+
+#[test]
+fn dir_lock() {
+    let _nomt_1 = setup_nomt("dir_lock", true).unwrap();
+    let nomt_2 = setup_nomt("dir_lock", false);
+    assert!(matches!(nomt_2, Err(e) if e.to_string().contains("Resource temporarily unavailable")));
+}
+
+#[test]
+fn dir_unlock() {
+    let nomt_1 = setup_nomt("dir_unlock", true).unwrap();
+    drop(nomt_1);
+    let _nomt_2 = setup_nomt("dir_unlock", false).unwrap();
+}

--- a/nomt/tests/rollback.rs
+++ b/nomt/tests/rollback.rs
@@ -364,6 +364,8 @@ fn test_rollback_reopen() {
     plan.apply_forward(&mut nomt);
     nomt.rollback(2).unwrap();
     plan.verify_restored_state(&mut nomt, 8);
+    // Drop the NOMT to release the lock.
+    drop(nomt);
 
     // Reopen the NOMT and rollback again.
     let mut nomt = setup_nomt(


### PR DESCRIPTION
Closes #483

This commit aim is to return an error message if another process tries
to use the same db directory, which is unsupported according to our
assumptions.

Note that this uses only advisory locking. It's still possible to mess
with the directory and containing files. It's the responsibility of the
user to prevent that and failure to do so can and will lead to
unexpected behavior.

## Implementation Notes

A couple of words on my research of the problem and the taken approach.

There are mandatory and advisory locking. Mandatory locking is a feature of OS that reserves an exclusive right for a specific program to access a particular file. On Linux, mandatory locking is turned off by default and to be avoided (see [this](https://www.kernel.org/doc/Documentation/filesystems/mandatory-locking.txt)). macOS doesn't support mandatory locking.

The typical way to solve this issue is to use advisory locking. That is, depend on the cooperation between the processes that use the files and directories in question. Obviously, this depends on a good will of those processes and not a ironclad solution.

On Linux, it's possible to lock a directory. `flock` with the fd of the directory open with O_PATH can be used. macOS doesn't support opening fds with O_PATH, so this option is not available. To make the solution cross-platform, I stuck to creating a lock file named `.lock` in the DB directory and obtaining an exclusive lock on that.

Now, the original TODO and issue (#483) mentions the TOCTOU issues. Namely, the fact that the checking if the db directory exists, opening the db dir, initializing the db, opening the db files are all non-atomic and it's possible that the state of the filesystem has changed between the checks and file opening or creation, which can lead to all sorts of issues. 

Proper implementation should probably employ `openat` family of syscalls to avoid some of those, at least on Linux. This all is out-of-scope for this PR and better be addressed on the next big refactoring in one fell swoop, e.g. with #501.
