### PR TITLE
ci: add darwin check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,16 @@ jobs:
       - run: rustup update stable && rustup default stable
       - run: cargo fmt --all --check
       - run: cargo fmt --manifest-path=benchtop/Cargo.toml --check
+  darwin_check:
+    name: NOMT - check darwin target
+    runs-on: ubuntu-latest
+    env:
+      # This is a workaround for the blake3 crate.
+      CARGO_FEATURE_PURE: 1
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: rustup target add x86_64-apple-darwin
+      # Build only the NOMT crate. Not everything builds cleanly under this configuration.
+      - run: cargo check --verbose -p nomt --locked --target x86_64-apple-darwin
+


### PR DESCRIPTION
this adds a check that verifies that the nomt crate and
benchtop builds cleanly on darwin.

This is limited to the nomt crate because this is definitely
sketchy and some crates (at the moment of writing it's at
least libfuzzer) do not build.

x86-64 darwin is picked because this is what ubuntu-latest
is running.