### PR TITLE
opt: improve key_memcmp with word-comparisons

### DIFF
--- a/nomt/src/beatree/leaf/node.rs
+++ b/nomt/src/beatree/leaf/node.rs
@@ -28,7 +28,7 @@
 use std::ops::Range;
 
 use crate::{
-    beatree::Key,
+    beatree::{ops::bit_ops::key_memcmp, Key},
     io::{page_pool::FatPage, PagePool, PAGE_SIZE},
 };
 
@@ -175,7 +175,7 @@ fn encode_cell_pointer(cell: &mut [u8], key: [u8; 32], offset: usize, overflow: 
 
 // look for key in the node. the return value has the same semantics as std binary_search*.
 fn search(cell_pointers: &[[u8; 34]], key: &Key) -> Result<usize, usize> {
-    cell_pointers.binary_search_by(|cell| cell[0..32].cmp(key))
+    cell_pointers.binary_search_by(|cell| key_memcmp(&cell[0..32], key))
 }
 
 #[cfg(feature = "benchmarks")]

--- a/nomt/src/beatree/ops/mod.rs
+++ b/nomt/src/beatree/ops/mod.rs
@@ -73,10 +73,13 @@ fn search_branch(branch: &BranchNode, key: Key) -> Option<(usize, PageNumber)> {
     while low < high {
         let mid = low + (high - low) / 2;
 
-        if key < get_key(branch, mid) {
-            high = mid;
-        } else {
-            low = mid + 1;
+        match bit_ops::key_memcmp(&key, &get_key(branch, mid)) {
+            Ordering::Less => {
+                high = mid;
+            }
+            _ => {
+                low = mid + 1;
+            }
         }
     }
 

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -355,7 +355,8 @@ impl<T: HashAlgorithm> Nomt<T> {
 
         let new_root = merkle_update.root;
         self.shared.lock().root = new_root;
-        self.store.commit(tx, self.page_cache.clone(), merkle_update.page_diffs)?;
+        self.store
+            .commit(tx, self.page_cache.clone(), merkle_update.page_diffs)?;
 
         Ok((
             new_root,

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -528,8 +528,6 @@ impl PageCache {
                 panic!("dirty page {:?} is missing", page_id);
             }
         }
-
-
     }
 
     /// Evict stale pages for the cache. This should only be used after all dirty pages have been

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -222,9 +222,7 @@ impl Store {
 
     /// Create a new raw value transaction to be applied against this database.
     pub fn new_value_tx(&self) -> ValueTransaction {
-        ValueTransaction {
-            batch: Vec::new(),
-        }
+        ValueTransaction { batch: Vec::new() }
     }
 
     /// Atomically apply the given transaction.

--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -1,4 +1,4 @@
-use super::{meta::Meta, Shared, MerkleTransaction, ValueTransaction};
+use super::{meta::Meta, MerkleTransaction, Shared, ValueTransaction};
 use crate::{
     beatree::{self, allocator::PageNumber, branch::BranchNode},
     bitbox,


### PR DESCRIPTION
This does word-wise comparisons for the two slices in `key_memcmp`. This gives another 10% or so improvement over the previous PR.
