### PR TITLE
chore: reduce benchtop init workload size

### DIFF
--- a/benchtop/src/custom_workload.rs
+++ b/benchtop/src/custom_workload.rs
@@ -13,7 +13,7 @@ pub struct RwInit {
 
 impl Workload for RwInit {
     fn run_step(&mut self, transaction: &mut dyn Transaction) {
-        const MAX_INIT_PER_ITERATION: u64 = 2 * 1024 * 1024;
+        const MAX_INIT_PER_ITERATION: u64 = 64 * 1024 * 1024;
 
         if self.num_vals == 0 {
             return;

--- a/benchtop/src/transfer_workload.rs
+++ b/benchtop/src/transfer_workload.rs
@@ -13,7 +13,7 @@ pub struct TransferInit {
 
 impl Workload for TransferInit {
     fn run_step(&mut self, transaction: &mut dyn Transaction) {
-        const MAX_INIT_PER_ITERATION: u64 = 2 * 1024 * 1024;
+        const MAX_INIT_PER_ITERATION: u64 = 64 * 1024;
 
         if self.num_accounts == 0 {
             return;


### PR DESCRIPTION
there are some parts of the code that are inherently non-parallel. This helps with performance a bit.
