### PR TITLE
fix: check bbn bump

### DIFF
--- a/nomt/src/beatree/ops/reconstruction.rs
+++ b/nomt/src/beatree/ops/reconstruction.rs
@@ -92,6 +92,10 @@ impl SeqFileReader {
             len >= BRANCH_NODE_SIZE as u64,
             "file is too small for BBN store"
         );
+        ensure!(
+            bump as u64 <= len / BRANCH_NODE_SIZE as u64,
+            "bump is out of bounds"
+        );
 
         let pn = 0u32;
         let ptr = unsafe {


### PR DESCRIPTION
Getting out-of-range is outside of our assumptions but
we should be defensive here anyway since that can lead
to an out-of-bounds access.