### PR TITLE
feat: make NOMT generic over hash function

### DIFF
--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use nomt::{KeyReadWrite, Node, Nomt, Options, Witness, WitnessedOperations};
+use nomt::{Blake3Hasher, KeyReadWrite, Node, Nomt, Options, Witness, WitnessedOperations};
 use sha2::Digest;
 
 const NOMT_DB_FOLDER: &str = "nomt_db";
@@ -14,7 +14,7 @@ impl NomtDB {
         opts.commit_concurrency(1);
 
         // Open NOMT database, it will create the folder if it does not exist
-        let nomt = Nomt::open(opts)?;
+        let nomt = Nomt::<Blake3Hasher>::open(opts)?;
 
         // Create a new Session object
         //

--- a/examples/read_value/src/main.rs
+++ b/examples/read_value/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use nomt::{KeyReadWrite, Nomt, Options};
+use nomt::{Blake3Hasher, KeyReadWrite, Nomt, Options};
 use sha2::Digest;
 
 const NOMT_DB_FOLDER: &str = "nomt_db";
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
     opts.commit_concurrency(1);
 
     // Open nomt database. This will create the folder if it does not exist
-    let nomt = Nomt::open(opts)?;
+    let nomt = Nomt::<Blake3Hasher>::open(opts)?;
 
     // Instantiate a new Session object to handle read and write operations
     // and generate a Witness later on

--- a/fuzz/fuzz_targets/api_surface.rs
+++ b/fuzz/fuzz_targets/api_surface.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 
-use nomt::{KeyPath, KeyReadWrite, Nomt, Options, Value};
+use nomt::{Blake3Hasher, KeyPath, KeyReadWrite, Nomt, Options, Value};
 
 fuzz_target!(|run: Run| {
     let db = open_db(run.commit_concurrency);
@@ -238,7 +238,7 @@ impl<'a> Arbitrary<'a> for NomtCalls {
     }
 }
 
-fn open_db(commit_concurrency: usize) -> Nomt {
+fn open_db(commit_concurrency: usize) -> Nomt<Blake3Hasher> {
     let tempfile = tempfile::tempdir().unwrap();
     let db_path = tempfile.path().join("db");
     let mut options = Options::new();

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -37,7 +37,7 @@ fn opts(path: PathBuf) -> Options {
 }
 
 pub struct Test {
-    nomt: Nomt,
+    nomt: Nomt<nomt::Blake3Hasher>,
     session: Option<Session>,
     access: HashMap<KeyPath, KeyReadWrite>,
 }

--- a/nomt/tests/exclusive_dir.rs
+++ b/nomt/tests/exclusive_dir.rs
@@ -2,9 +2,9 @@
 
 use std::path::PathBuf;
 
-use nomt::{Nomt, Options};
+use nomt::{Blake3Hasher, Nomt, Options};
 
-fn setup_nomt(path: &str, should_clean_up: bool) -> anyhow::Result<Nomt> {
+fn setup_nomt(path: &str, should_clean_up: bool) -> anyhow::Result<Nomt<Blake3Hasher>> {
     let path = {
         let mut p = PathBuf::from("test");
         p.push(path);

--- a/nomt/tests/rollback.rs
+++ b/nomt/tests/rollback.rs
@@ -1,5 +1,5 @@
 use hex_literal::hex;
-use nomt::{KeyPath, KeyReadWrite, Nomt, Options, Value};
+use nomt::{Blake3Hasher, KeyPath, KeyReadWrite, Nomt, Options, Value};
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::PathBuf,
@@ -13,7 +13,7 @@ fn setup_nomt(
     rollback_enabled: bool,
     commit_concurrency: usize,
     should_clean_up: bool,
-) -> Nomt {
+) -> Nomt<Blake3Hasher> {
     let path = {
         let mut p = PathBuf::from("test");
         p.push(path);
@@ -194,7 +194,7 @@ impl TestPlan {
         }
     }
 
-    fn apply_forward(&self, nomt: &mut Nomt) {
+    fn apply_forward(&self, nomt: &mut Nomt<Blake3Hasher>) {
         for commit_no in 0..self.to_insert.len() {
             let session = nomt.begin_session();
             let mut operations = Vec::new();
@@ -209,7 +209,7 @@ impl TestPlan {
         }
     }
 
-    fn verify_restored_state(&self, nomt: &mut Nomt, commit_ix: usize) {
+    fn verify_restored_state(&self, nomt: &mut Nomt<Blake3Hasher>, commit_ix: usize) {
         let mut errors: Vec<String> = vec![];
 
         let expected: BTreeMap<KeyPath, Value> = self.expected_values[commit_ix].clone();


### PR DESCRIPTION
I opted for a generic, but this could be refactored to a trait object if the API proves too clunky.
