### PR TITLE
chore: tuck beatree sync coordination inward

### DIFF
--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -50,7 +50,7 @@ pub fn update(
     io_handle: IoHandle,
     thread_pool: ThreadPool,
     workers: usize,
-) -> Result<SyncData> {
+) -> Result<(SyncData, Index)> {
     let leaf_reader = StoreReader::new(leaf_store.clone(), page_pool.clone());
     let (leaf_writer, leaf_finisher) = leaf_store.start_sync();
     let (bbn_writer, bbn_finisher) = bbn_store.start_sync();
@@ -105,13 +105,15 @@ pub fn update(
         branch_stage_outputs.post_io_drop,
     ));
 
-    Ok(SyncData {
+    Ok((
+        SyncData {
+            ln_freelist_pn: ln_meta.freelist_pn,
+            ln_bump: ln_meta.bump,
+            bbn_freelist_pn: bbn_meta.freelist_pn,
+            bbn_bump: bbn_meta.bump,
+        },
         bbn_index,
-        ln_freelist_pn: ln_meta.freelist_pn,
-        ln_bump: ln_meta.bump,
-        bbn_freelist_pn: bbn_meta.freelist_pn,
-        bbn_bump: bbn_meta.bump,
-    })
+    ))
 }
 
 // TODO: this should not be necessary with proper warm-ups.

--- a/nomt/src/beatree/ops/update/tests.rs
+++ b/nomt/src/beatree/ops/update/tests.rs
@@ -122,7 +122,7 @@ fn init_beatree() -> TreeData {
     let bbn_store =
         Store::open(&PAGE_POOL, bbn_fd.try_clone().unwrap(), PageNumber(1), None).unwrap();
 
-    let sync_data = super::update(
+    let (sync_data, bbn_index) = super::update(
         Arc::new(
             initial_items
                 .clone()
@@ -148,7 +148,7 @@ fn init_beatree() -> TreeData {
         ln_freelist_pn: sync_data.ln_freelist_pn,
         ln_bump: sync_data.ln_bump,
         init_items: initial_items,
-        bbn_index: sync_data.bbn_index,
+        bbn_index,
     }
 }
 

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -44,10 +44,6 @@ struct Shared {
     page_pool: PagePool,
     io_pool: IoPool,
     meta_fd: File,
-    #[allow(unused)]
-    ln_fd: File,
-    #[allow(unused)]
-    bbn_fd: File,
     ht_fd: File,
     // keep alive.
     #[allow(unused)]
@@ -163,8 +159,6 @@ impl Store {
                 meta.bitbox_num_pages,
                 meta.bitbox_seed,
                 o.panic_on_sync,
-                &bbn_fd,
-                &ln_fd,
             ))),
             shared: Arc::new(Shared {
                 rollback,
@@ -174,8 +168,6 @@ impl Store {
                 io_pool,
                 db_dir_fd,
                 meta_fd,
-                ln_fd,
-                bbn_fd,
                 ht_fd,
                 wal_fd,
                 flock,


### PR DESCRIPTION
Now, instead of sync handling the concurrency, beatree itself
controlls concurrency.

No functional changes.