### PR TITLE
refactor(leaf-stage): handle overflow inside leaf stage

### DIFF
--- a/nomt/src/beatree/mod.rs
+++ b/nomt/src/beatree/mod.rs
@@ -209,7 +209,7 @@ impl Tree {
             //   so things will be allocated and released following what is being performed
             //   on the branch_node_pool and committed later on onto disk
             ops::update(
-                &staged_changeset,
+                staged_changeset.clone(),
                 &mut bbn_index,
                 &sync.leaf_store_rd,
                 &mut sync.leaf_store_wr,


### PR DESCRIPTION
Like the previous PR, this improves the encapsulation of the leaf stage. And like the previous PR, there is a slight optimization as a result of incrementally applying changes as workers finish.

`fn update` is now dead-simple and just invokes both stages sequentially.

This is also a step towards handling overflow logic inside of workers, but that can come in a later refactoring.
