### PR TITLE
chore: remove unused result

### DIFF
--- a/nomt/src/rollback/mod.rs
+++ b/nomt/src/rollback/mod.rs
@@ -200,7 +200,7 @@ impl Rollback {
     }
 
     /// Dumps the contents of the staging to the rollback.
-    pub fn writeout_start(&self) -> anyhow::Result<WriteoutData> {
+    pub fn writeout_start(&self) -> WriteoutData {
         let mut in_memory = self.shared.in_memory.lock();
         let seglog = self.shared.seglog.lock();
 
@@ -208,12 +208,12 @@ impl Rollback {
 
         // NOTE: for now, if there is a pending truncate, we ignore everything else.
         if let Some(pending_truncate) = pending_truncate {
-            return Ok(WriteoutData {
+            return WriteoutData {
                 rollback_start_live: seglog.live_range().0 .0,
                 rollback_end_live: pending_truncate,
                 prune_to_new_start_live: None,
                 prune_to_new_end_live: Some(pending_truncate),
-            });
+            };
         }
 
         let prune_to_new_start_live = if in_memory.total_len() > self.shared.max_rollback_log_len {
@@ -224,12 +224,12 @@ impl Rollback {
 
         let (rollback_start_live, rollback_end_live) = seglog.live_range();
 
-        Ok(WriteoutData {
+        WriteoutData {
             rollback_start_live: rollback_start_live.0,
             rollback_end_live: rollback_end_live.0,
             prune_to_new_start_live,
             prune_to_new_end_live: None,
-        })
+        }
     }
 
     /// Finalizes the writeout.

--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -132,7 +132,7 @@ fn spawn_rollback_writeout_start(
             let (result_tx, result_rx) = channel::bounded(1);
             let rollback = rollback.clone();
             tp.execute(move || {
-                let writeout_data = rollback.writeout_start().unwrap();
+                let writeout_data = rollback.writeout_start();
                 let _ = result_tx.send(writeout_data);
             });
             Some(result_rx)


### PR DESCRIPTION
Quick change that removes unnecessary result.