### PR TITLE
refactor: grow beatree stores by 32MB increments

### DIFF
--- a/nomt/src/beatree/allocator/mod.rs
+++ b/nomt/src/beatree/allocator/mod.rs
@@ -261,8 +261,8 @@ struct StoreSync {
 
 type StoreSyncGuard = ArcMutexGuard<parking_lot::RawMutex, StoreSync>;
 
-// Grow the store by 1MB at a time.
-const GROW_STORE_BY_PAGES: u32 = 256;
+// Grow the store by 32MB at a time.
+const GROW_STORE_BY_PAGES: u32 = 8192;
 
 /// The sync allocator can be used by multiple threads to prospectively allocate pages in the store.
 ///


### PR DESCRIPTION
Larger increments will get out of the way of the critical path.
