### PR TITLE
opt(merkle): have page-walker precompute whether pages are empty

### DIFF
--- a/benchtop/Cargo.lock
+++ b/benchtop/Cargo.lock
@@ -1347,16 +1347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,10 +2209,10 @@ dependencies = [
  "anyhow",
  "bitvec",
  "blake3",
+ "cfg-if",
  "crossbeam",
  "crossbeam-channel",
  "dashmap",
- "fs2",
  "fxhash",
  "imbl",
  "io-uring",

--- a/core/src/trie_pos.rs
+++ b/core/src/trie_pos.rs
@@ -239,6 +239,11 @@ impl TriePosition {
         }
     }
 
+    /// Fast path for checking whether this is in the first layer in the page.
+    pub fn is_first_layer_in_page(&self) -> bool {
+        self.node_index & 1 == 0
+    }
+
     /// Get the number of shared bits between this position and `other`.
     ///
     /// This is essentially the depth of a hypothetical internal node which both positions would
@@ -323,6 +328,11 @@ impl ChildNodeIndices {
     /// Child node indices for the top two nodes of a page.
     pub fn next_page() -> Self {
         Self::from_left(0)
+    }
+
+    /// Whether these are at the top of a page.
+    pub fn in_next_page(&self) -> bool {
+        self.0 == 0
     }
 
     /// Get the index of the left child.

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -114,15 +114,6 @@ impl PageData {
     }
 }
 
-/// Checks whether a page is empty.
-pub fn page_is_empty(page: &[u8]) -> bool {
-    // 1. we assume the top layer of nodes are kept at index 0 and 1, respectively, and this
-    //    is packed as the first two 32-byte slots.
-    // 2. if both are empty, then the whole page is empty. this is because internal nodes
-    //    with both children as terminals are not allowed to exist.
-    &page[..64] == [0u8; 64].as_slice()
-}
-
 /// A handle to the page.
 ///
 /// Can be cloned cheaply.
@@ -481,11 +472,11 @@ impl PageCache {
                     tx.delete_page(page_id, known_bucket);
                     *bucket = None;
                 }
-                (Some(page), Some(known_bucket)) if page_is_empty(&page[..]) => {
+                (Some(_), Some(known_bucket)) if page_diff.cleared() => {
                     tx.delete_page(page_id, known_bucket);
                     *bucket = None;
                 }
-                (Some(page), maybe_bucket) => {
+                (Some(page), maybe_bucket) if !page_diff.cleared() => {
                     let new_bucket = tx.write_page(page_id, maybe_bucket, page, page_diff);
                     *bucket = Some(new_bucket);
                 }


### PR DESCRIPTION
Calling `page_is_empty` on every page was very expensive. It's cheaper to have the page-walker detect when pages have been completely cleared.
