### PR TITLE
refactor(beatree): introduce a read transaction type

### DIFF
--- a/nomt/src/beatree/ops/update/leaf_stage.rs
+++ b/nomt/src/beatree/ops/update/leaf_stage.rs
@@ -1,7 +1,7 @@
-use std::collections::BTreeMap;
 use std::ops::Range;
 use std::sync::Arc;
 
+use imbl::OrdMap;
 use threadpool::ThreadPool;
 
 use crate::beatree::{
@@ -84,7 +84,7 @@ pub fn run(
     leaf_reader: StoreReader,
     leaf_writer: SyncAllocator,
     io_handle: IoHandle,
-    changeset: Arc<BTreeMap<Key, ValueChange>>,
+    changeset: OrdMap<Key, ValueChange>,
     thread_pool: ThreadPool,
     num_workers: usize,
 ) -> anyhow::Result<LeafStageOutput> {

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use crossbeam_channel::Receiver;
+use imbl::OrdMap;
 use threadpool::ThreadPool;
 
 use std::{collections::BTreeMap, sync::Arc};
@@ -43,7 +44,7 @@ const LEAF_BULK_SPLIT_TARGET: usize = (LEAF_NODE_BODY_SIZE * 3) / 4;
 ///
 /// The changeset is a list of key value pairs to be added or removed from the btree.
 pub fn update(
-    changeset: Arc<BTreeMap<Key, ValueChange>>,
+    changeset: OrdMap<Key, ValueChange>,
     mut bbn_index: Index,
     leaf_cache: LeafCache,
     leaf_store: Store,

--- a/nomt/src/beatree/ops/update/tests.rs
+++ b/nomt/src/beatree/ops/update/tests.rs
@@ -126,13 +126,11 @@ fn init_beatree() -> TreeData {
     let bbn_store = Store::open(&PAGE_POOL, bbn_fd.clone(), PageNumber(1), None).unwrap();
 
     let (sync_data, bbn_index, _) = super::update(
-        Arc::new(
-            initial_items
-                .clone()
-                .into_iter()
-                .map(|(k, v)| (k, ValueChange::Insert(v)))
-                .collect(),
-        ),
+        initial_items
+            .clone()
+            .into_iter()
+            .map(|(k, v)| (k, ValueChange::Insert(v)))
+            .collect(),
         Index::default(),
         LeafCache::new(1, 1024),
         leaf_store,
@@ -211,7 +209,7 @@ fn exec_leaf_stage(
         leaf_reader,
         leaf_writer,
         io_handle.clone(),
-        Arc::new(changeset.into_iter().collect()),
+        changeset.into_iter().collect(),
         THREAD_POOL.clone(),
         commit_concurrency,
     )


### PR DESCRIPTION
This introduces a basic read transaction type (not currently used) that is a first step towards enabling a safe asynchronous API for beatree. The immediate motivations are:
  1. The removal of leaf children requires us to query many leaves asynchronously during merkle update.
  2. Likewise, the rollback log requires us to do the same in order to fetch previous values.

A less immediate but also useful goal is read transactions being used in `Session`s to enable parallel VMs to operate with fewer threads. This is groundwork for that future.

Read transactions don't block commit or `finish_sync` (leaving room for "async sync" in the future), but do block `sync` from beginning. We can expect that sync will _start_ at a natural moment where there are no outstanding read transactions (after a session is committed). When a sync will end is less predictable, and leaving some space for pipelining will be beneficial.
