### PR TITLE
fix: check EINTR for flock

### DIFF
--- a/nomt/src/sys/unix.rs
+++ b/nomt/src/sys/unix.rs
@@ -3,21 +3,29 @@
 use std::{fs::File, os::fd::AsRawFd as _};
 
 pub fn try_lock_exclusive(file: &File) -> std::io::Result<()> {
-    unsafe {
-        if libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == -1 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(())
-        }
-    }
+    cvt_r(|| unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) }).map(drop)
 }
 
 pub fn unlock(file: &File) -> std::io::Result<()> {
-    unsafe {
-        if libc::flock(file.as_raw_fd(), libc::LOCK_UN) == -1 {
+    unsafe { cvt_r(|| libc::flock(file.as_raw_fd(), libc::LOCK_UN)).map(drop) }
+}
+
+pub(super) fn cvt_r<F>(mut f: F) -> std::io::Result<i32>
+where
+    F: FnMut() -> i32,
+{
+    fn cvt(res: i32) -> std::io::Result<i32> {
+        if res == -1 {
             Err(std::io::Error::last_os_error())
         } else {
-            Ok(())
+            Ok(res)
+        }
+    }
+
+    loop {
+        match cvt(f()) {
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => (),
+            other => break other,
         }
     }
 }


### PR DESCRIPTION
use the cvt pattern when dealing with this kind of code, which checks
the resulting signed integer to be -1 and if it is requests errno and
converts it to an error.

this will come in-handy later because most of the syscalls we do returns
an error in this form and requires retrying in case of EINTR.