### PR TITLE
opt: use unbounded channels to submit I/O

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -1,4 +1,4 @@
-use crossbeam::channel::{TryRecvError, TrySendError};
+use crossbeam::channel::TryRecvError;
 use nomt_core::page_id::PageId;
 use parking_lot::{ArcRwLockReadGuard, Mutex, RwLock};
 use std::{
@@ -289,51 +289,6 @@ impl PageLoader {
         }
     }
 
-    /// Try to advance the state of the given page load. Fails if the I/O pool is down.
-    ///
-    /// Panics if the page load needs a completion.
-    ///
-    /// This returns a value indicating the state of the page load.
-    /// The user_data is only relevant if `Submitted` is returned, in which case a completion will
-    /// arrive with the same user data at some point.
-    pub fn try_advance(
-        &self,
-        ht_fd: RawFd,
-        load: &mut PageLoad,
-        user_data: u64,
-    ) -> anyhow::Result<PageLoadAdvance> {
-        let bucket = match load.take_blocked() {
-            Some(bucket) => bucket,
-            None => loop {
-                match load.probe_sequence.next(&self.meta_map) {
-                    ProbeResult::Tombstone(_) => continue,
-                    ProbeResult::Empty(_) => return Ok(PageLoadAdvance::GuaranteedFresh),
-                    ProbeResult::PossibleHit(bucket) => break BucketIndex(bucket),
-                }
-            },
-        };
-
-        let data_page_index = self.shared.store.data_page_index(bucket.0);
-
-        let page = self.io_handle.page_pool().alloc_fat_page();
-        let command = IoCommand {
-            kind: IoKind::Read(ht_fd, data_page_index, page),
-            user_data,
-        };
-
-        match self.io_handle.try_send(command) {
-            Ok(()) => {
-                load.state = PageLoadState::Submitted;
-                Ok(PageLoadAdvance::Submitted)
-            }
-            Err(TrySendError::Full(_)) => {
-                load.state = PageLoadState::Blocked;
-                Ok(PageLoadAdvance::Blocked)
-            }
-            Err(TrySendError::Disconnected(_)) => anyhow::bail!("I/O pool hangup"),
-        }
-    }
-
     /// Advance the state of the given page load, blocking the current thread.
     /// Fails if the I/O pool is down.
     ///
@@ -347,15 +302,12 @@ impl PageLoader {
         load: &mut PageLoad,
         user_data: u64,
     ) -> anyhow::Result<bool> {
-        let bucket = match load.take_blocked() {
-            Some(bucket) => bucket,
-            None => loop {
-                match load.probe_sequence.next(&self.meta_map) {
-                    ProbeResult::Tombstone(_) => continue,
-                    ProbeResult::Empty(_) => return Ok(false),
-                    ProbeResult::PossibleHit(bucket) => break BucketIndex(bucket),
-                }
-            },
+        let bucket = loop {
+            match load.probe_sequence.next(&self.meta_map) {
+                ProbeResult::Tombstone(_) => continue,
+                ProbeResult::Empty(_) => return Ok(false),
+                ProbeResult::PossibleHit(bucket) => break BucketIndex(bucket),
+            }
         };
 
         let data_page_index = self.shared.store.data_page_index(bucket.0);
@@ -442,16 +394,6 @@ impl PageLoadCompletion {
     }
 }
 
-/// The result of advancing a page load.
-pub enum PageLoadAdvance {
-    /// The page load is blocked by I/O backpressure.
-    Blocked,
-    /// The page load was submitted and a completion will follow.
-    Submitted,
-    /// The page is guaranteed not to exist.
-    GuaranteedFresh,
-}
-
 pub struct PageLoad {
     page_id: PageId,
     probe_sequence: ProbeSequence,
@@ -466,20 +408,11 @@ impl PageLoad {
     pub fn page_id(&self) -> &PageId {
         &self.page_id
     }
-
-    fn take_blocked(&mut self) -> Option<BucketIndex> {
-        match std::mem::replace(&mut self.state, PageLoadState::Pending) {
-            PageLoadState::Pending => None,
-            PageLoadState::Blocked => Some(BucketIndex(self.probe_sequence.bucket())),
-            PageLoadState::Submitted => panic!("attempted to re-submit page load"),
-        }
-    }
 }
 
 #[derive(Clone, Copy, PartialEq)]
 enum PageLoadState {
     Pending,
-    Blocked,
     Submitted,
 }
 

--- a/nomt/src/io/linux.rs
+++ b/nomt/src/io/linux.rs
@@ -16,7 +16,7 @@ struct PendingIo {
 
 pub fn start_io_worker(io_workers: usize, iopoll: bool) -> Sender<IoPacket> {
     // main bound is from the pending slab.
-    let (command_tx, command_rx) = crossbeam_channel::bounded(MAX_IN_FLIGHT * io_workers);
+    let (command_tx, command_rx) = crossbeam_channel::unbounded();
 
     start_workers(command_rx, io_workers, iopoll);
 

--- a/nomt/src/io/unix.rs
+++ b/nomt/src/io/unix.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::{Receiver, Sender};
 const MAX_IN_FLIGHT: usize = 64;
 
 pub fn start_io_worker(io_workers: usize, _iopoll: bool) -> Sender<IoPacket> {
-    let (command_tx, command_rx) = crossbeam_channel::bounded(MAX_IN_FLIGHT);
+    let (command_tx, command_rx) = crossbeam_channel::unbounded();
 
     for _ in 0..io_workers {
         spawn_worker_thread(command_rx.clone());

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -22,7 +22,7 @@ use std::{
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::OpenOptionsExt as _;
 
-pub use self::page_loader::{PageLoad, PageLoadAdvance, PageLoadCompletion, PageLoader};
+pub use self::page_loader::{PageLoad, PageLoadCompletion, PageLoader};
 pub use bitbox::BucketIndex;
 
 mod flock;

--- a/nomt/src/store/page_loader.rs
+++ b/nomt/src/store/page_loader.rs
@@ -5,7 +5,7 @@ use std::{os::fd::AsRawFd, sync::Arc};
 
 use super::Shared;
 
-pub use bitbox::{PageLoad, PageLoadAdvance, PageLoadCompletion};
+pub use bitbox::{PageLoad, PageLoadCompletion};
 
 pub struct PageLoader {
     pub(super) shared: Arc<Shared>,
@@ -16,22 +16,6 @@ impl PageLoader {
     /// Create a new page load.
     pub fn start_load(&self, page_id: PageId) -> PageLoad {
         self.inner.start_load(page_id)
-    }
-
-    /// Try to advance the state of the given page load. Fails if the I/O pool is down.
-    ///
-    /// Panics if the page load needs a completion.
-    ///
-    /// This returns a value indicating the state of the page load.
-    /// The user_data is only relevant if `Submitted` is returned, in which case a completion will
-    /// arrive with the same user data at some point.
-    pub fn try_advance(
-        &self,
-        load: &mut PageLoad,
-        user_data: u64,
-    ) -> anyhow::Result<PageLoadAdvance> {
-        self.inner
-            .try_advance(self.shared.ht_fd.as_raw_fd(), load, user_data)
     }
 
     /// Advance the state of the given page load, blocking the current thread.


### PR DESCRIPTION
This PR makes the `IoHandle` submit channel unbounded.

Previously, backpressure was causing threads submitting I/O to park and be woken by the I/O thread when backpressure began.
The concrete downsides:
  * The overhead of parking/unparking the threads handling the workload caused inefficiency.
  * The I/O threads had to acquire a mutex inside of the channel, which was sometimes contended. Then a further syscall was made. This reduced IOPS.

I suspect this problem was self-reinforcing: waking up senders slowed I/O throughput, which caused more backpressure, causing senders to park more, causing more wakeups to slow down the I/O thread. And so on.

This required some changes in `Seek`, which assumed that the channel itself backpressured.
