### PR TITLE
grow wal gradually

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -65,7 +65,7 @@ impl DB {
 
         let occupied_buckets = meta_map.full_count();
 
-        let wal_blob_builder = WalBlobBuilder::new();
+        let wal_blob_builder = WalBlobBuilder::new()?;
         Ok(Self {
             shared: Arc::new(Shared {
                 store,

--- a/nomt/src/bitbox/wal/tests.rs
+++ b/nomt/src/bitbox/wal/tests.rs
@@ -18,7 +18,7 @@ fn test_write_read() {
         options.open(&wal_filename).unwrap()
     };
 
-    let mut builder = WalBlobBuilder::new();
+    let mut builder = WalBlobBuilder::new().unwrap();
     builder.write_clear(0);
     builder.write_update(
         [0; 32],


### PR DESCRIPTION
This changeset makes the buffer in which we assemble the WAL blob to
grow gradually instead of just allocating a really big amount of virtual
memory at a time. This should not affect performance that much in the
steady state, if at all, but at the same time it would not require
allocating huge virtual memory areas which can actually fail in rare
cases.