### PR TITLE
ci: run cargo fmt --check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
       - run: cargo doc --verbose --workspace --document-private-items
+  fmt:
+    name: NOMT - fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: cargo fmt --all --check
+      - run: cargo fmt --manifest-path=benchtop/Cargo.toml --check


### PR DESCRIPTION
the time has come. Noticed a lot of time fmt changes are folded into
PRs. This is slightly annoying because after looking at a line for a
couple of seconds you may realize that it's just and only a formatting
change.

If you don't want to deal with this on the CI, I suggest you to install a pre-commit hook that would warn you if you are about to commit an unformatted code.