### PR TITLE
opt: write raw operates on page

### DIFF
--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -8,7 +8,7 @@ use crate::{
         ops::{bit_ops::bitwise_memcpy, get_key},
         Key,
     },
-    io::{FatPage, PagePool},
+    io::{page_pool::Page, FatPage, PagePool},
 };
 
 // Here is the layout of a branch node:
@@ -52,6 +52,10 @@ impl BranchNode {
 
     pub fn as_slice(&self) -> &[u8] {
         &*self.page
+    }
+
+    pub fn page(&self) -> Page {
+        self.page.page()
     }
 
     pub fn view(&self) -> BranchNodeView {

--- a/nomt/src/beatree/ops/update/branch_stage.rs
+++ b/nomt/src/beatree/ops/update/branch_stage.rs
@@ -8,8 +8,7 @@ use crate::beatree::{
     index::Index,
     Key,
 };
-
-use crate::io::{IoCommand, IoHandle, IoKind, PagePool, PAGE_SIZE};
+use crate::io::{IoCommand, IoHandle, IoKind, PagePool};
 
 use super::branch_updater::{BaseBranch, BranchUpdater, DigestResult as BranchDigestResult};
 use super::extend_range_protocol::{
@@ -420,10 +419,10 @@ impl super::branch_updater::HandleNewBranch for NewBranchHandler {
         let bbn = Arc::new(bbn);
 
         // TODO: handle error
-        let ptr = bbn.as_slice().as_ptr();
+        let page = bbn.page();
         self.io_handle
             .send(IoCommand {
-                kind: IoKind::WriteRaw(fd, page_number.0 as u64, ptr, PAGE_SIZE),
+                kind: IoKind::WriteRaw(fd, page_number.0 as u64, page),
                 user_data: 0,
             })
             .expect("I/O Pool Down");

--- a/nomt/src/beatree/ops/update/leaf_stage.rs
+++ b/nomt/src/beatree/ops/update/leaf_stage.rs
@@ -22,7 +22,7 @@ use crate::beatree::{
     },
     Key, ValueChange,
 };
-use crate::io::{IoCommand, IoHandle, IoKind, IoPool, PAGE_SIZE};
+use crate::io::{IoCommand, IoHandle, IoKind, IoPool};
 
 /// Tracker of all changes that happen to leaves during an update
 pub type LeavesTracker = super::NodesTracker<LeafNode>;
@@ -577,10 +577,10 @@ impl super::leaf_updater::HandleNewLeaf for NewLeafHandler {
         let page_number = self.leaf_writer.allocate().unwrap();
 
         // TODO: handle error
-        let ptr = leaf.inner.as_ptr();
+        let page = leaf.inner.page();
         self.io_handle
             .send(IoCommand {
-                kind: IoKind::WriteRaw(fd, page_number.0 as u64, ptr, PAGE_SIZE),
+                kind: IoKind::WriteRaw(fd, page_number.0 as u64, page),
                 user_data: 0,
             })
             .expect("I/O Pool Down");

--- a/nomt/src/io/linux.rs
+++ b/nomt/src/io/linux.rs
@@ -143,8 +143,8 @@ fn submission_entry(command: &mut IoCommand) -> squeue::Entry {
                 .offset(page_index * PAGE_SIZE as u64)
                 .build()
         }
-        IoKind::WriteRaw(fd, page_index, ptr, size) => {
-            opcode::Write::new(types::Fd(fd), ptr, size as u32)
+        IoKind::WriteRaw(fd, page_index, ref page) => {
+            opcode::Write::new(types::Fd(fd), page.as_ptr(), PAGE_SIZE as u32)
                 .offset(page_index * PAGE_SIZE as u64)
                 .build()
         }

--- a/nomt/src/io/page_pool.rs
+++ b/nomt/src/io/page_pool.rs
@@ -76,6 +76,14 @@ impl FatPage {
     pub fn as_mut_ptr(&self) -> *mut u8 {
         self.page.as_mut_ptr()
     }
+
+    /// Returns underlying [`Page`].
+    ///
+    /// Care must be taken that the returned page is not used after `self` is dropped. However,
+    /// failing to do so will not cause safety bugs.
+    pub fn page(&self) -> Page {
+        self.page.clone()
+    }
 }
 
 impl Deref for FatPage {

--- a/nomt/src/io/unix.rs
+++ b/nomt/src/io/unix.rs
@@ -45,11 +45,11 @@ fn execute(mut command: IoCommand) -> CompleteIo {
                     (page_index * PAGE_SIZE as u64) as libc::off_t,
                 )
             },
-            IoKind::WriteRaw(fd, page_index, ptr, size) => unsafe {
+            IoKind::WriteRaw(fd, page_index, ref mut page) => unsafe {
                 libc::pwrite(
                     fd,
-                    ptr as *const libc::c_void,
-                    size as libc::size_t,
+                    page.as_ptr() as *const libc::c_void,
+                    PAGE_SIZE as libc::size_t,
                     (page_index * PAGE_SIZE as u64) as libc::off_t,
                 )
             },


### PR DESCRIPTION
This is one of the first steps on the way to reduce the proliferation of FatPage across the codebase. 

The plan here is to gradually switch to Page in the IO subsystem. In the near future, Write and WriteRaw will be merged together.