### PR TITLE
fix: handle EINTR

### DIFF
--- a/nomt/src/io/unix.rs
+++ b/nomt/src/io/unix.rs
@@ -54,11 +54,10 @@ fn execute(mut command: IoCommand) -> CompleteIo {
                 )
             },
         };
-
         match command.kind.get_result(res) {
             IoKindResult::Ok => break Ok(()),
             IoKindResult::Err => break Err(std::io::Error::last_os_error()),
-            _ => (),
+            IoKindResult::Retry => (),
         }
     };
 


### PR DESCRIPTION
Many POSIX APIs can return EINTR. Typically, this happens when a signal
is delivered to a thread spending its time in the kernel. The canonical
way to handle this error is to retry running it.

Note that this can only happen before any data is read. Excerpts from
linux man pages for read(2):

    EINTR  The call was interrupted by a signal before any data was
              read;

macOS READ(2):

    [EINTR]            A read from a slow device was interrupted before any
                        data arrived by the delivery of a signal.

From what I can tell, this also applies to iouring.