### PR TITLE
fix: disable iopoll on tmpfs

### DIFF
--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -96,8 +96,8 @@ struct IoPacket {
 
 /// Create an I/O worker managing an io_uring and sending responses back via channels to a number
 /// of handles.
-pub fn start_io_pool(io_workers: usize, page_pool: PagePool) -> IoPool {
-    let sender = platform::start_io_worker(io_workers, true);
+pub fn start_io_pool(io_workers: usize, iopoll: bool, page_pool: PagePool) -> IoPool {
+    let sender = platform::start_io_worker(io_workers, iopoll);
     IoPool { sender, page_pool }
 }
 


### PR DESCRIPTION
reading from a file that is stored on tmpfs seemingly
returns all zeroes. Disable iopoll if run on tmpfs.

reproduced on linux 5.15 ubuntu.