### PR TITLE
refactor(beatree)!: include value hash in overflow cells

### DIFF
--- a/nomt/src/beatree/leaf/node.rs
+++ b/nomt/src/beatree/leaf/node.rs
@@ -6,7 +6,7 @@
 /// padding: [u8] // empty space between cell_pointers and cells
 /// cells: [Cell; n]
 /// value cell: [u8]
-/// overflow cell: (u64, [NodePointer]) | semantically, (value_size, [NodePointer]).
+/// overflow cell: (u64, u256, [NodePointer]) | semantically, (value_size, value_hash, [NodePointer]).
 /// ```
 ///
 /// | n | [(key ++ offset); n] | ----  | [[u8]; n] |
@@ -41,7 +41,7 @@ pub const MAX_LEAF_VALUE_SIZE: usize = (LEAF_NODE_BODY_SIZE / 3) - 32;
 /// The maximum number of node pointers which may appear directly in an overflow cell.
 ///
 /// Note that this gives an overflow value cell maximum size of 100 bytes.
-pub const MAX_OVERFLOW_CELL_NODE_POINTERS: usize = 23;
+pub const MAX_OVERFLOW_CELL_NODE_POINTERS: usize = 15;
 
 /// We use the high bit to encode whether a cell is an overflow cell.
 const OVERFLOW_BIT: u16 = 1 << 15;

--- a/nomt/src/beatree/ops/update/leaf_stage.rs
+++ b/nomt/src/beatree/ops/update/leaf_stage.rs
@@ -23,7 +23,7 @@ use crate::beatree::{
             leaf_updater::{BaseLeaf, DigestResult as LeafDigestResult, LeafUpdater},
         },
     },
-    Key,
+    Key, ValueChange,
 };
 use crate::io::{IoCommand, IoHandle, IoKind, IoPool, PAGE_SIZE};
 
@@ -87,7 +87,7 @@ pub fn run(
     leaf_reader: StoreReader,
     leaf_writer: SyncAllocator,
     io_handle: IoHandle,
-    changeset: Arc<BTreeMap<Key, Option<Vec<u8>>>>,
+    changeset: Arc<BTreeMap<Key, ValueChange>>,
     thread_pool: ThreadPool,
     num_workers: usize,
 ) -> anyhow::Result<LeafStageOutput> {
@@ -101,16 +101,16 @@ pub fn run(
     let changeset = changeset
         .iter()
         .map(|(k, v)| match v {
-            Some(v) if v.len() <= MAX_LEAF_VALUE_SIZE => Ok((*k, Some((v.clone(), false)))),
-            Some(large_value) => {
+            ValueChange::Insert(v) => Ok((*k, Some((v.clone(), false)))),
+            ValueChange::InsertOverflow(large_value, value_hash) => {
                 let (pages, num_writes) =
                     overflow::chunk(&large_value, &leaf_writer, &page_pool, &io_handle)?;
                 overflow_io += num_writes;
 
-                let cell = overflow::encode_cell(large_value.len(), &pages);
+                let cell = overflow::encode_cell(large_value.len(), value_hash.clone(), &pages);
                 Ok((*k, Some((cell, true))))
             }
-            None => Ok((*k, None)),
+            ValueChange::Delete => Ok((*k, None)),
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -11,7 +11,7 @@ use crate::beatree::{
     leaf::node::LEAF_NODE_BODY_SIZE,
     leaf_cache::LeafCache,
     ops::get_key,
-    Key, SyncData,
+    Key, SyncData, ValueChange,
 };
 use crate::io::{IoHandle, PagePool};
 
@@ -43,7 +43,7 @@ const LEAF_BULK_SPLIT_TARGET: usize = (LEAF_NODE_BODY_SIZE * 3) / 4;
 ///
 /// The changeset is a list of key value pairs to be added or removed from the btree.
 pub fn update(
-    changeset: Arc<BTreeMap<Key, Option<Vec<u8>>>>,
+    changeset: Arc<BTreeMap<Key, ValueChange>>,
     mut bbn_index: Index,
     leaf_cache: LeafCache,
     leaf_store: Store,

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -348,7 +348,7 @@ impl<T: HashAlgorithm> Nomt<T> {
         let mut tx = self.store.new_value_tx();
         for (path, read_write) in actuals {
             if let KeyReadWrite::Write(value) | KeyReadWrite::ReadThenWrite(_, value) = read_write {
-                tx.write_value(path, value);
+                tx.write_value::<T>(path, value);
             }
         }
 

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     page_cache::PageCache,
     page_diff::PageDiff,
     rollback::Rollback,
+    ValueHasher,
 };
 use meta::Meta;
 use nomt_core::{page_id::PageId, trie::KeyPath};
@@ -260,13 +261,14 @@ impl Store {
 /// An atomic transaction on raw key/value pairs to be applied against the store
 /// with [`Store::commit`].
 pub struct ValueTransaction {
-    batch: Vec<(KeyPath, Option<Vec<u8>>)>,
+    batch: Vec<(KeyPath, beatree::ValueChange)>,
 }
 
 impl ValueTransaction {
     /// Write a value to flat storage.
-    pub fn write_value(&mut self, path: KeyPath, value: Option<Vec<u8>>) {
-        self.batch.push((path, value))
+    pub fn write_value<T: ValueHasher>(&mut self, path: KeyPath, value: Option<Vec<u8>>) {
+        self.batch
+            .push((path, beatree::ValueChange::from_option::<T>(value)))
     }
 }
 


### PR DESCRIPTION
Including the value hash in overflow cells enables us to always obtain the value hash associated with any key just by reading the relevant leaf. This is a pre-requisite for removing leaf-children.
