### PR TITLE
refactor: add BranchOpsTracker

### DIFF
--- a/nomt/src/beatree/ops/update/branch_ops.rs
+++ b/nomt/src/beatree/ops/update/branch_ops.rs
@@ -1,0 +1,969 @@
+use std::ops::Deref;
+
+use crate::beatree::{
+    branch::node::{self, get_key, BRANCH_NODE_BODY_SIZE},
+    ops::{
+        bit_ops::separator_len,
+        update::{
+            branch_updater::{BaseBranch, BranchGauge},
+            BRANCH_MERGE_THRESHOLD,
+        },
+    },
+    Key, PageNumber,
+};
+
+// BranchOp used to create a new node starting off a possible base node.
+//
+// `Update` and `KeepChunk` refers only to compressed separator within the base node.
+pub enum BranchOp {
+    // Separator and its page number
+    Insert(Key, PageNumber),
+    // Contains the position at which the separator is saved in the base,
+    // along with the updated page number
+    Update(usize, PageNumber),
+    // Contains a range of separators that will be transfered unchanged
+    // in the new node from the base.
+    //
+    // These are always items which were prefix-compressed.
+    KeepChunk(KeepChunk),
+}
+
+// KeepChunk represents a sequence of separators contained in a branch node.
+// `start` and `end` represents the separators range where `end` is non inclusive.
+// 0-Sized chunks are not allowed, thus `start > end` must always hold.
+// `sum_separator_lengths` is the sum of the separator lengths of each separator
+// represented by the chunk itself.
+#[derive(Debug, Clone, Copy)]
+pub struct KeepChunk {
+    pub start: usize,
+    pub end: usize,
+    pub sum_separator_lengths: usize,
+}
+
+impl KeepChunk {
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+// Keeps track of all BranchOp that needs to be applied to the new branch node.
+//
+// It ensures that all operations that are extracted to build a branch node
+// will respect the constraints on the usage of uncompressed separators.
+pub struct BranchOpsTracker {
+    ops: Vec<BranchOp>,
+    // gauges total size of branch after ops applied.
+    gauge: BranchGauge,
+    // ensure that the gauge correctly reflects the ops
+    valid_gauge: bool,
+}
+
+impl BranchOpsTracker {
+    pub fn new() -> Self {
+        Self {
+            ops: vec![],
+            gauge: BranchGauge::default(),
+            valid_gauge: true,
+        }
+    }
+
+    // Push a new BranchOp::Insert operation.
+    pub fn push_insert(&mut self, key: Key, pn: PageNumber) {
+        assert!(self.valid_gauge);
+        let op = BranchOp::Insert(key, pn);
+        self.gauge.ingest_branch_op(None, &op);
+        self.ops.push(op);
+    }
+
+    // Push a new BranchOp::Update operation.
+    pub fn push_update(&mut self, base: &BaseBranch, pos: usize, pn: PageNumber) {
+        assert!(self.valid_gauge);
+        let op = BranchOp::Update(pos, pn);
+        self.gauge.ingest_branch_op(Some(base), &op);
+        self.ops.push(op);
+
+        // Replace with Insert if:
+        // 1. Prefix compression is stopped.
+        // 2. Update op is referring to an uncompressed separator.
+        if base.node.prefix_compressed() as usize <= pos || self.gauge.prefix_compressed.is_some() {
+            self.replace_with_insert(Some(base), self.ops.len() - 1);
+        }
+    }
+
+    // Push a new BranchOp::KeepChunk operation.
+    pub fn push_chunk(&mut self, base: &BaseBranch, start: usize, end: usize) {
+        assert!(self.valid_gauge);
+
+        let base_compressed_end = std::cmp::min(end, base.node.prefix_compressed() as usize);
+
+        if start != base_compressed_end {
+            let chunk = KeepChunk {
+                start,
+                end: base_compressed_end,
+                sum_separator_lengths: node::uncompressed_separator_range_size(
+                    base.node.prefix_len() as usize,
+                    base.node.separator_range_len(start, base_compressed_end),
+                    base_compressed_end - start,
+                    separator_len(&base.key(start)),
+                ),
+            };
+
+            let branch_op = BranchOp::KeepChunk(chunk);
+            self.gauge.ingest_branch_op(Some(base), &branch_op);
+            self.ops.push(branch_op);
+
+            // Replace with Insert if prefix compression is stopped.
+            if self.gauge.prefix_compressed.is_some() {
+                self.replace_with_insert(Some(base), self.ops.len() - 1);
+            }
+        }
+
+        // Every kept uncompressed separator becomes an Insert operation.
+        for i in base_compressed_end..end {
+            let (key, pn) = base.key_value(i);
+            self.push_insert(key, pn);
+        }
+    }
+
+    fn replace_with_insert(&mut self, base: Option<&BaseBranch>, op_index: usize) -> usize {
+        match self.ops[op_index] {
+            BranchOp::Insert(_, _) => 1,
+            BranchOp::Update(pos, new_pn) => {
+                // UNWRAP: `Update` op only exists when base is Some.
+                self.ops[op_index] = BranchOp::Insert(base.unwrap().key(pos), new_pn);
+                1
+            }
+            BranchOp::KeepChunk(chunk) => {
+                self.ops.remove(op_index);
+
+                for pos in (chunk.start..chunk.end).into_iter().rev() {
+                    // UNWRAP: `KeepChunk` op only exists when base is Some.
+                    let (key, pn) = base.unwrap().key_value(pos);
+                    self.ops.insert(op_index, BranchOp::Insert(key, pn));
+                }
+                chunk.end - chunk.start
+            }
+        }
+    }
+
+    // Extract the first item within a `BranchOp::KeepChunk` operation into a `BranchOp::Insert`.
+    fn extract_insert_from_keep_chunk(&mut self, base: &BaseBranch, index: usize) {
+        let BranchOp::KeepChunk(chunk) = self.ops[index] else {
+            panic!(
+                "Attempted to extract `BranchOp::Insert` from non `BranchOp::KeepChunk` operation"
+            );
+        };
+
+        let (key, pn) = base.key_value(chunk.start);
+        let separator_len = separator_len(&key);
+
+        if chunk.start == chunk.end - 1 {
+            // 0-sized chunks are not allowed,
+            // thus 1-Sized chunks become just an `BranchOp::Insert`.
+            self.ops[index] = BranchOp::Insert(key, pn);
+        } else {
+            self.ops[index] = BranchOp::KeepChunk(KeepChunk {
+                start: chunk.start + 1,
+                end: chunk.end,
+                sum_separator_lengths: chunk.sum_separator_lengths - separator_len,
+            });
+            self.ops.insert(index, BranchOp::Insert(key, pn));
+        }
+    }
+
+    // Body size of a branch node that would be built with all available ops.
+    pub fn body_size(&self) -> usize {
+        assert!(self.valid_gauge);
+        self.gauge.body_size()
+    }
+
+    // Extract all available operations alongside their gauge.
+    pub fn extract_ops<'a>(&'a mut self) -> (BranchOps<'a>, BranchGauge) {
+        assert!(self.valid_gauge);
+        let end = self.ops.len();
+        let gauge = std::mem::take(&mut self.gauge);
+        (
+            BranchOps {
+                ops: &mut self.ops,
+                end,
+            },
+            gauge,
+        )
+    }
+
+    // Extract a series of operations that is able to construct a branch node
+    // with the specified target size.
+    //
+    // If `stop_prefix_compression` has to be called, then the target becomes BRANCH_MERGE_THRESHOLD
+    // to minimize the amount of uncompressed items inserted in the node.
+    //
+    // SAFETY: This function is expected to be called in a loop until None is returned.
+    pub fn extract_ops_until<'a>(
+        &'a mut self,
+        base: Option<&BaseBranch>,
+        mut target: usize,
+    ) -> Option<(BranchOps<'a>, BranchGauge)> {
+        let mut pos = 0;
+        let mut gauge = BranchGauge::default();
+
+        while pos < self.ops.len() && gauge.body_size() < target {
+            match *&self.ops[pos] {
+                BranchOp::Insert(key, _) => {
+                    if gauge.body_size_after(key, separator_len(&key)) > BRANCH_NODE_BODY_SIZE {
+                        if gauge.body_size() < BRANCH_MERGE_THRESHOLD {
+                            // rare case: body was artifically small due to long shared prefix.
+                            // start applying items without prefix compression. we assume items are less
+                            // than half the body size, so the next item should apply cleanly.
+                            gauge.stop_prefix_compression();
+                            // change the target requirement to minumize the number of non
+                            // compressed separators saved into one node
+                            target = BRANCH_MERGE_THRESHOLD;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                BranchOp::Update(update_pos, _) => {
+                    // UNWRAP: `Update` op only exist when base is Some.
+                    let key = base.unwrap().key(update_pos);
+
+                    if gauge.body_size_after(key, separator_len(&key)) > BRANCH_NODE_BODY_SIZE {
+                        if gauge.body_size() < BRANCH_MERGE_THRESHOLD {
+                            // Replace the Update op and repeat the loop
+                            // to see if `stop_prefix_compression` is activated
+                            self.replace_with_insert(base, pos);
+                            continue;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                BranchOp::KeepChunk(chunk) => {
+                    // UNWRAP: `KeepChunk` op only exists when base is Some.
+                    let base = base.unwrap();
+
+                    if gauge.body_size_after_chunk(base, &chunk) > target {
+                        // Try to split the chunk to make it fit into the available space.
+                        // `try_split_keep_chunk` works on the gauge thus it accounts for a possible
+                        // stop of the prefix compression even if working on a KeepChunk operation
+                        let left_n_items = self.try_split_keep_chunk(
+                            base,
+                            &gauge,
+                            pos,
+                            target,
+                            BRANCH_NODE_BODY_SIZE,
+                        );
+
+                        if left_n_items == 0 {
+                            // If no item from the chunk is capable of fitting,
+                            // then extract the first element from the chunk and repeat the loop
+                            // to see if `stop_prefix_compression` is activated
+                            self.extract_insert_from_keep_chunk(base, pos);
+                            continue;
+                        }
+                    }
+                }
+            };
+
+            gauge.ingest_branch_op(base, &self.ops[pos]);
+            let n_ops = if gauge.prefix_compressed.is_some() {
+                // replace everything with Insert if the prefix compression was stopped
+                self.replace_with_insert(base, pos)
+            } else {
+                1
+            };
+            pos += n_ops;
+        }
+
+        if gauge.body_size() >= target {
+            self.valid_gauge = false;
+            Some((
+                BranchOps {
+                    ops: &mut self.ops,
+                    end: pos,
+                },
+                gauge,
+            ))
+        } else {
+            self.valid_gauge = true;
+            self.gauge = gauge;
+            None
+        }
+    }
+
+    // Replace `KeepChunk` and `Update` ops with `Insert` ops,
+    // preparing for the base to be changed.
+    pub fn prepare_merge_ops(&mut self, base: Option<&BaseBranch>) {
+        assert!(self.valid_gauge);
+
+        let mut i = 0;
+        while i < self.ops.len() {
+            let replaced_ops = self.replace_with_insert(base, i);
+            i += replaced_ops;
+        }
+    }
+
+    // Try to split `self.ops[index]`, which is expected to be KeepChunk,
+    // into two halves, targeting a `target` size and and not exceeding a `limit`.
+    //
+    // `target` and `limit` are required to understand when to accept a split
+    // with a final size smaller than the target. Constraining the split to always
+    // be bigger than the target causes the update algorithm to frequently
+    // fall into underfull to overfull scenarios.
+    fn try_split_keep_chunk(
+        &mut self,
+        base: &BaseBranch,
+        gauge: &BranchGauge,
+        index: usize,
+        target: usize,
+        limit: usize,
+    ) -> usize {
+        let BranchOp::KeepChunk(chunk) = self.ops[index] else {
+            panic!("Attempted to split non `BranchOp::KeepChunk` operation");
+        };
+
+        let mut left_chunk_n_items = 0;
+        let mut left_chunk_sum_separator_lengths = 0;
+        let mut gauge = gauge.clone();
+        for i in chunk.start..chunk.end {
+            left_chunk_n_items += 1;
+
+            let key = get_key(&base.node, i);
+            let separator_len = separator_len(&key);
+            let body_size_after = gauge.body_size_after(key, separator_len);
+
+            if body_size_after >= target {
+                // if an item jumps from below the target to bigger then the limit, do not use it
+                if body_size_after > limit {
+                    left_chunk_n_items -= 1;
+                } else {
+                    gauge.ingest_key(key, separator_len);
+                    left_chunk_sum_separator_lengths += separator_len;
+                }
+                break;
+            }
+            left_chunk_sum_separator_lengths += separator_len;
+            gauge.ingest_key(key, separator_len);
+        }
+
+        // if none or all elements are taken then nothing needs to be changed
+        if left_chunk_n_items != 0 && chunk.len() != left_chunk_n_items {
+            let left_chunk = KeepChunk {
+                start: chunk.start,
+                end: chunk.start + left_chunk_n_items,
+                sum_separator_lengths: left_chunk_sum_separator_lengths,
+            };
+
+            let right_chunk = KeepChunk {
+                start: chunk.start + left_chunk_n_items,
+                end: chunk.end,
+                sum_separator_lengths: chunk.sum_separator_lengths
+                    - left_chunk_sum_separator_lengths,
+            };
+
+            self.ops.insert(index, BranchOp::KeepChunk(left_chunk));
+            self.ops[index + 1] = BranchOp::KeepChunk(right_chunk);
+        }
+        left_chunk_n_items
+    }
+}
+
+// Simple wrapper over a series of BranchOp meant to be used as &[BranchOp],
+// with the added feature of draining the slice from the initial container
+// of the operations.
+pub struct BranchOps<'a> {
+    ops: &'a mut Vec<BranchOp>,
+    end: usize,
+}
+
+impl<'a> Deref for BranchOps<'a> {
+    type Target = [BranchOp];
+    fn deref(&self) -> &Self::Target {
+        &self.ops[..self.end]
+    }
+}
+
+impl<'a> Drop for BranchOps<'a> {
+    fn drop(&mut self) {
+        self.ops.drain(..self.end);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::beatree::{
+        branch::node::{self, get_key, BRANCH_NODE_BODY_SIZE},
+        ops::{
+            bit_ops::separator_len,
+            update::{
+                branch_ops::{BranchOp, BranchOpsTracker, KeepChunk},
+                branch_updater::{
+                    tests::{make_branch, make_branch_with_body_size_target, prefixed_key},
+                    BaseBranch, BranchGauge,
+                },
+                BRANCH_BULK_SPLIT_TARGET, BRANCH_BULK_SPLIT_THRESHOLD, BRANCH_MERGE_THRESHOLD,
+            },
+        },
+        Key, PageNumber,
+    };
+
+    #[test]
+    fn bulk_split() {
+        let key = |i| prefixed_key(0x00, 16, i);
+
+        let mut gauge = BranchGauge::default();
+        let mut n_keys = 0;
+
+        let mut ops_tracker = BranchOpsTracker::new();
+
+        while gauge.body_size() < BRANCH_BULK_SPLIT_THRESHOLD {
+            let key = key(n_keys);
+
+            gauge.ingest_key(key, separator_len(&key));
+            ops_tracker.push_insert(key, PageNumber(n_keys as u32));
+
+            n_keys += 1;
+        }
+
+        let mut n_splits = 0;
+        let mut n_items_in_splits = 0;
+        while let Some((ops, _gauge)) =
+            ops_tracker.extract_ops_until(None, BRANCH_BULK_SPLIT_TARGET)
+        {
+            n_splits += 1;
+            n_items_in_splits += ops.len();
+        }
+
+        let expected_bulk_split = BRANCH_BULK_SPLIT_THRESHOLD / BRANCH_BULK_SPLIT_TARGET;
+
+        // After ingesting all those ops, the bulk split is expected to be initiated.
+        assert_eq!(n_splits, expected_bulk_split);
+        // The gauge needs to contain all the ops not present in the previous split.
+        assert_eq!(ops_tracker.gauge.n(), n_keys - n_items_in_splits);
+        // Operations are expected to be drainded.
+        assert_eq!(ops_tracker.ops.len(), n_keys - n_items_in_splits);
+    }
+
+    #[test]
+    fn extract_ops_until_only_inserts() {
+        let key = |i| prefixed_key(0x00, 16, i);
+        let mut gauge = BranchGauge::default();
+        let target = BRANCH_MERGE_THRESHOLD;
+        let mut ops_tracker = BranchOpsTracker::new();
+
+        // Collect BranchOp::Insert into updater.ops until the gauge associated
+        // to the ops is just after the target.
+        let mut rightsized = false;
+        ops_tracker.ops = (0..)
+            .map(|i| key(i))
+            .take_while(|key| {
+                let res = !rightsized;
+                rightsized = gauge.body_size_after(*key, separator_len(key)) >= target;
+
+                if res {
+                    gauge.ingest_key(*key, separator_len(key));
+                }
+                res
+            })
+            .enumerate()
+            .map(|(i, key)| BranchOp::Insert(key, PageNumber(i as u32)))
+            .collect();
+        let n_ops = ops_tracker.ops.len();
+
+        // All ops are expected to be consumed without any modification.
+        let Some((res_ops, res_gauge)) = ops_tracker.extract_ops_until(None, target) else {
+            panic!()
+        };
+
+        assert_eq!(res_ops.len(), n_ops);
+        assert_eq!(res_gauge.body_size(), gauge.body_size());
+        drop(res_ops);
+        assert!(ops_tracker.ops.is_empty());
+    }
+
+    #[test]
+    fn extract_ops_until_only_updates() {
+        let key = |i| prefixed_key(0x00, 16, i);
+
+        let mut gauge = BranchGauge::default();
+        let target = BRANCH_MERGE_THRESHOLD;
+
+        let branch = make_branch_with_body_size_target(key, |size| size < BRANCH_NODE_BODY_SIZE);
+
+        let mut ops_tracker = BranchOpsTracker::new();
+        let base = Some(BaseBranch::new(branch.clone()));
+
+        // Collect BranchOp::Update into updater.ops until the gauge associated
+        // to the ops is just after the target.
+        let mut rightsized = false;
+        ops_tracker.ops = (0..)
+            .map(|i| (i, get_key(&branch, i)))
+            .take_while(|(_i, key)| {
+                let res = !rightsized;
+                rightsized = gauge.body_size_after(*key, separator_len(key)) >= target;
+
+                if res {
+                    gauge.ingest_key(*key, separator_len(key));
+                }
+                res
+            })
+            .map(|(i, _key)| BranchOp::Update(i, PageNumber(i as u32)))
+            .collect();
+        let n_ops = ops_tracker.ops.len();
+
+        // All ops are expected to be consumed without any modification.
+        let Some((res_ops, res_gauge)) = ops_tracker.extract_ops_until(base.as_ref(), target)
+        else {
+            panic!()
+        };
+
+        assert_eq!(res_ops.len(), n_ops);
+        assert_eq!(res_gauge.body_size(), gauge.body_size());
+        drop(res_ops);
+        assert!(ops_tracker.ops.is_empty());
+    }
+
+    #[test]
+    fn extract_ops_until_only_keeps() {
+        let key = |i| prefixed_key(0x00, 16, i);
+
+        let mut gauge = BranchGauge::default();
+        let target = BRANCH_MERGE_THRESHOLD;
+        let mut ops_tracker = BranchOpsTracker::new();
+
+        let branch = make_branch_with_body_size_target(key, |size| size < BRANCH_NODE_BODY_SIZE);
+
+        let base = BaseBranch::new(branch.clone());
+
+        // Collect BranchOp::KeepChunk into updater.ops until the gauge associated
+        // to the ops is just after the target.
+        // The chunks are increasingly bigger, the first one covers 1 element, and each
+        // of the following chunks covers one more element.
+        let mut rightsized = false;
+        let mut from = 0;
+        ops_tracker.ops = (1usize..)
+            .map(|to| {
+                let start = from;
+                let end = from + to;
+                from += to;
+                KeepChunk {
+                    start,
+                    end,
+                    sum_separator_lengths: node::uncompressed_separator_range_size(
+                        branch.prefix_len() as usize,
+                        branch.separator_range_len(start, end),
+                        end - start,
+                        separator_len(&get_key(&branch, start)),
+                    ),
+                }
+            })
+            .take_while(|keep_chunk| {
+                let res = !rightsized;
+                rightsized = gauge.body_size_after_chunk(&base, &keep_chunk) >= target;
+                if res {
+                    gauge.ingest_chunk(&base, &keep_chunk);
+                }
+                res
+            })
+            .map(|keep_chunk| BranchOp::KeepChunk(keep_chunk))
+            .collect();
+
+        let n_ops = ops_tracker.ops.len();
+
+        // Almost all ops are expected to be consumed.
+        let Some((res_ops, res_gauge)) = ops_tracker.extract_ops_until(Some(&base), target) else {
+            panic!()
+        };
+
+        // Last keep_chunk is expected to have been split.
+        assert_eq!(res_ops.len(), n_ops);
+        drop(res_ops);
+        assert_eq!(ops_tracker.ops.len(), 1);
+        assert!(res_gauge.body_size() > target);
+    }
+
+    #[test]
+    fn consume_and_update_stop_prefix_compression_on_updates() {
+        let compressed_key = |i| prefixed_key(0x00, 30, i);
+        let uncompressed_key = |i| prefixed_key(0xFF, 30, i);
+
+        let mut gauge = BranchGauge::default();
+        let mut ops_tracker = BranchOpsTracker::new();
+
+        // Collect BranchOp::Insert into ops_tracker.ops until the gauge associated
+        // to the ops is just after the BRANCH_MERGE_THRESHOLD / 2
+        ops_tracker.ops = (0..)
+            .map(|i| compressed_key(i))
+            .take_while(|key| {
+                if gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD / 2 {
+                    false
+                } else {
+                    gauge.ingest_key(*key, separator_len(key));
+                    true
+                }
+            })
+            .enumerate()
+            .map(|(i, key)| BranchOp::Insert(key, PageNumber(i as u32)))
+            .collect();
+        let n_insert_op = ops_tracker.ops.len();
+
+        // Use a branch containing keys which do not share a prefix with the just ingested keys
+        let branch = make_branch_with_body_size_target(uncompressed_key, |size| {
+            size < BRANCH_NODE_BODY_SIZE
+        });
+
+        let base = BaseBranch::new(branch.clone());
+
+        // Extends ops_tracker.ops with BranchOp::Update operations until the final expected gauge
+        // reaches the target.
+        gauge.stop_prefix_compression();
+        let mut rightsized = false;
+        let update_ops: Vec<BranchOp> = (0..)
+            .map(|i| (i, get_key(&branch, i)))
+            .take_while(|(_i, key)| {
+                let res = !rightsized;
+                rightsized =
+                    gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD;
+
+                if res {
+                    gauge.ingest_key(*key, separator_len(key));
+                }
+                res
+            })
+            .map(|(i, _key)| BranchOp::Update(i, PageNumber(i as u32)))
+            .collect();
+
+        ops_tracker.ops.extend(update_ops);
+
+        let Some((res_ops, res_gauge)) =
+            ops_tracker.extract_ops_until(Some(&base), BRANCH_NODE_BODY_SIZE)
+        else {
+            panic!()
+        };
+
+        // Make sure that not only the update operation on which the stop_prefix_compression
+        // requirement has been found has been updated to insert, but also all subsequent operations.
+        for i in n_insert_op..res_ops.len() {
+            assert!(matches!(
+                res_ops[i],
+                BranchOp::Insert(k, PageNumber(_)) if k == uncompressed_key(i - n_insert_op)
+            ));
+        }
+
+        // The target has been downgraded to reduce the amount of uncompressed items
+        assert!(res_gauge.body_size() > BRANCH_MERGE_THRESHOLD);
+        assert!(res_gauge.body_size() < BRANCH_NODE_BODY_SIZE);
+    }
+
+    #[test]
+    fn consume_and_update_stop_prefix_compression_on_keeps() {
+        let compressed_key = |i| prefixed_key(0x00, 30, i);
+        let uncompressed_key = |i| prefixed_key(0xFF, 30, i);
+
+        let mut gauge = BranchGauge::default();
+        let mut ops_tracker = BranchOpsTracker::new();
+
+        // Collect BranchOp::Insert into updater.ops until the gauge associated
+        // to the ops is just after the BRANCH_MERGE_THRESHOLD / 2
+        ops_tracker.ops = (0..)
+            .map(|i| compressed_key(i))
+            .take_while(|key| {
+                if gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD / 2 {
+                    false
+                } else {
+                    gauge.ingest_key(*key, separator_len(key));
+                    true
+                }
+            })
+            .enumerate()
+            .map(|(i, key)| BranchOp::Insert(key, PageNumber(i as u32)))
+            .collect();
+        let n_insert_op = ops_tracker.ops.len();
+
+        // Use a branch containing keys which do not share a prefix with the just ingested keys.
+        let branch = make_branch_with_body_size_target(uncompressed_key, |size| {
+            size < BRANCH_NODE_BODY_SIZE
+        });
+
+        let base = BaseBranch::new(branch.clone());
+
+        // Extends updater.ops with BranchOp::KeepChunk operations until the final expected gauge
+        // reaches the target.
+        // The chunks are increasingly bigger, the first one covers 7 elements, and each
+        // of the following chunks covers one more element.
+        gauge.stop_prefix_compression();
+        let mut rightsized = false;
+        let mut from = 0;
+        let mut total_kept_itmes = 0;
+        let keep_ops: Vec<BranchOp> = (7..)
+            .map(|to| {
+                let start = from;
+                let end = from + to;
+                from += to;
+                KeepChunk {
+                    start,
+                    end,
+                    sum_separator_lengths: node::uncompressed_separator_range_size(
+                        branch.prefix_len() as usize,
+                        branch.separator_range_len(start, end),
+                        end - start,
+                        separator_len(&get_key(&branch, start)),
+                    ),
+                }
+            })
+            .take_while(|keep_chunk| {
+                let res = !rightsized;
+                rightsized =
+                    gauge.body_size_after_chunk(&base, &keep_chunk) >= BRANCH_MERGE_THRESHOLD;
+                if res {
+                    gauge.ingest_chunk(&base, &keep_chunk);
+                    total_kept_itmes += keep_chunk.end - keep_chunk.start;
+                }
+                res
+            })
+            .map(|keep_chunk| BranchOp::KeepChunk(keep_chunk))
+            .collect();
+
+        ops_tracker.ops.extend(keep_ops);
+
+        let Some((res_ops, res_gauge)) =
+            ops_tracker.extract_ops_until(Some(&base), BRANCH_NODE_BODY_SIZE)
+        else {
+            panic!()
+        };
+
+        // Make sure that not only the KeepChunk operation on which the stop_prefix_compression
+        // requirement has been found has been updated to insert, but also all subsequent operations.
+        for i in n_insert_op..res_ops.len() {
+            assert!(matches!(
+                res_ops[i],
+                BranchOp::Insert(k, PageNumber(_)) if k == uncompressed_key(i - n_insert_op)
+            ));
+        }
+
+        // Ensure that the last keep operation has been split correctly.
+        let expected_size_split_chunk = total_kept_itmes - (res_ops.len() - n_insert_op);
+        drop(res_ops);
+        let BranchOp::KeepChunk(split_keep_chunk) = &ops_tracker.ops[0] else {
+            panic!()
+        };
+        let split_keep_chunk = split_keep_chunk.end - split_keep_chunk.start;
+        assert_eq!(split_keep_chunk, expected_size_split_chunk);
+
+        // The target has been downgraded to reduce the amount of uncompressed items.
+        assert!(res_gauge.body_size() > BRANCH_MERGE_THRESHOLD);
+        assert!(res_gauge.body_size() < BRANCH_NODE_BODY_SIZE);
+    }
+
+    #[test]
+    fn push_after_stop_prefix_compression() {
+        let key = |i| prefixed_key(0x00, 6, i);
+
+        let mut ops_tracker = BranchOpsTracker::new();
+
+        let branch = make_branch((2..10).map(|i| (key(i), i)).collect());
+
+        let base = BaseBranch::new(branch.clone());
+
+        ops_tracker.push_insert(key(0), PageNumber(0)); // insert
+        ops_tracker.gauge.stop_prefix_compression();
+        ops_tracker.push_insert(key(1), PageNumber(0)); // insert
+        ops_tracker.push_update(&base, 0, PageNumber(1)); // update
+        ops_tracker.push_chunk(&base, 1, 8); // keep_chunk
+
+        // Make sure that all ops are Insert type.
+        for op in ops_tracker.ops {
+            assert!(matches!(op, BranchOp::Insert(..)));
+        }
+    }
+
+    #[test]
+    fn try_split_keep_chunk() {
+        let key = |i| prefixed_key(0x00, 16, i);
+        let keys: Vec<(Key, usize)> = (0..100).map(|i| (key(i), i)).collect();
+
+        let mut base_node_gauge = BranchGauge::default();
+
+        let mut sum_separator_lengths = 0;
+        for (key, _) in keys.clone() {
+            let len = separator_len(&key);
+            base_node_gauge.ingest_key(key, len);
+            sum_separator_lengths += len;
+        }
+
+        let branch = make_branch(keys.clone());
+        let base = BaseBranch::new(branch);
+
+        let chunk = KeepChunk {
+            start: 0,
+            end: keys.len(),
+            sum_separator_lengths,
+        };
+
+        // Perform a standard split
+        let gauge = BranchGauge::default();
+        let target = base_node_gauge.body_size() / 3;
+        let limit = base_node_gauge.body_size() / 2;
+        let mut ops_tracker = BranchOpsTracker::new();
+        ops_tracker.ops = vec![BranchOp::KeepChunk(chunk)];
+        let left_split_len = ops_tracker.try_split_keep_chunk(&base, &gauge, 0, target, limit);
+
+        assert_eq!(ops_tracker.ops.len(), 2);
+        let chunk1 = match &ops_tracker.ops[0] {
+            BranchOp::KeepChunk(c1) => c1,
+            _ => panic!(),
+        };
+        let chunk2 = match &ops_tracker.ops[1] {
+            BranchOp::KeepChunk(c2) => c2,
+            _ => panic!(),
+        };
+        assert_eq!(chunk1.len(), left_split_len);
+        assert_eq!(chunk1.len() + chunk2.len(), keys.len());
+        assert!(gauge.body_size_after_chunk(&base, chunk1) > target);
+        assert!(gauge.body_size_after_chunk(&base, chunk1) < limit);
+
+        // Perform a split which is not able to reach the target
+        let gauge = BranchGauge::default();
+        let target = base_node_gauge.body_size() * 2;
+        let limit = base_node_gauge.body_size() * 2;
+        let mut ops_tracker = BranchOpsTracker::new();
+        ops_tracker.ops = vec![BranchOp::KeepChunk(chunk)];
+        ops_tracker.try_split_keep_chunk(&base, &gauge, 0, target, limit);
+
+        assert_eq!(ops_tracker.ops.len(), 1);
+        let chunk1 = match &ops_tracker.ops[0] {
+            BranchOp::KeepChunk(c1) => c1,
+            _ => panic!(),
+        };
+        assert_eq!(chunk1.len(), keys.len());
+        assert!(gauge.body_size_after_chunk(&base, chunk1) < target);
+
+        // Perform a split with a target too little,
+        // but something smaller than the limit will still be split.
+        let gauge = BranchGauge::default();
+        let target = 1;
+        let limit = BRANCH_NODE_BODY_SIZE;
+        let mut ops_tracker = BranchOpsTracker::new();
+        ops_tracker.ops = vec![BranchOp::KeepChunk(chunk)];
+        ops_tracker.try_split_keep_chunk(&base, &gauge, 0, target, limit);
+
+        assert_eq!(ops_tracker.ops.len(), 2);
+        let chunk1 = match &ops_tracker.ops[0] {
+            BranchOp::KeepChunk(c1) => c1,
+            _ => panic!(),
+        };
+        assert_eq!(chunk1.len(), 1);
+        assert!(gauge.body_size_after_chunk(&base, chunk1) > target);
+        assert!(gauge.body_size_after_chunk(&base, chunk1) < limit);
+
+        // Perform a split with a limit too little,
+        // nothing will still be split.
+        let gauge = BranchGauge::default();
+        let target = 1;
+        let limit = 1;
+        let mut ops_tracker = BranchOpsTracker::new();
+        ops_tracker.ops = vec![BranchOp::KeepChunk(chunk)];
+        ops_tracker.try_split_keep_chunk(&base, &gauge, 0, target, limit);
+
+        assert_eq!(ops_tracker.ops.len(), 1);
+        let chunk1 = match &ops_tracker.ops[0] {
+            BranchOp::KeepChunk(c1) => c1,
+            _ => panic!(),
+        };
+        assert_eq!(chunk1.len(), keys.len());
+    }
+
+    #[test]
+    fn replace_with_insert() {
+        let key = |i| prefixed_key(0x00, 16, i);
+        let n_keys = 100;
+        let keys: Vec<(Key, usize)> = (1..1 + n_keys).map(|i| (key(i), i)).collect();
+
+        let mut base_node_gauge = BranchGauge::default();
+
+        let mut sum_separator_lengths = 0;
+        for (key, _) in keys.clone() {
+            let len = separator_len(&key);
+            base_node_gauge.ingest_key(key, len);
+            sum_separator_lengths += len;
+        }
+
+        let branch = make_branch(keys.clone());
+        let base = BaseBranch::new(branch);
+
+        let insert1 = BranchOp::Insert(key(0), PageNumber(1));
+        let insert2 = BranchOp::Insert(key(n_keys + 2), PageNumber(2));
+        let chunk = KeepChunk {
+            start: 1,
+            end: keys.len(),
+            sum_separator_lengths,
+        };
+
+        let mut ops_tracker = BranchOpsTracker::new();
+        ops_tracker.ops = vec![
+            insert1,
+            BranchOp::Update(0, PageNumber(3)),
+            BranchOp::KeepChunk(chunk),
+            insert2,
+        ];
+
+        // insert remains insert
+        ops_tracker.replace_with_insert(None, 0);
+        assert!(matches!(ops_tracker.ops[0], BranchOp::Insert(k,..) if k == key(0)));
+        assert_eq!(ops_tracker.ops.len(), 4);
+
+        // update becomes insert
+        ops_tracker.replace_with_insert(Some(&base), 1);
+        assert!(matches!(ops_tracker.ops[1], BranchOp::Insert(k,..) if k == key(1)));
+        assert_eq!(ops_tracker.ops.len(), 4);
+
+        // keep becomes multiple inserts
+        ops_tracker.replace_with_insert(Some(&base), 2);
+        for (i, op) in ops_tracker.ops[2..ops_tracker.ops.len() - 2]
+            .iter()
+            .enumerate()
+        {
+            assert!(matches!(op, BranchOp::Insert(k,..) if *k == key(i + 2)));
+        }
+        assert!(
+            matches!(ops_tracker.ops[ops_tracker.ops.len() - 1], BranchOp::Insert(k,..) if k == key(n_keys + 2))
+        );
+        assert_eq!(ops_tracker.ops.len(), 2 + n_keys);
+    }
+
+    #[test]
+    fn extract_insert_from_keep_chunk() {
+        let key = |i| prefixed_key(0x00, 16, i);
+        let n_keys = 100;
+        let keys: Vec<(Key, usize)> = (0..n_keys).map(|i| (key(i), i)).collect();
+        let sum_separator_lengths = keys.clone().iter().map(|(k, _)| separator_len(k)).sum();
+
+        let branch = make_branch(keys.clone());
+        let base = BaseBranch::new(branch);
+
+        let chunk = KeepChunk {
+            start: 0,
+            end: keys.len(),
+            sum_separator_lengths,
+        };
+
+        let mut ops_tracker = BranchOpsTracker::new();
+        ops_tracker.ops = vec![BranchOp::KeepChunk(chunk)];
+
+        ops_tracker.extract_insert_from_keep_chunk(&base, 0);
+        assert_eq!(ops_tracker.ops.len(), 2);
+        assert!(matches!(ops_tracker.ops[0], BranchOp::Insert(k,..) if k == key(0)));
+        assert!(matches!(ops_tracker.ops[1], BranchOp::KeepChunk(c) if c.len() == n_keys - 1));
+
+        // 0-sized chunks are not allowed.
+        let chunk = KeepChunk {
+            start: 0,
+            end: 1,
+            sum_separator_lengths,
+        };
+        ops_tracker.ops = vec![BranchOp::KeepChunk(chunk)];
+        ops_tracker.extract_insert_from_keep_chunk(&base, 0);
+        assert_eq!(ops_tracker.ops.len(), 1);
+        assert!(matches!(ops_tracker.ops[0], BranchOp::Insert(k,..) if k == key(0)));
+    }
+}

--- a/nomt/src/beatree/ops/update/branch_updater.rs
+++ b/nomt/src/beatree/ops/update/branch_updater.rs
@@ -12,11 +12,12 @@ use crate::beatree::{
 use crate::io::PagePool;
 
 use super::{
+    branch_ops::{BranchOp, BranchOpsTracker, KeepChunk},
     get_key, BRANCH_BULK_SPLIT_TARGET, BRANCH_BULK_SPLIT_THRESHOLD, BRANCH_MERGE_THRESHOLD,
 };
 
 pub struct BaseBranch {
-    node: Arc<BranchNode>,
+    pub node: Arc<BranchNode>,
     low: usize,
 }
 
@@ -56,42 +57,8 @@ impl BaseBranch {
         get_key(&self.node, i)
     }
 
-    fn key_value(&self, i: usize) -> (Key, PageNumber) {
+    pub fn key_value(&self, i: usize) -> (Key, PageNumber) {
         (self.key(i), self.node.node_pointer(i).into())
-    }
-}
-
-// BranchOp used to create a new node starting off a possible base node.
-//
-// `Update` and `KeepChunk` refers only to compressed separator within the base node.
-enum BranchOp {
-    // Separator and its page number
-    Insert(Key, PageNumber),
-    // Contains the position at which the separator is saved in the base,
-    // along with the updated page number
-    Update(usize, PageNumber),
-    // Contains a range of separators that will be transfered unchanged
-    // in the new node from the base.
-    //
-    // These are always items which were prefix-compressed.
-    KeepChunk(KeepChunk),
-}
-
-// KeepChunk represents a sequence of separators contained in a branch node.
-// `start` and `end` represents the separators range where `end` is non inclusive.
-// 0-Sized chunks are not allowed, thus `start > end` must always hold.
-// `sum_separator_lengths` is the sum of the separator lengths of each separator
-// represented by the chunk itself.
-#[derive(Debug, Clone, Copy)]
-struct KeepChunk {
-    start: usize,
-    end: usize,
-    sum_separator_lengths: usize,
-}
-
-impl KeepChunk {
-    fn len(&self) -> usize {
-        self.end - self.start
     }
 }
 
@@ -106,18 +73,13 @@ pub trait HandleNewBranch {
 }
 
 pub struct BranchUpdater {
-    // the 'base' node we are working from. does not exist if DB is empty.
+    // The 'base' node we are working from. does not exist if DB is empty.
     base: Option<BaseBranch>,
-    // the cutoff key, which determines if an operation is in-scope.
+    // The cutoff key, which determines if an operation is in-scope.
     // does not exist for the last branch in the database.
     cutoff: Option<Key>,
-    ops: Vec<BranchOp>,
-    // gauges total size of branch after ops applied.
-    // if bulk split is undergoing, this just stores the total size of the last branch,
-    // and the gauges for the previous branches are stored in `bulk_split`.
-    gauge: BranchGauge,
+    ops_tracker: BranchOpsTracker,
     page_pool: PagePool,
-    bulk_split: Option<BranchBulkSplitter>,
 }
 
 impl BranchUpdater {
@@ -125,10 +87,8 @@ impl BranchUpdater {
         BranchUpdater {
             base,
             cutoff,
-            ops: Vec::new(),
-            gauge: BranchGauge::new(),
+            ops_tracker: BranchOpsTracker::new(),
             page_pool,
-            bulk_split: None,
         }
     }
 
@@ -137,26 +97,14 @@ impl BranchUpdater {
         // keep all elements that are skipped looking for `key`
         let res = self.keep_up_to(Some(&key));
 
-        match (res, pn) {
-            (_, Some(pn)) if self.gauge.prefix_compressed.is_some() => {
-                // prefix compression stopped so each added element must be an BranchOp::Insert
-                self.ops.push(BranchOp::Insert(key, pn));
-                self.bulk_split_step();
-            }
+        let Some(pn) = pn else { return };
+
+        if let Some(pos) = res {
             // UNWRAP: if the item has been found it must be a base node
-            (Some(pos), Some(pn))
-                if pos < self.base.as_ref().unwrap().node.prefix_compressed() as usize =>
-            {
-                // a compressed separator has been changed
-                self.ops.push(BranchOp::Update(pos, pn));
-                self.bulk_split_step();
-            }
-            (_, Some(pn)) => {
-                // a new key or a previous uncompressed separator has been updated
-                self.ops.push(BranchOp::Insert(key, pn));
-                self.bulk_split_step();
-            }
-            _ => (),
+            self.ops_tracker
+                .push_update(self.base.as_ref().unwrap(), pos, pn);
+        } else {
+            self.ops_tracker.push_insert(key, pn);
         }
     }
 
@@ -166,28 +114,29 @@ impl BranchUpdater {
         // note: if we need a merge, it'd be more efficient to attempt to combine it with the last
         // branch of the bulk split first rather than pushing the ops onwards. probably irrelevant
         // in practice; bulk splits are rare.
-        let last_ops_start = self.build_bulk_splitter_branches(new_branches);
 
-        if self.gauge.body_size() == 0 {
-            self.ops.clear();
+        if self.ops_tracker.body_size() > BRANCH_BULK_SPLIT_THRESHOLD {
+            self.try_split(new_branches, BRANCH_BULK_SPLIT_TARGET);
+        }
 
+        if self.ops_tracker.body_size() > BRANCH_NODE_BODY_SIZE {
+            self.try_split(new_branches, BRANCH_MERGE_THRESHOLD);
+        }
+
+        if self.ops_tracker.body_size() == 0 {
             DigestResult::Finished
-        } else if self.gauge.body_size() > BRANCH_NODE_BODY_SIZE {
-            assert_eq!(
-                last_ops_start, 0,
-                "normal split can only occur when not bulk splitting"
-            );
-            self.split(new_branches)
-        } else if self.gauge.body_size() >= BRANCH_MERGE_THRESHOLD || self.cutoff.is_none() {
-            let node = self.build_branch(&self.ops[last_ops_start..], &self.gauge);
-            let separator = self.op_first_key(&self.ops[last_ops_start]);
+        } else if self.ops_tracker.body_size() >= BRANCH_MERGE_THRESHOLD || self.cutoff.is_none() {
+            let base = self.base.as_ref();
+            let page_pool = &self.page_pool;
+            let (ops, gauge) = self.ops_tracker.extract_ops();
+
+            let node = build_branch(base, page_pool, &ops, &gauge);
+            let separator = op_first_key(base, &ops[0]);
             new_branches.handle_new_branch(separator, node, self.cutoff);
 
-            self.ops.clear();
-            self.gauge = BranchGauge::new();
             DigestResult::Finished
         } else {
-            self.prepare_merge_ops(last_ops_start);
+            self.ops_tracker.prepare_merge_ops(self.base.as_ref());
 
             // UNWRAP: protected above.
             DigestResult::NeedsMerge(self.cutoff.unwrap())
@@ -216,598 +165,219 @@ impl BranchUpdater {
             return None;
         }
 
-        let (maybe_chunk, uncompressed_range, found) = {
-            // UNWRAP: self.base is not None
-            let base = self.base.as_mut().unwrap();
+        // UNWRAP: self.base is not None
+        let base = self.base.as_mut().unwrap();
 
-            let from = base.low;
-            let base_n = base.node.n() as usize;
+        let from = base.low;
+        let base_n = base.node.n() as usize;
 
-            let (found, to) = match up_to {
-                // Nothing more to do, the end has already been reached
-                None if from == base_n => return None,
-                // Jump directly to the end of the base node and update `base.low` accordingly
-                None => {
-                    base.low = base_n;
-                    (false, base_n)
-                }
-                Some(up_to) => match base.find_key(up_to) {
-                    Some(res) => res,
-                    // already at the end
-                    None => return None,
-                },
-            };
-
-            if from == to {
-                // nothing to keep
-                return if found { Some(to) } else { None };
+        let (found, to) = match up_to {
+            // Nothing more to do, the end has already been reached
+            None if from == base_n => return None,
+            // Jump directly to the end of the base node and update `base.low` accordingly
+            None => {
+                base.low = base_n;
+                (false, base_n)
             }
+            Some(up_to) => match base.find_key(up_to) {
+                Some(res) => res,
+                // already at the end
+                None => return None,
+            },
+        };
 
-            let base_compressed_end = std::cmp::min(to, base.node.prefix_compressed() as usize);
+        if from != to {
+            self.ops_tracker.push_chunk(base, from, to);
+        }
 
-            let maybe_chunk = if from == base_compressed_end {
-                None
-            } else {
-                Some(KeepChunk {
-                    start: from,
-                    end: base_compressed_end,
-                    sum_separator_lengths: node::uncompressed_separator_range_size(
-                        base.node.prefix_len() as usize,
-                        base.node.separator_range_len(from, base_compressed_end),
-                        base_compressed_end - from,
-                        separator_len(&base.key(from)),
-                    ),
+        return if found { Some(to) } else { None };
+    }
+
+    // Try to perform a split of the current available ops with a target branch node size.
+    fn try_split(&mut self, new_branches: &mut impl HandleNewBranch, target: usize) {
+        let base = self.base.as_ref();
+        while let Some((ops, gauge)) = self
+            .ops_tracker
+            .extract_ops_until(self.base.as_ref(), target)
+        {
+            let node = build_branch(base, &self.page_pool, &ops, &gauge);
+            let separator = op_first_key(base, &ops[0]);
+            new_branches.handle_new_branch(separator, node, self.cutoff);
+        }
+    }
+}
+
+fn op_first_key(base: Option<&BaseBranch>, branch_op: &BranchOp) -> Key {
+    // UNWRAPs: `KeepChunk` and `Update` ops only exists when base is Some.
+    match branch_op {
+        BranchOp::Insert(k, _) => *k,
+        BranchOp::Update(pos, _) => base.unwrap().key(*pos),
+        BranchOp::KeepChunk(chunk) => base.unwrap().key(chunk.start),
+    }
+}
+
+fn build_branch(
+    base: Option<&BaseBranch>,
+    page_pool: &PagePool,
+    ops: &[BranchOp],
+    gauge: &BranchGauge,
+) -> BranchNode {
+    let branch = BranchNode::new_in(&page_pool);
+
+    let mut builder = BranchNodeBuilder::new(
+        branch,
+        gauge.n,
+        gauge.prefix_compressed_items(),
+        gauge.prefix_len,
+    );
+
+    let Some(base) = base else {
+        // SAFETY: If no base is avaialble, then all ops are expected to be `BranchOp::Insert`
+        for op in ops {
+            match op {
+                BranchOp::Insert(key, pn) => builder.push(*key, separator_len(key), pn.0),
+                _ => panic!("Unextected BranchOp creating a BranchNode without BaseBranch"),
+            }
+        }
+        return builder.finish();
+    };
+
+    // This second phase of joining Update and KeepChunk into a unique update chunk is performed
+    // for two reasons:
+    //
+    // 1. It could often happen that the sequence of KeepChunk are interleaved by Update with only a change
+    // in the node pointers
+    // 2. To avoid keeping all the update information within the BranchOp::KeepChunk because it would require
+    // further allocations
+    let apply_chunk = |builder: &mut BranchNodeBuilder,
+                       base_range: Range<usize>,
+                       ops_range: Range<usize>| {
+        let n_compressed_left = gauge
+            .prefix_compressed_items()
+            .saturating_sub(builder.n_pushed());
+
+        let compressed_end = std::cmp::min(base_range.start + n_compressed_left, base_range.end);
+
+        builder.push_chunk(
+            &base.node,
+            base_range.start,
+            compressed_end,
+            ops[ops_range]
+                .iter()
+                .filter_map(|op| {
+                    if let BranchOp::Update(pos, pn) = op {
+                        Some((pos - base_range.start, *pn))
+                    } else {
+                        None
+                    }
                 })
-            };
-
-            (
-                maybe_chunk,
-                base_compressed_end..to,
-                if found { Some(to) } else { None },
-            )
-        };
-
-        // push compressed chunk
-        if let Some(chunk) = maybe_chunk {
-            self.ops.push(BranchOp::KeepChunk(chunk));
-            self.bulk_split_step();
-
-            if self.gauge.prefix_compressed.is_some() {
-                // prefix compression stopped so KeepChunk must be replaced by multiple Inserts
-                let last_op = self.ops.len() - 1;
-                replace_with_insert(&mut self.ops, last_op, self.base.as_ref());
-            }
-        }
-
-        // convert every kept uncompressed separator into an Insert operation
-        for i in uncompressed_range {
-            // UNWRAP: self.base is not None
-            let (key, pn) = self.base.as_ref().unwrap().key_value(i);
-            self.ops.push(BranchOp::Insert(key, pn));
-            self.bulk_split_step();
-        }
-
-        found
-    }
-
-    // check whether bulk split needs to start, and if so, start it.
-    // If ongoing, check if we need to cut off.
-    fn bulk_split_step(&mut self) {
-        let Some(last_op) = self.ops.last() else {
-            panic!("Attempted bulk_split_step on no BranchOp available");
-        };
-
-        // UNWRAPs: `KeepChunk` or `Update` ops only exist when base is Some.
-        let body_size_after = match last_op {
-            BranchOp::KeepChunk(ref chunk) => self
-                .gauge
-                .body_size_after_chunk(self.base.as_ref().unwrap(), &chunk),
-            BranchOp::Update(pos, _) => {
-                let key = self.base.as_ref().unwrap().key(*pos);
-                self.gauge.body_size_after(key, separator_len(&key))
-            }
-            BranchOp::Insert(key, _) => self.gauge.body_size_after(*key, separator_len(&key)),
-        };
-
-        match self.bulk_split {
-            None if body_size_after >= BRANCH_BULK_SPLIT_THRESHOLD => {
-                self.bulk_split = Some(BranchBulkSplitter::default())
-            }
-            Some(_) if body_size_after >= BRANCH_BULK_SPLIT_TARGET => (),
-            _ => {
-                self.gauge.ingest_branch_op(self.base.as_ref(), last_op);
-                return;
-            }
-        };
-
-        // continue or start the bulk split
-        // UNWRAPs: bulk_split has just been checked to be Some or has just been set to Some
-        let mut from = self.bulk_split.as_ref().unwrap().total_count;
-        loop {
-            match self.consume_and_update_until(from, BRANCH_BULK_SPLIT_TARGET) {
-                Ok((item_count, gauge)) => {
-                    self.bulk_split.as_mut().unwrap().push(item_count, gauge);
-                    from = from + item_count;
-                }
-                Err(gauge) => {
-                    self.gauge = gauge;
-                    break;
-                }
-            }
-        }
-    }
-
-    fn build_bulk_splitter_branches(&mut self, new_branches: &mut impl HandleNewBranch) -> usize {
-        let Some(splitter) = self.bulk_split.take() else {
-            return 0;
-        };
-
-        let mut start = 0;
-        for (item_count, gauge) in splitter.items {
-            let branch_ops = &self.ops[start..][..item_count];
-            let separator = self.op_first_key(&self.ops[start]);
-            let new_node = self.build_branch(branch_ops, &gauge);
-
-            new_branches.handle_new_branch(separator, new_node, self.cutoff);
-
-            start += item_count;
-        }
-
-        start
-    }
-
-    fn split(&mut self, new_branches: &mut impl HandleNewBranch) -> DigestResult {
-        let midpoint = self.gauge.body_size() / 2;
-
-        let (split_point, left_gauge) = match self.consume_and_update_until(0, midpoint) {
-            Ok((split_point, left_gauge)) => (split_point, left_gauge),
-            // If the current ops cannot reach the target and there is a cutoff
-            // return NeedsMerge with the relative cutoff.
-            Err(new_gauge) if self.cutoff.is_some() => {
-                self.gauge = new_gauge;
-                // UNWRAP: self.cutoff has just been checked to be Some.
-                return DigestResult::NeedsMerge(self.cutoff.unwrap());
-            }
-            // If there is no cutoff, then construct the leaf with all the available ops.
-            Err(new_gauge) => (self.ops.len(), new_gauge),
-        };
-
-        let left_separator = self.op_first_key(&self.ops[0]);
-        let left_ops = &self.ops[..split_point];
-        let left_node = self.build_branch(left_ops, &left_gauge);
-
-        if split_point == self.ops.len() {
-            // It could be possible due to prefix uncompression
-            // that after `consume_and_update_until` all ops fits in a single node.
-            new_branches.handle_new_branch(left_separator, left_node, self.cutoff);
-            self.ops.clear();
-            self.gauge = BranchGauge::new();
-            return DigestResult::Finished;
-        }
-
-        let right_separator = self.op_first_key(&self.ops[split_point]);
-        new_branches.handle_new_branch(left_separator, left_node, Some(right_separator));
-
-        let mut right_gauge = BranchGauge::new();
-        let right_ops = &self.ops[split_point..];
-
-        for op in right_ops {
-            right_gauge.ingest_branch_op(self.base.as_ref(), op);
-        }
-
-        if right_gauge.body_size() > BRANCH_NODE_BODY_SIZE {
-            // This is a rare case left uncovered by the bulk split, the threshold to activate it
-            // has not been reached by the sum of all left and right operations. Now the right
-            // node is too big, and another split is required to be executed
-            self.ops.drain(..split_point);
-            self.gauge = right_gauge;
-            self.split(new_branches)
-        } else if right_gauge.body_size() >= BRANCH_MERGE_THRESHOLD || self.cutoff.is_none() {
-            let right_node = self.build_branch(right_ops, &right_gauge);
-
-            new_branches.handle_new_branch(right_separator, right_node, self.cutoff);
-
-            self.ops.clear();
-            self.gauge = BranchGauge::new();
-
-            DigestResult::Finished
-        } else {
-            // degenerate split: impossible to create two nodes with >50%. Merge remainder into
-            // sibling node.
-
-            self.prepare_merge_ops(split_point);
-            self.gauge = right_gauge;
-
-            // UNWRAP: protected above.
-            DigestResult::NeedsMerge(self.cutoff.unwrap())
-        }
-    }
-
-    // Starting from the specified index `from` within `self.ops`, consume and possibly
-    // change the operations themselves to achieve a sequence of operations that are able to
-    // construct a branch node with the specified target size.
-    //
-    // If `stop_prefix_compression` has to be called, then the target becomes BRANCH_MERGE_THRESHOLD
-    // to minimize the amount of uncompressed items inserted in the node.
-    //
-    // If reaching the target is not possible, then the gauge reflecting the last operations
-    // will be returned as an error.
-    fn consume_and_update_until(
-        &mut self,
-        from: usize,
-        mut target: usize,
-    ) -> Result<(usize, BranchGauge), BranchGauge> {
-        let mut pos = from;
-        let mut gauge = BranchGauge::new();
-
-        while pos < self.ops.len() && gauge.body_size() < target {
-            match *&self.ops[pos] {
-                BranchOp::Insert(key, _) => {
-                    if gauge.body_size_after(key, separator_len(&key)) > BRANCH_NODE_BODY_SIZE {
-                        if gauge.body_size() < BRANCH_MERGE_THRESHOLD {
-                            // rare case: body was artifically small due to long shared prefix.
-                            // start applying items without prefix compression. we assume items are less
-                            // than half the body size, so the next item should apply cleanly.
-                            gauge.stop_prefix_compression();
-                            // change the target requirement to minumize the number of non
-                            // compressed separators saved into one node
-                            target = BRANCH_MERGE_THRESHOLD;
-                        } else {
-                            break;
-                        }
-                    }
-                }
-                BranchOp::Update(update_pos, _) => {
-                    // UNWRAP: `Update` op only exist when base is Some.
-                    let key = self.base.as_ref().unwrap().key(update_pos);
-
-                    if gauge.body_size_after(key, separator_len(&key)) > BRANCH_NODE_BODY_SIZE {
-                        if gauge.body_size() < BRANCH_MERGE_THRESHOLD {
-                            // Replace the Update op and repeat the loop
-                            // to see if `stop_prefix_compression` is activated
-                            replace_with_insert(&mut self.ops, pos, self.base.as_ref());
-                            continue;
-                        } else {
-                            break;
-                        }
-                    }
-                }
-                BranchOp::KeepChunk(..) => {
-                    // UNWRAP: `KeepChunk` op only exists when base is Some.
-                    let base = self.base.as_ref().unwrap();
-
-                    // Try to split the chunk to make it fit into the available space.
-                    // `try_split_keep_chunk` works on the gauge thus it accounts for a possible
-                    // stop of the prefix compression even if working on a KeepChunk operation
-                    let left_n_items = try_split_keep_chunk(
-                        base,
-                        &gauge,
-                        &mut self.ops,
-                        pos,
-                        target,
-                        BRANCH_NODE_BODY_SIZE,
-                    );
-
-                    if left_n_items == 0 {
-                        // If no item from the chunk is capable of fitting,
-                        // then extract the first element from the chunk and repeat the loop
-                        // to see if `stop_prefix_compression` is activated
-                        extract_insert_from_keep_chunk(base, &mut self.ops, pos);
-                        continue;
-                    }
-                }
-            };
-
-            gauge.ingest_branch_op(self.base.as_ref(), &self.ops[pos]);
-            let n_ops = if gauge.prefix_compressed.is_some() {
-                // replace everything with Insert if the prefix compression was stopped
-                replace_with_insert(&mut self.ops, pos, self.base.as_ref())
-            } else {
-                1
-            };
-            pos += n_ops;
-        }
-
-        if gauge.body_size() >= target {
-            Ok((pos - from, gauge))
-        } else {
-            Err(gauge)
-        }
-    }
-
-    fn build_branch(&self, ops: &[BranchOp], gauge: &BranchGauge) -> BranchNode {
-        let branch = BranchNode::new_in(&self.page_pool);
-
-        // UNWRAP: freshly allocated branch can always be checked out.
-        let mut builder = BranchNodeBuilder::new(
-            branch,
-            gauge.n,
-            gauge.prefix_compressed_items(),
-            gauge.prefix_len,
+                .into_iter(),
         );
 
-        let Some(base) = self.base.as_ref() else {
-            // SAFETY: If no base is avaialble, then all ops are expected to be `BranchOp::Insert`
-            for op in ops {
-                match op {
-                    BranchOp::Insert(key, pn) => builder.push(*key, separator_len(key), pn.0),
-                    _ => panic!("Unextected BranchOp creating a BranchNode without BaseBranch"),
+        for pos in compressed_end..base_range.end {
+            let (key, pn) = base.key_value(pos);
+            builder.push(key, separator_len(&key), pn.0);
+        }
+    };
+
+    let mut pending_keep_chunk = None;
+    // contains a range within `ops` which define the `pending_keep_chunk`
+    let mut pending_ops_range = None;
+    let mut i = 0;
+    while i < ops.len() {
+        // Check if the chunk could grow.
+        // If yes, then update it and restart the loop on the next operation.
+        // Otherwise, apply the pending chunk and let the same operation be re-evaluated.
+        if pending_keep_chunk.is_some() {
+            // UNWRAPS: pending_keep_chunk has just been checked to be Some.
+            // If pending_keep_chunk is Some, then pending_ops_range is also.
+            match &ops[i] {
+                // found a insert, apply pending chunk
+                BranchOp::Insert(_, _) => {
+                    apply_chunk(
+                        &mut builder,
+                        pending_keep_chunk.take().unwrap(),
+                        pending_ops_range.take().unwrap(),
+                    );
                 }
-            }
-            return builder.finish();
-        };
-
-        // This second phase of joining Update and KeepChunk into a unique update chunk is performed
-        // for two reasons:
-        //
-        // 1. It could often happen that the sequence of KeepChunk are interleaved by Update with only a change
-        // in the node pointers
-        // 2. To avoid keeping all the update information within the BranchOp::KeepChunk because it would require
-        // further allocations
-        let apply_chunk =
-            |builder: &mut BranchNodeBuilder, base_range: Range<usize>, ops_range: Range<usize>| {
-                let n_compressed_left = gauge
-                    .prefix_compressed_items()
-                    .saturating_sub(builder.n_pushed());
-
-                let compressed_end =
-                    std::cmp::min(base_range.start + n_compressed_left, base_range.end);
-
-                builder.push_chunk(
-                    &base.node,
-                    base_range.start,
-                    compressed_end,
-                    ops[ops_range]
-                        .iter()
-                        .filter_map(|op| {
-                            if let BranchOp::Update(pos, pn) = op {
-                                Some((pos - base_range.start, *pn))
-                            } else {
-                                None
-                            }
-                        })
-                        .into_iter(),
-                );
-
-                // UNWRAP: apply_chunk works on an aggregation of `KeepChunk and `Update` ops,
-                // and they only exist when the base is Some.
-                for pos in compressed_end..base_range.end {
-                    let (key, pn) = self.base.as_ref().unwrap().key_value(pos);
-                    builder.push(key, separator_len(&key), pn.0);
-                }
-            };
-
-        let mut pending_keep_chunk = None;
-        // contains a range within `ops` which define the `pending_keep_chunk`
-        let mut pending_ops_range = None;
-        let mut i = 0;
-        while i < ops.len() {
-            // Check if the chunk could grow.
-            // If yes, then update it and restart the loop on the next operation.
-            // Otherwise, apply the pending chunk and let the same operation be re-evaluated.
-            if pending_keep_chunk.is_some() {
-                // UNWRAPS: pending_keep_chunk has just been checked to be Some.
-                // If pending_keep_chunk is Some, then pending_ops_range is also.
-                match &ops[i] {
-                    // found a insert, apply pending chunk
-                    BranchOp::Insert(_, _) => {
+                BranchOp::KeepChunk(chunk) => {
+                    let range = pending_keep_chunk.as_mut().unwrap();
+                    let ops_range = pending_ops_range.as_mut().unwrap();
+                    if range.end == chunk.start {
+                        // KeepChunk that follow the pending chunk
+                        range.end = chunk.end;
+                        ops_range.end += 1;
+                        i += 1;
+                        continue;
+                    } else {
+                        // KeepChunk that doens't follow the pending chunk
                         apply_chunk(
                             &mut builder,
                             pending_keep_chunk.take().unwrap(),
                             pending_ops_range.take().unwrap(),
                         );
                     }
-                    BranchOp::KeepChunk(chunk) => {
-                        let range = pending_keep_chunk.as_mut().unwrap();
-                        let ops_range = pending_ops_range.as_mut().unwrap();
-                        if range.end == chunk.start {
-                            // KeepChunk that follow the pending chunk
-                            range.end = chunk.end;
-                            ops_range.end += 1;
-                            i += 1;
-                            continue;
-                        } else {
-                            // KeepChunk that doens't follow the pending chunk
-                            apply_chunk(
-                                &mut builder,
-                                pending_keep_chunk.take().unwrap(),
-                                pending_ops_range.take().unwrap(),
-                            );
-                        }
-                    }
-                    BranchOp::Update(pos, _) => {
-                        let range = pending_keep_chunk.as_mut().unwrap();
-                        let ops_range = pending_ops_range.as_mut().unwrap();
-                        if range.end == *pos {
-                            // Update that follow the pending chunk
-                            range.end += 1;
-                            ops_range.end += 1;
-                            i += 1;
-                            continue;
-                        } else {
-                            // Update that doens't follow the pending chunk
-                            apply_chunk(
-                                &mut builder,
-                                pending_keep_chunk.take().unwrap(),
-                                pending_ops_range.take().unwrap(),
-                            );
-                        }
-                    }
-                }
-            }
-
-            match &ops[i] {
-                BranchOp::Insert(key, pn) => {
-                    builder.push(*key, separator_len(key), pn.0);
-                    i += 1;
-                }
-                BranchOp::KeepChunk(chunk) => {
-                    pending_keep_chunk = Some(chunk.start..chunk.end);
-                    pending_ops_range = Some(i..i + 1);
-                    i += 1;
                 }
                 BranchOp::Update(pos, _) => {
-                    pending_keep_chunk = Some(*pos..*pos + 1);
-                    pending_ops_range = Some(i..i + 1);
-                    i += 1;
+                    let range = pending_keep_chunk.as_mut().unwrap();
+                    let ops_range = pending_ops_range.as_mut().unwrap();
+                    if range.end == *pos {
+                        // Update that follow the pending chunk
+                        range.end += 1;
+                        ops_range.end += 1;
+                        i += 1;
+                        continue;
+                    } else {
+                        // Update that doens't follow the pending chunk
+                        apply_chunk(
+                            &mut builder,
+                            pending_keep_chunk.take().unwrap(),
+                            pending_ops_range.take().unwrap(),
+                        );
+                    }
                 }
-            };
-        }
-
-        if let (Some(range), Some(ops_range)) = (pending_keep_chunk, pending_ops_range) {
-            apply_chunk(&mut builder, range, ops_range);
-        }
-
-        builder.finish()
-    }
-
-    fn prepare_merge_ops(&mut self, split_point: usize) {
-        self.ops.drain(..split_point);
-
-        // Replace `KeepChunk` and `Update` ops with pure key-value ops,
-        // preparing for the base to be changed.
-        let mut i = 0;
-        while i < self.ops.len() {
-            let replaced_ops = replace_with_insert(&mut self.ops, i, self.base.as_ref());
-            i += replaced_ops;
-        }
-    }
-
-    fn op_first_key(&self, branch_op: &BranchOp) -> Key {
-        // UNWRAPs: `KeepChunk` leaf ops only exists when base is Some.
-        match branch_op {
-            BranchOp::Insert(k, _) => *k,
-            BranchOp::Update(pos, _) => self.base.as_ref().unwrap().key(*pos),
-            BranchOp::KeepChunk(chunk) => self.base.as_ref().unwrap().key(chunk.start),
-        }
-    }
-}
-
-fn replace_with_insert(
-    ops: &mut Vec<BranchOp>,
-    op_index: usize,
-    base: Option<&BaseBranch>,
-) -> usize {
-    match ops[op_index] {
-        BranchOp::Insert(_, _) => 1,
-        BranchOp::Update(pos, new_pn) => {
-            // UNWRAP: `Update` op only exists when base is Some.
-            ops[op_index] = BranchOp::Insert(base.unwrap().key(pos), new_pn);
-            1
-        }
-        BranchOp::KeepChunk(chunk) => {
-            ops.remove(op_index);
-
-            for pos in (chunk.start..chunk.end).into_iter().rev() {
-                // UNWRAP: `KeepChunk` op only exists when base is Some.
-                let (key, pn) = base.unwrap().key_value(pos);
-                ops.insert(op_index, BranchOp::Insert(key, pn));
             }
-            chunk.end - chunk.start
         }
-    }
-}
 
-// Given a vector of `BranchOp`, try to split the `index` operation,
-// which is expected to be KeepChunk, into two halves,
-// targeting a `target` size and and not exceeding a `limit`.
-//
-// `target` and `limit` are required to understand when to accept a split
-// with a final size smaller than the target. Constraining the split to always
-// be bigger than the target causes the update algorithm to frequently
-// fall into underfull to overfull scenarios.
-fn try_split_keep_chunk(
-    base: &BaseBranch,
-    gauge: &BranchGauge,
-    ops: &mut Vec<BranchOp>,
-    index: usize,
-    target: usize,
-    limit: usize,
-) -> usize {
-    let BranchOp::KeepChunk(chunk) = ops[index] else {
-        panic!("Attempted to split non `BranchOp::KeepChunk` operation");
-    };
-
-    let mut left_chunk_n_items = 0;
-    let mut left_chunk_sum_separator_lengths = 0;
-    let mut gauge = gauge.clone();
-    for i in chunk.start..chunk.end {
-        left_chunk_n_items += 1;
-
-        let key = get_key(&base.node, i);
-        let separator_len = separator_len(&key);
-        let body_size_after = gauge.body_size_after(key, separator_len);
-
-        if body_size_after >= target {
-            // if an item jumps from below the target to bigger then the limit, do not use it
-            if body_size_after > limit {
-                left_chunk_n_items -= 1;
-            } else {
-                gauge.ingest_key(key, separator_len);
-                left_chunk_sum_separator_lengths += separator_len;
+        match &ops[i] {
+            BranchOp::Insert(key, pn) => {
+                builder.push(*key, separator_len(key), pn.0);
+                i += 1;
             }
-            break;
-        }
-        left_chunk_sum_separator_lengths += separator_len;
-        gauge.ingest_key(key, separator_len);
-    }
-
-    // if none or all elements are taken then nothing needs to be changed
-    if left_chunk_n_items != 0 && chunk.len() != left_chunk_n_items {
-        let left_chunk = KeepChunk {
-            start: chunk.start,
-            end: chunk.start + left_chunk_n_items,
-            sum_separator_lengths: left_chunk_sum_separator_lengths,
+            BranchOp::KeepChunk(chunk) => {
+                pending_keep_chunk = Some(chunk.start..chunk.end);
+                pending_ops_range = Some(i..i + 1);
+                i += 1;
+            }
+            BranchOp::Update(pos, _) => {
+                pending_keep_chunk = Some(*pos..*pos + 1);
+                pending_ops_range = Some(i..i + 1);
+                i += 1;
+            }
         };
-
-        let right_chunk = KeepChunk {
-            start: chunk.start + left_chunk_n_items,
-            end: chunk.end,
-            sum_separator_lengths: chunk.sum_separator_lengths - left_chunk_sum_separator_lengths,
-        };
-
-        ops.insert(index, BranchOp::KeepChunk(left_chunk));
-        ops[index + 1] = BranchOp::KeepChunk(right_chunk);
     }
-    left_chunk_n_items
-}
 
-// extract the first item within a `BranchOp::KeepChunk` operation into a `BranchOp::Insert`
-fn extract_insert_from_keep_chunk(base: &BaseBranch, ops: &mut Vec<BranchOp>, index: usize) {
-    let BranchOp::KeepChunk(chunk) = ops[index] else {
-        panic!("Attempted to extract `BranchOp::Insert` from non `BranchOp::KeepChunk` operation");
-    };
-
-    let (key, pn) = base.key_value(chunk.start);
-    let separator_len = separator_len(&key);
-
-    if chunk.start == chunk.end - 1 {
-        // 0-sized chunks are not allowed, thus 1-Sized chunks become just an BranchOp::Insert
-        ops[index] = BranchOp::Insert(key, pn);
-    } else {
-        ops[index] = BranchOp::KeepChunk(KeepChunk {
-            start: chunk.start + 1,
-            end: chunk.end,
-            sum_separator_lengths: chunk.sum_separator_lengths - separator_len,
-        });
-        ops.insert(index, BranchOp::Insert(key, pn));
+    if let (Some(range), Some(ops_range)) = (pending_keep_chunk, pending_ops_range) {
+        apply_chunk(&mut builder, range, ops_range);
     }
+
+    builder.finish()
 }
 
 #[derive(Clone)]
-struct BranchGauge {
+pub struct BranchGauge {
     // key and length of the first separator if any
     first_separator: Option<(Key, usize)>,
     prefix_len: usize,
     // sum of all separator lengths (not including the first key).
     sum_separator_lengths: usize,
     // the number of items that are prefix compressed.`None` means everything will be compressed.
-    prefix_compressed: Option<usize>,
+    pub prefix_compressed: Option<usize>,
     n: usize,
 }
 
-impl BranchGauge {
-    fn new() -> Self {
+impl Default for BranchGauge {
+    fn default() -> Self {
         BranchGauge {
             first_separator: None,
             prefix_len: 0,
@@ -816,8 +386,10 @@ impl BranchGauge {
             n: 0,
         }
     }
+}
 
-    fn ingest_key(&mut self, key: Key, len: usize) {
+impl BranchGauge {
+    pub fn ingest_key(&mut self, key: Key, len: usize) {
         let Some((ref first, _)) = self.first_separator else {
             self.first_separator = Some((key, len));
             self.prefix_len = len;
@@ -833,7 +405,7 @@ impl BranchGauge {
         self.n += 1;
     }
 
-    fn ingest_branch_op(&mut self, base: Option<&BaseBranch>, op: &BranchOp) {
+    pub fn ingest_branch_op(&mut self, base: Option<&BaseBranch>, op: &BranchOp) {
         // UNWRAPs: `KeepChunk` and `Update` ops only exist when base is Some.
         match op {
             BranchOp::Update(pos, _) => {
@@ -849,7 +421,7 @@ impl BranchGauge {
         }
     }
 
-    fn ingest_chunk(&mut self, base: &BaseBranch, chunk: &KeepChunk) {
+    pub fn ingest_chunk(&mut self, base: &BaseBranch, chunk: &KeepChunk) {
         if let Some((ref first, _)) = self.first_separator {
             if self.prefix_compressed.is_none() {
                 let chunk_last_key = base.key(chunk.end - 1);
@@ -869,7 +441,7 @@ impl BranchGauge {
         };
     }
 
-    fn stop_prefix_compression(&mut self) {
+    pub fn stop_prefix_compression(&mut self) {
         assert!(self.prefix_compressed.is_none());
         self.prefix_compressed = Some(self.n);
     }
@@ -890,7 +462,7 @@ impl BranchGauge {
         }
     }
 
-    fn body_size_after(&mut self, key: Key, len: usize) -> usize {
+    pub fn body_size_after(&mut self, key: Key, len: usize) -> usize {
         let p;
         let t;
         if let Some((ref first, first_len)) = self.first_separator {
@@ -913,7 +485,7 @@ impl BranchGauge {
         branch_node::body_size(p, t, self.n + 1)
     }
 
-    fn body_size_after_chunk(&self, base: &BaseBranch, chunk: &KeepChunk) -> usize {
+    pub fn body_size_after_chunk(&self, base: &BaseBranch, chunk: &KeepChunk) -> usize {
         let p;
         let t;
         if let Some((ref first, first_len)) = self.first_separator {
@@ -946,44 +518,28 @@ impl BranchGauge {
         branch_node::body_size(p, t, self.n + chunk.len())
     }
 
-    fn body_size(&self) -> usize {
+    pub fn body_size(&self) -> usize {
         branch_node::body_size(
             self.prefix_len,
             self.total_separator_lengths(self.prefix_len),
             self.n,
         )
     }
-}
 
-#[derive(Default)]
-struct BranchBulkSplitter {
-    items: Vec<(usize, BranchGauge)>,
-    total_count: usize,
-}
-
-impl BranchBulkSplitter {
-    fn push(&mut self, count: usize, gauge: BranchGauge) {
-        self.items.push((count, gauge));
-        self.total_count += count;
+    #[cfg(test)]
+    pub fn n(&self) -> usize {
+        self.n
     }
 }
 
 #[cfg(test)]
 pub mod tests {
     use super::{
-        get_key, prefix_len, Arc, BaseBranch, BranchGauge, BranchNode, BranchNodeBuilder, BranchOp,
+        get_key, prefix_len, Arc, BaseBranch, BranchGauge, BranchNode, BranchNodeBuilder,
         BranchUpdater, DigestResult, HandleNewBranch, Key, PageNumber, PagePool,
         BRANCH_MERGE_THRESHOLD, BRANCH_NODE_BODY_SIZE,
     };
-    use crate::beatree::{
-        branch::node,
-        ops::{
-            bit_ops::separator_len,
-            update::{
-                branch_updater::KeepChunk, BRANCH_BULK_SPLIT_TARGET, BRANCH_BULK_SPLIT_THRESHOLD,
-            },
-        },
-    };
+    use crate::beatree::ops::bit_ops::separator_len;
     use std::collections::HashMap;
 
     lazy_static::lazy_static! {
@@ -1003,7 +559,7 @@ pub mod tests {
 
     #[test]
     fn gauge_stop_uncompressed() {
-        let mut gauge = BranchGauge::new();
+        let mut gauge = BranchGauge::default();
 
         gauge.ingest_key([0; 32], 0);
 
@@ -1039,7 +595,7 @@ pub mod tests {
         assert!(gauge.body_size_after(unprefixed_key, 256) < BRANCH_NODE_BODY_SIZE);
     }
 
-    fn prefixed_key(prefix_byte: u8, prefix_len: usize, i: usize) -> Key {
+    pub fn prefixed_key(prefix_byte: u8, prefix_len: usize, i: usize) -> Key {
         let mut k = [0u8; 32];
         for x in k.iter_mut().take(prefix_len) {
             *x = prefix_byte;
@@ -1065,15 +621,15 @@ pub mod tests {
         builder.finish()
     }
 
-    fn make_branch(vs: Vec<(Key, usize)>) -> Arc<BranchNode> {
+    pub fn make_branch(vs: Vec<(Key, usize)>) -> Arc<BranchNode> {
         Arc::new(make_raw_branch(vs))
     }
 
-    fn make_branch_with_body_size_target(
+    pub fn make_branch_with_body_size_target(
         mut key: impl FnMut(usize) -> Key,
         mut body_size_predicate: impl FnMut(usize) -> bool,
     ) -> Arc<BranchNode> {
-        let mut gauge = BranchGauge::new();
+        let mut gauge = BranchGauge::default();
         let mut items = Vec::new();
         loop {
             let next_key = key(items.len());
@@ -1098,7 +654,7 @@ pub mod tests {
         body_size_target: usize,
         bbn_pn: u32,
     ) -> Arc<BranchNode> {
-        let mut gauge = BranchGauge::new();
+        let mut gauge = BranchGauge::default();
         let mut items = Vec::new();
         loop {
             let Some(next_key) = keys.next() else {
@@ -1428,7 +984,7 @@ pub mod tests {
         );
 
         let branch_1_body_size = {
-            let mut gauge = BranchGauge::new();
+            let mut gauge = BranchGauge::default();
             for i in 0..new_branch_1.n() as usize {
                 let key = get_key(&new_branch_1, i);
                 gauge.ingest_key(key, separator_len(&key))
@@ -1447,78 +1003,12 @@ pub mod tests {
         );
     }
 
-    // initiate a bulk split step, ingest enough key to reach BRANCH_BULK_SPLIT_THRESHOLD
-    fn init_bulk_split() -> (usize, BranchUpdater) {
-        let key = |i| prefixed_key(0x00, 16, i);
-
-        let mut gauge = BranchGauge::new();
-        let mut n_keys = 0;
-
-        let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
-        updater.reset_base(None, Some(key(u16::MAX as usize)));
-
-        while gauge.body_size() < BRANCH_BULK_SPLIT_THRESHOLD {
-            let key = key(n_keys);
-
-            gauge.ingest_key(key, separator_len(&key));
-            updater.ingest(key, Some(PageNumber(n_keys as u32)));
-
-            n_keys += 1;
-        }
-
-        (n_keys, updater)
-    }
-
-    #[test]
-    fn bulk_split_initiation() {
-        let (n_keys, updater) = init_bulk_split();
-
-        let expected_bulk_split = BRANCH_BULK_SPLIT_THRESHOLD / BRANCH_BULK_SPLIT_TARGET;
-        // After ingesting all those ops, the bulk split is expected to be initiated.
-        let bulk_splitter = updater.bulk_split.as_ref().unwrap();
-        assert_eq!(bulk_splitter.items.len(), expected_bulk_split);
-        // The gauge needs to contain all the ops not present in the previous split.
-        assert_eq!(updater.gauge.n, n_keys - bulk_splitter.total_count);
-        // No operations are expected to be consumed yet.
-        assert_eq!(updater.ops.len(), n_keys);
-    }
-
-    #[test]
-    fn bulk_split_continuation() {
-        let key = |i| prefixed_key(0x00, 16, i);
-        let (mut n_keys, mut updater) = init_bulk_split();
-
-        let present_bulk_split_item = updater.bulk_split.as_ref().unwrap().items.len();
-
-        // Given an initialized bulk split, ingest more keys to reach the next bulk split.
-        let mut gauge = updater.gauge.clone();
-        while gauge.body_size() < BRANCH_BULK_SPLIT_TARGET {
-            let key = key(n_keys);
-
-            gauge.ingest_key(key, separator_len(&key));
-            updater.ingest(key, Some(PageNumber(n_keys as u32)));
-
-            n_keys += 1;
-        }
-
-        let bulk_splitter = updater.bulk_split.as_ref().unwrap();
-        // One new item in bulk split is expected.
-        assert_eq!(bulk_splitter.items.len(), present_bulk_split_item + 1);
-        // All ingested keys are expected to be part of the bulk_splitter.
-        assert_eq!(bulk_splitter.total_count, n_keys);
-        // The gauge is expected to be emtpy.
-        assert_eq!(updater.gauge.n, 0);
-        assert_eq!(updater.gauge.body_size(), 0);
-        // No operations are expected to be consumed yet.
-        assert_eq!(updater.ops.len(), n_keys);
-    }
-
     #[test]
     fn split_left_node_needs_merge() {
         let compressed_key = |i| prefixed_key(0x00, 25, i);
         let uncompressed_key = |i| prefixed_key(0xFF, 25, i);
 
-        let mut gauge = BranchGauge::new();
+        let mut gauge = BranchGauge::default();
         let mut n_keys = 0;
 
         let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
@@ -1553,7 +1043,8 @@ pub mod tests {
         };
         assert_eq!(cutoff, expected_cutoff);
         assert_eq!(new_branches.inner.len(), 0);
-        assert_eq!(updater.ops.len(), n_keys);
+        let (ops, _) = updater.ops_tracker.extract_ops();
+        assert_eq!(ops.len(), n_keys);
     }
 
     #[test]
@@ -1561,7 +1052,7 @@ pub mod tests {
         let compressed_key = |i| prefixed_key(0x00, 5, i);
         let uncompressed_key = |i| prefixed_key(0xFF, 5, i);
 
-        let mut gauge = BranchGauge::new();
+        let mut gauge = BranchGauge::default();
         let mut n_keys = 0;
 
         let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
@@ -1589,7 +1080,9 @@ pub mod tests {
             panic!()
         };
         assert_eq!(new_branches.inner.len(), 1);
-        assert!(updater.ops.is_empty());
+
+        let (ops, _) = updater.ops_tracker.extract_ops();
+        assert!(ops.is_empty());
     }
 
     #[test]
@@ -1597,7 +1090,7 @@ pub mod tests {
         let compressed_key = |i| prefixed_key(0x00, 25, i);
         let uncompressed_key = |i| prefixed_key(0xFF, 25, i);
 
-        let mut gauge = BranchGauge::new();
+        let mut gauge = BranchGauge::default();
         let mut n_keys = 0;
 
         let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
@@ -1628,551 +1121,7 @@ pub mod tests {
             panic!()
         };
         assert_eq!(new_branches.inner.len(), 1);
-        assert!(updater.ops.is_empty());
-    }
-
-    #[test]
-    fn consume_and_update_until_inserts() {
-        let key = |i| prefixed_key(0x00, 16, i);
-        let mut gauge = BranchGauge::new();
-        let target = BRANCH_MERGE_THRESHOLD;
-        let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
-
-        // Collect BranchOp::Insert into updater.ops until the gauge associated
-        // to the ops is just after the target.
-        let mut rightsized = false;
-        updater.ops = (0..)
-            .map(|i| key(i))
-            .take_while(|key| {
-                let res = !rightsized;
-                rightsized = gauge.body_size_after(*key, separator_len(key)) >= target;
-
-                if res {
-                    gauge.ingest_key(*key, separator_len(key));
-                }
-                res
-            })
-            .enumerate()
-            .map(|(i, key)| BranchOp::Insert(key, PageNumber(i as u32)))
-            .collect();
-
-        // All ops are expected to be consumed without any modification.
-        let Ok((item_count, res_gauge)) = updater.consume_and_update_until(0, target) else {
-            panic!()
-        };
-        assert_eq!(item_count, updater.ops.len());
-        assert_eq!(res_gauge.body_size(), gauge.body_size());
-    }
-
-    #[test]
-    fn consume_and_update_updates() {
-        let key = |i| prefixed_key(0x00, 16, i);
-
-        let mut gauge = BranchGauge::new();
-        let target = BRANCH_MERGE_THRESHOLD;
-
-        let branch = make_branch_with_body_size_target(key, |size| size < BRANCH_NODE_BODY_SIZE);
-
-        let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
-        updater.reset_base(
-            Some(BaseBranch {
-                node: branch.clone(),
-                low: 0,
-            }),
-            None,
-        );
-
-        // Collect BranchOp::Update into updater.ops until the gauge associated
-        // to the ops is just after the target.
-        let mut rightsized = false;
-        updater.ops = (0..)
-            .map(|i| (i, get_key(&branch, i)))
-            .take_while(|(_i, key)| {
-                let res = !rightsized;
-                rightsized = gauge.body_size_after(*key, separator_len(key)) >= target;
-
-                if res {
-                    gauge.ingest_key(*key, separator_len(key));
-                }
-                res
-            })
-            .map(|(i, _key)| BranchOp::Update(i, PageNumber(i as u32)))
-            .collect();
-
-        // All ops are expected to be consumed without any modification.
-        let Ok((item_count, res_gauge)) = updater.consume_and_update_until(0, target) else {
-            panic!()
-        };
-        assert_eq!(item_count, updater.ops.len());
-        assert_eq!(res_gauge.body_size(), gauge.body_size());
-    }
-
-    #[test]
-    fn consume_and_update_keeps() {
-        let key = |i| prefixed_key(0x00, 16, i);
-
-        let mut gauge = BranchGauge::new();
-        let target = BRANCH_MERGE_THRESHOLD;
-
-        let branch = make_branch_with_body_size_target(key, |size| size < BRANCH_NODE_BODY_SIZE);
-
-        let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
-        updater.reset_base(
-            Some(BaseBranch {
-                node: branch.clone(),
-                low: 0,
-            }),
-            None,
-        );
-
-        let base_branch = BaseBranch {
-            node: branch.clone(),
-            low: 0,
-        };
-
-        // Collect BranchOp::KeepChunk into updater.ops until the gauge associated
-        // to the ops is just after the target.
-        // The chunks are increasingly bigger, the first one covers 1 element, and each
-        // of the following chunks covers one more element.
-        let mut rightsized = false;
-        let mut from = 0;
-        updater.ops = (1usize..)
-            .map(|to| {
-                let start = from;
-                let end = from + to;
-                from += to;
-                KeepChunk {
-                    start,
-                    end,
-                    sum_separator_lengths: node::uncompressed_separator_range_size(
-                        branch.prefix_len() as usize,
-                        branch.separator_range_len(start, end),
-                        end - start,
-                        separator_len(&get_key(&branch, start)),
-                    ),
-                }
-            })
-            .take_while(|keep_chunk| {
-                let res = !rightsized;
-                rightsized = gauge.body_size_after_chunk(&base_branch, &keep_chunk) >= target;
-                if res {
-                    gauge.ingest_chunk(&base_branch, &keep_chunk);
-                }
-                res
-            })
-            .map(|keep_chunk| BranchOp::KeepChunk(keep_chunk))
-            .collect();
-
-        // Almost all ops are expected to be consumed.
-        let Ok((item_count, res_gauge)) = updater.consume_and_update_until(0, target) else {
-            panic!()
-        };
-        // Last keep_chunk is expected to have been split.
-        assert_eq!(item_count, updater.ops.len() - 1);
-        assert!(res_gauge.body_size() > target);
-    }
-
-    #[test]
-    fn consume_and_update_stop_prefix_compression_on_updates() {
-        let compressed_key = |i| prefixed_key(0x00, 30, i);
-        let uncompressed_key = |i| prefixed_key(0xFF, 30, i);
-
-        let mut gauge = BranchGauge::new();
-        let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
-
-        // Collect BranchOp::Insert into updater.ops until the gauge associated
-        // to the ops is just after the BRANCH_MERGE_THRESHOLD / 2
-        updater.ops = (0..)
-            .map(|i| compressed_key(i))
-            .take_while(|key| {
-                if gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD / 2 {
-                    false
-                } else {
-                    gauge.ingest_key(*key, separator_len(key));
-                    true
-                }
-            })
-            .enumerate()
-            .map(|(i, key)| BranchOp::Insert(key, PageNumber(i as u32)))
-            .collect();
-        let n_insert_op = updater.ops.len();
-
-        // Use a branch containing keys which do not share a prefix with the just ingested keys
-        let branch = make_branch_with_body_size_target(uncompressed_key, |size| {
-            size < BRANCH_NODE_BODY_SIZE
-        });
-
-        updater.reset_base(
-            Some(BaseBranch {
-                node: branch.clone(),
-                low: 0,
-            }),
-            None,
-        );
-
-        // Extends updater.ops with BranchOp::Update operations until the final expected gauge
-        // reaches the target.
-        gauge.stop_prefix_compression();
-        let mut rightsized = false;
-        let update_ops: Vec<BranchOp> = (0..)
-            .map(|i| (i, get_key(&branch, i)))
-            .take_while(|(_i, key)| {
-                let res = !rightsized;
-                rightsized =
-                    gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD;
-
-                if res {
-                    gauge.ingest_key(*key, separator_len(key));
-                }
-                res
-            })
-            .map(|(i, _key)| BranchOp::Update(i, PageNumber(i as u32)))
-            .collect();
-
-        updater.ops.extend(update_ops);
-
-        let Ok((item_count, res_gauge)) =
-            updater.consume_and_update_until(0, BRANCH_NODE_BODY_SIZE)
-        else {
-            panic!()
-        };
-
-        // Make sure that not only the update operation on which the stop_prefix_compression
-        // requirement has been found has been updated to insert, but also all subsequent operations.
-        for i in n_insert_op..item_count {
-            assert!(matches!(
-                updater.ops[i],
-                BranchOp::Insert(k, PageNumber(_)) if k == uncompressed_key(i - n_insert_op)
-            ));
-        }
-
-        // The target has been downgraded to reduce the amount of uncompressed items
-        assert!(res_gauge.body_size() > BRANCH_MERGE_THRESHOLD);
-        assert!(res_gauge.body_size() < BRANCH_NODE_BODY_SIZE);
-    }
-
-    #[test]
-    fn consume_and_update_stop_prefix_compression_on_keeps() {
-        let compressed_key = |i| prefixed_key(0x00, 30, i);
-        let uncompressed_key = |i| prefixed_key(0xFF, 30, i);
-
-        let mut gauge = BranchGauge::new();
-        let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
-
-        // Collect BranchOp::Insert into updater.ops until the gauge associated
-        // to the ops is just after the BRANCH_MERGE_THRESHOLD / 2
-        updater.ops = (0..)
-            .map(|i| compressed_key(i))
-            .take_while(|key| {
-                if gauge.body_size_after(*key, separator_len(key)) >= BRANCH_MERGE_THRESHOLD / 2 {
-                    false
-                } else {
-                    gauge.ingest_key(*key, separator_len(key));
-                    true
-                }
-            })
-            .enumerate()
-            .map(|(i, key)| BranchOp::Insert(key, PageNumber(i as u32)))
-            .collect();
-        let n_insert_op = updater.ops.len();
-
-        // Use a branch containing keys which do not share a prefix with the just ingested keys.
-        let branch = make_branch_with_body_size_target(uncompressed_key, |size| {
-            size < BRANCH_NODE_BODY_SIZE
-        });
-
-        updater.reset_base(
-            Some(BaseBranch {
-                node: branch.clone(),
-                low: 0,
-            }),
-            None,
-        );
-        let base_branch = BaseBranch {
-            node: branch.clone(),
-            low: 0,
-        };
-
-        // Extends updater.ops with BranchOp::KeepChunk operations until the final expected gauge
-        // reaches the target.
-        // The chunks are increasingly bigger, the first one covers 7 elements, and each
-        // of the following chunks covers one more element.
-        gauge.stop_prefix_compression();
-        let mut rightsized = false;
-        let mut from = 0;
-        let mut total_kept_itmes = 0;
-        let keep_ops: Vec<BranchOp> = (7..)
-            .map(|to| {
-                let start = from;
-                let end = from + to;
-                from += to;
-                KeepChunk {
-                    start,
-                    end,
-                    sum_separator_lengths: node::uncompressed_separator_range_size(
-                        branch.prefix_len() as usize,
-                        branch.separator_range_len(start, end),
-                        end - start,
-                        separator_len(&get_key(&branch, start)),
-                    ),
-                }
-            })
-            .take_while(|keep_chunk| {
-                let res = !rightsized;
-                rightsized = gauge.body_size_after_chunk(&base_branch, &keep_chunk)
-                    >= BRANCH_MERGE_THRESHOLD;
-                if res {
-                    gauge.ingest_chunk(&base_branch, &keep_chunk);
-                    total_kept_itmes += keep_chunk.end - keep_chunk.start;
-                }
-                res
-            })
-            .map(|keep_chunk| BranchOp::KeepChunk(keep_chunk))
-            .collect();
-
-        updater.ops.extend(keep_ops);
-
-        let Ok((item_count, res_gauge)) =
-            updater.consume_and_update_until(0, BRANCH_NODE_BODY_SIZE)
-        else {
-            panic!()
-        };
-
-        // Make sure that not only the KeepChunk operation on which the stop_prefix_compression
-        // requirement has been found has been updated to insert, but also all subsequent operations.
-        for i in n_insert_op..item_count {
-            assert!(matches!(
-                updater.ops[i],
-                BranchOp::Insert(k, PageNumber(_)) if k == uncompressed_key(i - n_insert_op)
-            ));
-        }
-
-        // Ensure that the last keep operation has been split correctly.
-        let expected_size_split_chunk = total_kept_itmes - (item_count - n_insert_op);
-        let BranchOp::KeepChunk(split_keep_chunk) = &updater.ops[item_count] else {
-            panic!()
-        };
-        let split_keep_chunk = split_keep_chunk.end - split_keep_chunk.start;
-        assert_eq!(split_keep_chunk, expected_size_split_chunk);
-
-        // The target has been downgraded to reduce the amount of uncompressed items.
-        assert!(res_gauge.body_size() > BRANCH_MERGE_THRESHOLD);
-        assert!(res_gauge.body_size() < BRANCH_NODE_BODY_SIZE);
-    }
-
-    #[test]
-    fn ingest_after_stop_prefix_compression() {
-        let key = |i| prefixed_key(0x00, 6, i);
-
-        let mut updater = BranchUpdater::new(PAGE_POOL.clone(), None, None);
-
-        let n_keep = 10;
-        let branch = make_branch((2..n_keep).map(|i| (key(i), i)).collect());
-
-        updater.reset_base(
-            Some(BaseBranch {
-                node: branch,
-                low: 0,
-            }),
-            None,
-        );
-
-        updater.ingest(key(0), Some(PageNumber(0))); // insert
-        updater.gauge.stop_prefix_compression();
-        updater.ingest(key(1), Some(PageNumber(0))); // insert
-        updater.ingest(key(2), Some(PageNumber(1))); // update
-        updater.ingest(key(n_keep), Some(PageNumber(0))); // keep_chunk + insert
-
-        // Make sure that all ops are Insert type.
-        for op in updater.ops {
-            assert!(matches!(op, BranchOp::Insert(..)));
-        }
-    }
-
-    #[test]
-    fn try_split_keep_chunk() {
-        let key = |i| prefixed_key(0x00, 16, i);
-        let keys: Vec<(Key, usize)> = (0..100).map(|i| (key(i), i)).collect();
-
-        let mut base_node_gauge = BranchGauge::new();
-
-        let mut sum_separator_lengths = 0;
-        for (key, _) in keys.clone() {
-            let len = separator_len(&key);
-            base_node_gauge.ingest_key(key, len);
-            sum_separator_lengths += len;
-        }
-
-        let branch = make_branch(keys.clone());
-        let base = BaseBranch {
-            node: branch,
-            low: 0,
-        };
-
-        let chunk = KeepChunk {
-            start: 0,
-            end: keys.len(),
-            sum_separator_lengths,
-        };
-
-        // Perform a standard split
-        let gauge = BranchGauge::new();
-        let target = base_node_gauge.body_size() / 3;
-        let limit = base_node_gauge.body_size() / 2;
-        let mut ops = vec![BranchOp::KeepChunk(chunk)];
-        let left_split_len = super::try_split_keep_chunk(&base, &gauge, &mut ops, 0, target, limit);
-
-        assert_eq!(ops.len(), 2);
-        let chunk1 = match &ops[0] {
-            BranchOp::KeepChunk(c1) => c1,
-            _ => panic!(),
-        };
-        let chunk2 = match &ops[1] {
-            BranchOp::KeepChunk(c2) => c2,
-            _ => panic!(),
-        };
-        assert_eq!(chunk1.len(), left_split_len);
-        assert_eq!(chunk1.len() + chunk2.len(), keys.len());
-        assert!(gauge.body_size_after_chunk(&base, chunk1) > target);
-        assert!(gauge.body_size_after_chunk(&base, chunk1) < limit);
-
-        // Perform a split which is not able to reach the target
-        let gauge = BranchGauge::new();
-        let target = base_node_gauge.body_size() * 2;
-        let limit = base_node_gauge.body_size() * 2;
-        let mut ops = vec![BranchOp::KeepChunk(chunk)];
-        super::try_split_keep_chunk(&base, &gauge, &mut ops, 0, target, limit);
-
-        assert_eq!(ops.len(), 1);
-        let chunk1 = match &ops[0] {
-            BranchOp::KeepChunk(c1) => c1,
-            _ => panic!(),
-        };
-        assert_eq!(chunk1.len(), keys.len());
-        assert!(gauge.body_size_after_chunk(&base, chunk1) < target);
-
-        // Perform a split with a target too little,
-        // but something smaller than the limit will still be split.
-        let gauge = BranchGauge::new();
-        let target = 1;
-        let limit = BRANCH_NODE_BODY_SIZE;
-        let mut ops = vec![BranchOp::KeepChunk(chunk)];
-        super::try_split_keep_chunk(&base, &gauge, &mut ops, 0, target, limit);
-
-        assert_eq!(ops.len(), 2);
-        let chunk1 = match &ops[0] {
-            BranchOp::KeepChunk(c1) => c1,
-            _ => panic!(),
-        };
-        assert_eq!(chunk1.len(), 1);
-        assert!(gauge.body_size_after_chunk(&base, chunk1) > target);
-        assert!(gauge.body_size_after_chunk(&base, chunk1) < limit);
-
-        // Perform a split with a limit too little,
-        // nothing will still be split.
-        let gauge = BranchGauge::new();
-        let target = 1;
-        let limit = 1;
-        let mut ops = vec![BranchOp::KeepChunk(chunk)];
-        super::try_split_keep_chunk(&base, &gauge, &mut ops, 0, target, limit);
-
-        assert_eq!(ops.len(), 1);
-        let chunk1 = match &ops[0] {
-            BranchOp::KeepChunk(c1) => c1,
-            _ => panic!(),
-        };
-        assert_eq!(chunk1.len(), keys.len());
-    }
-
-    #[test]
-    fn replace_with_insert() {
-        let key = |i| prefixed_key(0x00, 16, i);
-        let n_keys = 100;
-        let keys: Vec<(Key, usize)> = (1..1 + n_keys).map(|i| (key(i), i)).collect();
-
-        let mut base_node_gauge = BranchGauge::new();
-
-        let mut sum_separator_lengths = 0;
-        for (key, _) in keys.clone() {
-            let len = separator_len(&key);
-            base_node_gauge.ingest_key(key, len);
-            sum_separator_lengths += len;
-        }
-
-        let branch = make_branch(keys.clone());
-        let base = BaseBranch {
-            node: branch,
-            low: 0,
-        };
-
-        let insert1 = BranchOp::Insert(key(0), PageNumber(1));
-        let insert2 = BranchOp::Insert(key(n_keys + 2), PageNumber(2));
-        let chunk = KeepChunk {
-            start: 1,
-            end: keys.len(),
-            sum_separator_lengths,
-        };
-
-        let mut ops = vec![
-            insert1,
-            BranchOp::Update(0, PageNumber(3)),
-            BranchOp::KeepChunk(chunk),
-            insert2,
-        ];
-
-        // insert remains insert
-        super::replace_with_insert(&mut ops, 0, None);
-        assert!(matches!(ops[0], BranchOp::Insert(k,..) if k == key(0)));
-        assert_eq!(ops.len(), 4);
-
-        // update becomes insert
-        super::replace_with_insert(&mut ops, 1, Some(&base));
-        assert!(matches!(ops[1], BranchOp::Insert(k,..) if k == key(1)));
-        assert_eq!(ops.len(), 4);
-
-        // keep becomes multiple inserts
-        super::replace_with_insert(&mut ops, 2, Some(&base));
-        for (i, op) in ops[2..ops.len() - 2].iter().enumerate() {
-            assert!(matches!(op, BranchOp::Insert(k,..) if *k == key(i + 2)));
-        }
-        assert!(matches!(ops[ops.len() - 1], BranchOp::Insert(k,..) if k == key(n_keys + 2)));
-        assert_eq!(ops.len(), 2 + n_keys);
-    }
-
-    #[test]
-    fn extract_insert_from_keep_chunk() {
-        let key = |i| prefixed_key(0x00, 16, i);
-        let n_keys = 100;
-        let keys: Vec<(Key, usize)> = (0..n_keys).map(|i| (key(i), i)).collect();
-        let sum_separator_lengths = keys.clone().iter().map(|(k, _)| separator_len(k)).sum();
-
-        let branch = make_branch(keys.clone());
-        let base = BaseBranch {
-            node: branch,
-            low: 0,
-        };
-
-        let chunk = KeepChunk {
-            start: 0,
-            end: keys.len(),
-            sum_separator_lengths,
-        };
-        let mut ops = vec![BranchOp::KeepChunk(chunk)];
-
-        super::extract_insert_from_keep_chunk(&base, &mut ops, 0);
-        assert_eq!(ops.len(), 2);
-        assert!(matches!(ops[0], BranchOp::Insert(k,..) if k == key(0)));
-        assert!(matches!(ops[1], BranchOp::KeepChunk(c) if c.len() == n_keys - 1));
-
-        // 0-sized chunks are not allowed.
-        let chunk = KeepChunk {
-            start: 0,
-            end: 1,
-            sum_separator_lengths,
-        };
-        let mut ops = vec![BranchOp::KeepChunk(chunk)];
-        super::extract_insert_from_keep_chunk(&base, &mut ops, 0);
-        assert_eq!(ops.len(), 1);
-        assert!(matches!(ops[0], BranchOp::Insert(k,..) if k == key(0)));
+        let (ops, _) = updater.ops_tracker.extract_ops();
+        assert!(ops.is_empty());
     }
 }

--- a/nomt/src/beatree/ops/update/mod.rs
+++ b/nomt/src/beatree/ops/update/mod.rs
@@ -16,6 +16,7 @@ use crate::beatree::{
 };
 use crate::io::{IoHandle, PagePool};
 
+mod branch_ops;
 mod branch_stage;
 mod branch_updater;
 mod extend_range_protocol;


### PR DESCRIPTION
The following includes a significant refactor of the branch updater. The main goal was to encapsulate all the logic for branch operation handling elsewhere, in this case in the `BranchOpsTracker`.

I'm not attached to specific names, so suggestions are welcome. I find it extremely interesting how the `BranchUpdater` has been greatly simplified, and as a result, the module's source of errors seems to be drastically reduced.

It is a substantial refactor, and I wasn't able to split it across multiple smaller pull requests. Looking at how many lines changed it seems completely new code, but it isn't. Just most of the logic that was spread around the `BranchUpdter` is logically moved into the `BranchOpsTracker`. The only real change is in how bulk split is handled. It is not something that is checked on each ingestion, but it is only attempted during the `digest` method. 
