### PR TITLE
opt: introduce a leaf cache

### DIFF
--- a/nomt/src/beatree/leaf_cache.rs
+++ b/nomt/src/beatree/leaf_cache.rs
@@ -1,0 +1,95 @@
+//! The leaf cache stores recently accessed leaf nodes.
+
+use crate::beatree::{allocator::PageNumber, leaf::node::LeafNode};
+use lru::LruCache;
+use parking_lot::{Mutex, MutexGuard};
+use std::{collections::hash_map::RandomState, hash::BuildHasher, sync::Arc};
+
+/// A cache for leaf nodes.
+///
+/// This i cheap to clone.
+#[derive(Clone)]
+pub struct LeafCache {
+    inner: Arc<Shared>,
+}
+
+impl LeafCache {
+    /// Create a new cache with the given number of shards and the maximum number of items
+    /// to hold. `shards` must be non-zero.
+    pub fn new(shards: usize, max_items: usize) -> Self {
+        let items_per_shard = max_items / shards;
+        LeafCache {
+            inner: Arc::new(Shared {
+                shards: (0..shards)
+                    .map(|_| Shard {
+                        cache: LruCache::unbounded(),
+                        max_items: items_per_shard,
+                    })
+                    .map(Mutex::new)
+                    .collect::<Vec<_>>(),
+                shard_assigner: RandomState::new(),
+            }),
+        }
+    }
+
+    /// Get a cache entry, updating the LRU state.
+    pub fn get(&self, page_number: PageNumber) -> Option<Arc<LeafNode>> {
+        let mut shard = self.inner.shard_for(page_number);
+
+        shard.cache.get(&page_number).map(|x| x.clone())
+    }
+
+    /// Check whether the cache contains a key without updating the LRU state.
+    pub fn contains_key(&self, page_number: PageNumber) -> bool {
+        let shard = self.inner.shard_for(page_number);
+
+        shard.cache.contains(&page_number)
+    }
+
+    /// Insert a cache entry. This does not evict anything.
+    pub fn insert(&self, page_number: PageNumber, node: Arc<LeafNode>) {
+        let mut shard = self.inner.shard_for(page_number);
+
+        shard.cache.put(page_number, node);
+    }
+
+    /// Evict all excess items from the cache.
+    pub fn evict(&self) {
+        for shard in &self.inner.shards {
+            let mut shard = shard.lock();
+            while shard.cache.len() > shard.max_items {
+                let _ = shard.cache.pop_lru();
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn all_page_numbers(&self) -> std::collections::BTreeSet<PageNumber> {
+        let mut set = std::collections::BTreeSet::new();
+        for shard in &self.inner.shards {
+            let shard = shard.lock();
+            set.extend(shard.cache.iter().map(|(pn, _)| *pn));
+        }
+        set
+    }
+}
+
+struct Shared {
+    shards: Vec<Mutex<Shard>>,
+    shard_assigner: RandomState,
+}
+
+impl Shared {
+    fn shard_for(&self, page_number: PageNumber) -> MutexGuard<'_, Shard> {
+        self.shards[self.shard_index_for(page_number)].lock()
+    }
+
+    fn shard_index_for(&self, page_number: PageNumber) -> usize {
+        (self.shard_assigner.hash_one(page_number.0) as usize) % self.shards.len()
+    }
+}
+
+struct Shard {
+    cache: LruCache<PageNumber, Arc<LeafNode>>,
+    max_items: usize,
+}

--- a/nomt/src/beatree/ops/update/tests.rs
+++ b/nomt/src/beatree/ops/update/tests.rs
@@ -6,6 +6,7 @@ use crate::{
             self,
             node::{LeafNode, MAX_LEAF_VALUE_SIZE},
         },
+        leaf_cache::LeafCache,
         ops::{
             bit_ops::separate,
             update::{
@@ -131,6 +132,7 @@ fn init_beatree() -> TreeData {
                 .collect(),
         ),
         Index::default(),
+        LeafCache::new(1, 1024),
         leaf_store,
         bbn_store,
         PAGE_POOL.clone(),
@@ -178,14 +180,16 @@ fn exec_leaf_stage(
     let (leaf_writer, leaf_finisher) = leaf_store.start_sync();
 
     let bbn_index = &TREE_DATA.bbn_index;
-    let leaf_cache = preload_leaves(
+    let leaf_cache = LeafCache::new(commit_concurrency, 1024);
+    preload_leaves(
+        &leaf_cache,
         &leaf_reader,
         bbn_index,
         &IO_POOL.make_handle(),
         changeset.keys().cloned(),
     )
     .unwrap();
-    let leaf_page_numbers: BTreeSet<PageNumber> = leaf_cache.iter().map(|v| *v.pair().0).collect();
+    let leaf_page_numbers: BTreeSet<PageNumber> = leaf_cache.all_page_numbers();
 
     let io_handle = IO_POOL.make_handle();
     let leaf_stage_output = super::leaf_stage::run(


### PR DESCRIPTION
This is super raw; will be refined in later PRs. Let's not merge until the full stack is ready.

The cache is populated when leaves are read and when the workload creates new leaves.
