### PR TITLE
opt(beatree): have beatree update issue writes immediately

### DIFF
--- a/nomt/src/beatree/allocator/free_list.rs
+++ b/nomt/src/beatree/allocator/free_list.rs
@@ -210,6 +210,8 @@ impl FreeList {
         self.len = len;
         self.fragmented = fragmented;
 
+        // preallocate pops, therefore, we must set it back.
+        self.pop = false;
         pages
     }
 

--- a/nomt/src/beatree/bbn.rs
+++ b/nomt/src/beatree/bbn.rs
@@ -1,3 +1,5 @@
+#![allow(unused)] // TODO: delete in follow-up
+
 use crate::io::{page_pool::FatPage, PagePool};
 
 use std::{collections::BTreeSet, fs::File, sync::Arc};

--- a/nomt/src/beatree/leaf/store.rs
+++ b/nomt/src/beatree/leaf/store.rs
@@ -1,3 +1,5 @@
+#![allow(unused)] // TODO: delete in follow-up.
+
 use crate::{
     beatree::{
         allocator::{AllocatorCommitOutput, AllocatorReader, AllocatorWriter, PageNumber},

--- a/nomt/src/beatree/ops/mod.rs
+++ b/nomt/src/beatree/ops/mod.rs
@@ -6,7 +6,7 @@ use bitvec::prelude::*;
 use std::cmp::Ordering;
 
 use super::{
-    allocator::PageNumber,
+    allocator::{PageNumber, StoreReader},
     branch::BranchNode,
     index::Index,
     leaf::{self, node::LeafNode},
@@ -21,11 +21,7 @@ pub use reconstruction::reconstruct;
 pub use update::update;
 
 /// Lookup a key in the btree.
-pub fn lookup(
-    key: Key,
-    bbn_index: &Index,
-    leaf_store: &leaf::store::LeafStoreReader,
-) -> Result<Option<Vec<u8>>> {
+pub fn lookup(key: Key, bbn_index: &Index, leaf_store: &StoreReader) -> Result<Option<Vec<u8>>> {
     let branch = match bbn_index.lookup(key) {
         None => return Ok(None),
         Some((_, branch)) => branch,

--- a/nomt/src/beatree/ops/update/branch_updater.rs
+++ b/nomt/src/beatree/ops/update/branch_updater.rs
@@ -10,8 +10,7 @@ use crate::beatree::{
 use crate::io::PagePool;
 
 use super::{
-    branch_stage::BranchesTracker, get_key, BRANCH_BULK_SPLIT_TARGET, BRANCH_BULK_SPLIT_THRESHOLD,
-    BRANCH_MERGE_THRESHOLD,
+    get_key, BRANCH_BULK_SPLIT_TARGET, BRANCH_BULK_SPLIT_THRESHOLD, BRANCH_MERGE_THRESHOLD,
 };
 
 pub struct BaseBranch {
@@ -54,12 +53,6 @@ pub enum DigestResult {
 /// A callback which takes ownership of newly created leaves.
 pub trait HandleNewBranch {
     fn handle_new_branch(&mut self, separator: Key, node: BranchNode, cutoff: Option<Key>);
-}
-
-impl HandleNewBranch for BranchesTracker {
-    fn handle_new_branch(&mut self, separator: Key, node: BranchNode, cutoff: Option<Key>) {
-        self.insert(separator, node, cutoff)
-    }
 }
 
 pub struct BranchUpdater {

--- a/nomt/src/beatree/ops/update/extend_range_protocol.rs
+++ b/nomt/src/beatree/ops/update/extend_range_protocol.rs
@@ -185,11 +185,9 @@ pub fn request_range_extension<Node>(
     if let Some((last_key, last_changed_entry)) = response.changed.last_mut() {
         if last_changed_entry.inserted.is_some() {
             // UNWRAP: the entry has just been checked to have an inserted node
-            nodes_tracker.pending_base = Some((
-                *last_key,
-                last_changed_entry.inserted.take().unwrap(),
-                last_changed_entry.next_separator,
-            ));
+            let (node, pn) = last_changed_entry.inserted.take().unwrap();
+
+            nodes_tracker.set_pending_base(*last_key, node, last_changed_entry.next_separator, pn);
         }
     }
 

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -5,17 +5,14 @@ use threadpool::ThreadPool;
 use std::{collections::BTreeMap, sync::Arc};
 
 use crate::beatree::{
-    allocator::PageNumber,
-    bbn,
+    allocator::{PageNumber, Store, StoreReader},
     branch::BRANCH_NODE_BODY_SIZE,
     index::Index,
-    leaf::{
-        node::{LeafNode, LEAF_NODE_BODY_SIZE},
-        store::{LeafStoreReader, LeafStoreWriter},
-    },
+    leaf::node::{LeafNode, LEAF_NODE_BODY_SIZE},
     ops::get_key,
-    Key,
+    Key, SyncData,
 };
+use crate::io::{IoHandle, PagePool};
 
 mod branch_stage;
 mod branch_updater;
@@ -23,8 +20,9 @@ mod extend_range_protocol;
 mod leaf_stage;
 mod leaf_updater;
 
-#[cfg(test)]
-mod tests;
+// TODO: reinstate
+// #[cfg(test)]
+// mod tests;
 
 // All nodes less than this body size will be merged with a neighboring node.
 const BRANCH_MERGE_THRESHOLD: usize = BRANCH_NODE_BODY_SIZE / 2;
@@ -46,43 +44,84 @@ const LEAF_BULK_SPLIT_TARGET: usize = (LEAF_NODE_BODY_SIZE * 3) / 4;
 /// The changeset is a list of key value pairs to be added or removed from the btree.
 pub fn update(
     changeset: Arc<BTreeMap<Key, Option<Vec<u8>>>>,
-    bbn_index: &mut Index,
-    leaf_reader: &LeafStoreReader,
-    leaf_writer: &mut LeafStoreWriter,
-    bbn_writer: &mut bbn::BbnStoreWriter,
+    mut bbn_index: Index,
+    leaf_store: Store,
+    bbn_store: Store,
+    page_pool: PagePool,
+    io_handle: IoHandle,
     thread_pool: ThreadPool,
     workers: usize,
-) -> Result<()> {
-    let leaf_cache = preload_leaves(leaf_reader, &bbn_index, changeset.keys().cloned())?;
+) -> Result<SyncData> {
+    let leaf_reader = StoreReader::new(leaf_store.clone(), page_pool.clone());
+    let (leaf_writer, leaf_finisher) = leaf_store.start_sync();
+    let (bbn_writer, bbn_finisher) = bbn_store.start_sync();
 
-    let branch_changeset = leaf_stage::run(
+    let leaf_cache = preload_leaves(
+        &leaf_reader,
+        &bbn_index,
+        &io_handle,
+        changeset.keys().cloned(),
+    )?;
+
+    let leaf_stage_outputs = leaf_stage::run(
         &bbn_index,
         leaf_cache,
         leaf_reader,
         leaf_writer,
+        io_handle.clone(),
         changeset,
         thread_pool.clone(),
         workers,
-    );
+    )?;
 
-    branch_stage::run(
-        bbn_index,
+    let branch_stage_outputs = branch_stage::run(
+        &mut bbn_index,
         bbn_writer,
-        leaf_writer.page_pool().clone(),
-        branch_changeset,
+        page_pool.clone(),
+        io_handle.clone(),
+        leaf_stage_outputs.leaf_changeset,
         thread_pool,
         workers,
-    );
+    )?;
 
-    Ok(())
+    let (ln_freelist_pages, ln_meta) =
+        leaf_finisher.finish(&page_pool, leaf_stage_outputs.freed_pages)?;
+
+    let (bbn_freelist_pages, bbn_meta) =
+        bbn_finisher.finish(&page_pool, branch_stage_outputs.freed_pages)?;
+
+    let mut total_io = leaf_stage_outputs.submitted_io + branch_stage_outputs.submitted_io;
+    total_io += ln_freelist_pages.len();
+    total_io += bbn_freelist_pages.len();
+
+    crate::beatree::writeout::submit_freelist_write(&io_handle, &leaf_store, ln_freelist_pages)?;
+    crate::beatree::writeout::submit_freelist_write(&io_handle, &bbn_store, bbn_freelist_pages)?;
+
+    for _ in 0..total_io {
+        io_handle.recv()?;
+    }
+
+    drop((
+        leaf_stage_outputs.post_io_drop,
+        branch_stage_outputs.post_io_drop,
+    ));
+
+    Ok(SyncData {
+        bbn_index,
+        ln_freelist_pn: ln_meta.freelist_pn,
+        ln_bump: ln_meta.bump,
+        bbn_freelist_pn: bbn_meta.freelist_pn,
+        bbn_bump: bbn_meta.bump,
+    })
 }
 
 // TODO: this should not be necessary with proper warm-ups.
 fn preload_leaves(
-    leaf_reader: &LeafStoreReader,
+    leaf_reader: &StoreReader,
     bbn_index: &Index,
+    io_handle: &IoHandle,
     keys: impl IntoIterator<Item = Key>,
-) -> Result<DashMap<PageNumber, LeafNode>> {
+) -> Result<DashMap<PageNumber, Arc<LeafNode>>> {
     let leaf_pages = DashMap::new();
     let mut last_pn = None;
 
@@ -98,8 +137,7 @@ fn preload_leaves(
             continue;
         }
         last_pn = Some(leaf_pn);
-        leaf_reader
-            .io_handle()
+        io_handle
             .send(leaf_reader.io_command(leaf_pn, leaf_pn.0 as u64))
             .expect("I/O Pool Disconnected");
 
@@ -107,14 +145,11 @@ fn preload_leaves(
     }
 
     for _ in 0..submissions {
-        let completion = leaf_reader
-            .io_handle()
-            .recv()
-            .expect("I/O Pool Disconnected");
+        let completion = io_handle.recv().expect("I/O Pool Disconnected");
         completion.result?;
         let pn = PageNumber(completion.command.user_data as u32);
         let page = completion.command.kind.unwrap_buf();
-        leaf_pages.insert(pn, LeafNode { inner: page });
+        leaf_pages.insert(pn, Arc::new(LeafNode { inner: page }));
     }
 
     Ok(leaf_pages)
@@ -125,7 +160,7 @@ pub struct ChangedNodeEntry<Node> {
     /// PageNumber of the Node that is being replaced by the current entry
     pub deleted: Option<PageNumber>,
     /// New or modified Node that will be written
-    pub inserted: Option<Node>,
+    pub inserted: Option<(Arc<Node>, PageNumber)>,
     /// Separator of the next node.
     pub next_separator: Option<Key>,
 }
@@ -136,7 +171,13 @@ pub struct NodesTracker<Node> {
     /// is associated with a ChangedNodeEntry
     pub inner: BTreeMap<Key, ChangedNodeEntry<Node>>,
     /// Pending base received from the right worker which will be used as new base
-    pub pending_base: Option<(Key, Node, Option<Key>)>,
+    pub pending_base: Option<(Key, Arc<Node>, Option<Key>)>,
+    /// Page numbers which were allocated and discarded entirely during this update.
+    pub extra_freed: Vec<PageNumber>,
+    /// Pages which are potentially being written and which must be kept alive until I/O
+    /// is guaranteed complete.
+    pub deferred_drop_pages: Vec<Arc<Node>>,
+    pub new_inserted: usize,
 }
 
 impl<Node> NodesTracker<Node> {
@@ -145,6 +186,9 @@ impl<Node> NodesTracker<Node> {
         Self {
             inner: BTreeMap::new(),
             pending_base: None,
+            extra_freed: Vec::new(),
+            new_inserted: 0,
+            deferred_drop_pages: Vec::new(),
         }
     }
 
@@ -165,7 +209,13 @@ impl<Node> NodesTracker<Node> {
     }
 
     /// Add or modify a ChangedNodeEntry specifying an inserted Node.
-    pub fn insert(&mut self, key: Key, node: Node, next_separator: Option<Key>) {
+    pub fn insert(
+        &mut self,
+        key: Key,
+        node: Arc<Node>,
+        next_separator: Option<Key>,
+        pn: PageNumber,
+    ) {
         let entry = self.inner.entry(key).or_insert(ChangedNodeEntry {
             deleted: None,
             inserted: None,
@@ -173,7 +223,22 @@ impl<Node> NodesTracker<Node> {
         });
 
         entry.next_separator = next_separator;
-        entry.inserted.replace(node);
+        entry.inserted.replace((node, pn));
+
+        self.new_inserted += 1;
+    }
+
+    /// Set the new pending base node.
+    pub fn set_pending_base(
+        &mut self,
+        separator: Key,
+        node: Arc<Node>,
+        cutoff: Option<Key>,
+        pn: PageNumber,
+    ) {
+        self.extra_freed.push(pn);
+        self.deferred_drop_pages.push(node.clone());
+        self.pending_base = Some((separator, node, cutoff));
     }
 
     #[cfg(test)]

--- a/nomt/src/beatree/writeout.rs
+++ b/nomt/src/beatree/writeout.rs
@@ -4,94 +4,22 @@
 // size beforehand. After the writes are completed (fsync'd), we wait for the MANIFEST to be
 // updated and then perform some cleanup.
 
-use super::{allocator::PageNumber, branch::BranchNode};
+use super::allocator::{PageNumber, Store};
 use crate::io::{FatPage, IoHandle};
-use std::{fs::File, os::fd::AsRawFd as _, sync::Arc};
 
-pub fn write_bbn(
-    io_handle: IoHandle,
-    bbn_fd: &File,
-    bbn: Vec<Arc<BranchNode>>,
-    bbn_free_list_pages: Vec<(PageNumber, FatPage)>,
-    bbn_extend_file_sz: Option<u64>,
+pub fn submit_freelist_write(
+    io_handle: &IoHandle,
+    store: &Store,
+    free_list_pages: Vec<(PageNumber, FatPage)>,
 ) -> anyhow::Result<()> {
-    if let Some(new_len) = bbn_extend_file_sz {
-        bbn_fd.set_len(new_len)?;
-    }
-
-    let mut sent = 0;
-    for branch_node in bbn {
-        let wrt = branch_node.as_slice();
-        let (ptr, len) = (wrt.as_ptr(), wrt.len());
-        let bbn_pn = branch_node.bbn_pn();
+    for (pn, page) in free_list_pages {
         io_handle
             .send(crate::io::IoCommand {
-                kind: crate::io::IoKind::WriteRaw(bbn_fd.as_raw_fd(), bbn_pn as u64, ptr, len),
+                kind: crate::io::IoKind::Write(store.store_fd(), pn.0 as u64, page),
                 user_data: 0,
             })
             .unwrap();
-        sent += 1;
     }
 
-    for (pn, page) in bbn_free_list_pages {
-        io_handle
-            .send(crate::io::IoCommand {
-                kind: crate::io::IoKind::Write(bbn_fd.as_raw_fd(), pn.0 as u64, page),
-                user_data: 0,
-            })
-            .unwrap();
-        sent += 1;
-    }
-
-    while sent > 0 {
-        io_handle.recv().unwrap();
-        sent -= 1;
-    }
-
-    bbn_fd.sync_all()?;
-    Ok(())
-}
-
-pub fn write_ln(
-    io_handle: IoHandle,
-    ln_fd: &File,
-    mut ln: Vec<(PageNumber, FatPage)>,
-    mut ln_free_list_pages: Vec<(PageNumber, FatPage)>,
-    ln_extend_file_sz: Option<u64>,
-) -> anyhow::Result<()> {
-    if let Some(new_len) = ln_extend_file_sz {
-        ln_fd.set_len(new_len)?;
-    }
-
-    ln.sort_unstable_by_key(|item| item.0 .0);
-    ln_free_list_pages.sort_unstable_by_key(|item| item.0 .0);
-
-    let mut sent = 0;
-    for (pn, page) in ln {
-        io_handle
-            .send(crate::io::IoCommand {
-                kind: crate::io::IoKind::Write(ln_fd.as_raw_fd(), pn.0 as u64, page),
-                user_data: 0,
-            })
-            .unwrap();
-        sent += 1;
-    }
-
-    for (pn, page) in ln_free_list_pages {
-        io_handle
-            .send(crate::io::IoCommand {
-                kind: crate::io::IoKind::Write(ln_fd.as_raw_fd(), pn.0 as u64, page),
-                user_data: 0,
-            })
-            .unwrap();
-        sent += 1;
-    }
-
-    while sent > 0 {
-        io_handle.recv().unwrap();
-        sent -= 1;
-    }
-
-    ln_fd.sync_all()?;
     Ok(())
 }


### PR DESCRIPTION
This PR modifies the beatree update / sync logic so writes are dispatched while work is ongoing.

Currently, this doesn't optimize or pessimize - it takes exactly the same amount of time as before. Profiles seem to indicate that this is because backpressure on the I/O channel creates some locking/unlocking overhead in the bounded channel.

I will experiment with unbounded I/O channels too, as I'm also seeing this effect in the HT write sequence now that I know what to look for.

Future PRs will:
  1. Reinstate the beatree update tests
  2. Delete the `beatree/bbn` and `beatree/leaf/store` modules
