### PR TITLE
fix: page_walker and trie_position bugs

### DIFF
--- a/core/src/trie_pos.rs
+++ b/core/src/trie_pos.rs
@@ -248,7 +248,7 @@ impl TriePosition {
 
     /// Fast path for checking whether this is in the first layer in the page.
     pub fn is_first_layer_in_page(&self) -> bool {
-        self.node_index & 1 == 0
+        self.node_index & !1 == 0
     }
 
     /// Get the number of shared bits between this position and `other`.


### PR DESCRIPTION
`TriePosition::is_first_layer_in_page` was returning a false positive.
`PageWalker::build_stack` wasn't respecting the comment:
 > or `None`, if we need to push the root page as well
 
Tests have been fixed/added to ensure the correct behavior
of the corrected function and the usage of the clear bit in the page diff.