### PR TITLE
feat: introduce db magic & version

### DIFF
--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -298,6 +298,8 @@ fn create(o: &crate::Options) -> anyhow::Result<()> {
     let mut meta_fd = std::fs::File::create(o.path.join("meta"))?;
     let mut buf = [0u8; 4096];
     Meta {
+        magic: meta::MAGIC,
+        version: meta::VERSION,
         ln_freelist_pn: 0,
         ln_bump: 1,
         bbn_freelist_pn: 0,
@@ -308,7 +310,7 @@ fn create(o: &crate::Options) -> anyhow::Result<()> {
         rollback_start_live: 0,
         rollback_end_live: 0,
     }
-    .encode_to(&mut buf[0..56]);
+    .encode_to(&mut buf[0..meta::META_SIZE]);
     meta_fd.write_all(&buf)?;
     meta_fd.sync_all()?;
     drop(meta_fd);

--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -1,4 +1,7 @@
-use super::{meta::Meta, MerkleTransaction, Shared, ValueTransaction};
+use super::{
+    meta::{self, Meta},
+    MerkleTransaction, Shared, ValueTransaction,
+};
 use crate::{beatree, bitbox, merkle, page_cache::PageCache, rollback};
 
 use crossbeam::channel::{self, Receiver};
@@ -78,6 +81,8 @@ impl Sync {
         let beatree_meta_wd = beatree_sync.wait_pre_meta().unwrap();
 
         let new_meta = Meta {
+            magic: meta::MAGIC,
+            version: meta::VERSION,
             ln_freelist_pn: beatree_meta_wd.ln_freelist_pn,
             ln_bump: beatree_meta_wd.ln_bump,
             bbn_freelist_pn: beatree_meta_wd.bbn_freelist_pn,


### PR DESCRIPTION
Introduces a version number to the manifest file.

Version numbering starts with 1, 0 is an invalid version. Magic
number is set to bytes equivalent to the ASCII string `NOMT`.

This also adds validation rules: invalid magic is rejected. Version
less than 1 is rejected. Also the validation code will reject all versions
above the current one assuming they will introduce incompatibilities.

I anticipate that we can preserve backward compatibility in some cases and
therefore opening db formats with lower version might be possible. If not,
then a validation error should also be returned.

Closes THR-36