### PR TITLE
fix(wal): add sync_seqn to WAL and skip recovery when not matching.

### DIFF
--- a/nomt/src/bitbox/wal/mod.rs
+++ b/nomt/src/bitbox/wal/mod.rs
@@ -1,6 +1,7 @@
-const WAL_ENTRY_TAG_END: u8 = 0;
-const WAL_ENTRY_TAG_CLEAR: u8 = 1;
-const WAL_ENTRY_TAG_UPDATE: u8 = 2;
+const WAL_ENTRY_TAG_START: u8 = 0;
+const WAL_ENTRY_TAG_END: u8 = 1;
+const WAL_ENTRY_TAG_CLEAR: u8 = 2;
+const WAL_ENTRY_TAG_UPDATE: u8 = 3;
 
 pub use read::{WalBlobReader, WalEntry};
 pub use write::WalBlobBuilder;

--- a/nomt/src/bitbox/wal/tests.rs
+++ b/nomt/src/bitbox/wal/tests.rs
@@ -14,6 +14,7 @@ fn test_write_read() {
     };
 
     let mut builder = WalBlobBuilder::new().unwrap();
+    builder.reset(69);
     builder.write_clear(0);
     builder.write_update(
         [0; 32],
@@ -52,6 +53,8 @@ fn test_write_read() {
 
     let page_pool = PagePool::new();
     let mut reader = WalBlobReader::new(&page_pool, &wal_fd).unwrap();
+
+    assert_eq!(reader.sync_seqn(), 69);
     assert_eq!(
         reader.read_entry().unwrap(),
         Some(WalEntry::Clear { bucket: 0 })

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -25,7 +25,7 @@ use store::Store;
 
 pub use nomt_core::proof;
 pub use nomt_core::trie::{KeyPath, LeafData, Node, NodePreimage};
-pub use options::Options;
+pub use options::{Options, PanicOnSyncMode};
 
 // beatree module needs to be exposed to be benchmarked
 #[cfg(feature = "benchmarks")]

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -150,6 +150,7 @@ impl Store {
             o.commit_concurrency,
         )?;
         let pages = bitbox::DB::open(
+            meta.sync_seqn,
             meta.bitbox_num_pages,
             meta.bitbox_seed,
             page_pool.clone(),

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -1,4 +1,7 @@
-use nomt::{KeyPath, KeyReadWrite, Node, Nomt, Options, Session, Witness, WitnessedOperations};
+use nomt::{
+    KeyPath, KeyReadWrite, Node, Nomt, Options, PanicOnSyncMode, Session, Witness,
+    WitnessedOperations,
+};
 use std::{
     collections::{hash_map::Entry, HashMap},
     mem,
@@ -42,16 +45,17 @@ pub struct Test {
     access: HashMap<KeyPath, KeyReadWrite>,
 }
 
+#[allow(dead_code)]
 impl Test {
     pub fn new(name: impl AsRef<Path>) -> Self {
-        Self::new_with_params(name, 1, 64_000, false, true)
+        Self::new_with_params(name, 1, 64_000, None, true)
     }
 
     pub fn new_with_params(
         name: impl AsRef<Path>,
         commit_concurrency: usize,
         hashtable_buckets: u32,
-        panic_on_sync: bool,
+        panic_on_sync: Option<PanicOnSyncMode>,
         cleanup_dir: bool,
     ) -> Self {
         let path = {
@@ -63,7 +67,9 @@ impl Test {
             let _ = std::fs::remove_dir_all(&path);
         }
         let mut o = opts(path);
-        o.panic_on_sync(panic_on_sync);
+        if let Some(mode) = panic_on_sync {
+            o.panic_on_sync(mode);
+        }
         o.bitbox_seed([0; 16]);
         o.hashtable_buckets(hashtable_buckets);
         o.commit_concurrency(commit_concurrency);

--- a/nomt/tests/exclusive_dir.rs
+++ b/nomt/tests/exclusive_dir.rs
@@ -15,7 +15,6 @@ fn setup_nomt(path: &str, should_clean_up: bool) -> anyhow::Result<Nomt<Blake3Ha
     }
     let mut o = Options::new();
     o.path(path);
-    o.panic_on_sync(false);
     o.bitbox_seed([0; 16]);
     Nomt::open(o)
 }

--- a/nomt/tests/extend_range_protocol.rs
+++ b/nomt/tests/extend_range_protocol.rs
@@ -30,7 +30,7 @@ const KEYS_AND_VALUE_SIZES: [(u8, usize); 16] =[
 // and all the remaining keys to the next worker. This makes possible
 // to expect the type of communication between the two workers
 fn insert_delete_and_read(name: impl AsRef<Path>, to_delete: Vec<u8>) {
-    let mut t = Test::new_with_params(name, 2, 64_000, false, true);
+    let mut t = Test::new_with_params(name, 2, 64_000, None, true);
 
     // insert values
     for (k, value_size) in KEYS_AND_VALUE_SIZES.clone() {

--- a/nomt/tests/fill_and_empty.rs
+++ b/nomt/tests/fill_and_empty.rs
@@ -30,7 +30,7 @@ fn fill_and_empty(commit_concurrency: usize) {
         format!("fill_and_empty_{}", commit_concurrency), // name
         commit_concurrency,
         15000, // hashtable_buckets
-        false, // panic_on_sync
+        None,  // panic_on_sync
         true,  //  cleanup_dir
     );
 

--- a/nomt/tests/last_layer_trie.rs
+++ b/nomt/tests/last_layer_trie.rs
@@ -8,7 +8,7 @@ fn last_layer_trie() {
         "last_layer_trie", // name
         1,                 // commit_concurrency
         10_000,            // hashtable_buckets
-        false,             // panic_on_sync
+        None,              // panic_on_sync
         true,              // cleanup_dir
     );
 

--- a/nomt/tests/rollback.rs
+++ b/nomt/tests/rollback.rs
@@ -25,7 +25,6 @@ fn setup_nomt(
     let mut o = Options::new();
     o.path(path);
     o.commit_concurrency(commit_concurrency);
-    o.panic_on_sync(false);
     o.bitbox_seed([0; 16]);
     o.rollback(rollback_enabled);
     Nomt::open(o).unwrap()

--- a/nomt/tests/wal.rs
+++ b/nomt/tests/wal.rs
@@ -1,16 +1,17 @@
 mod common;
 
 use common::Test;
+use nomt::PanicOnSyncMode;
 
 #[test]
-fn wal_recovery_test() {
+fn wal_recovery_test_post_meta_swap() {
     // Initialize the db with panic on sync equals true.
     let mut t = Test::new_with_params(
         "wal_add_remove_1000",
-        /* commit_concurrency */ 1,
-        /* hashtable_buckets */ 1000000,
-        /* panic_on_sync */ true,
-        /* clean */ true,
+        1,                               // commit_concurrency,
+        1000000,                         // hashtable_buckets,
+        Some(PanicOnSyncMode::PostMeta), // panic_on_sync
+        true,                            // clean
     );
 
     common::set_balance(&mut t, 0, 1000);
@@ -26,12 +27,49 @@ fn wal_recovery_test() {
     // Re-open the db without cleaning the DB dir and without panic on sync.
     let mut t = Test::new_with_params(
         "wal_add_remove_1000",
-        /* commit_concurrency */ 1,
-        /* hashtable_buckets */ 1000000,
-        /* panic_on_sync */ false,
-        /* clean */ false,
+        1,       // commit_concurrency,
+        1000000, // hashtable_buckets,
+        None,    // panic_on_sync
+        false,   // clean
     );
     assert_eq!(common::read_balance(&mut t, 0), Some(1000));
     assert_eq!(common::read_balance(&mut t, 1), Some(2000));
     assert_eq!(common::read_balance(&mut t, 2), Some(3000));
+}
+
+#[test]
+fn wal_recovery_test_pre_meta_swap() {
+    // Initialize the db with panic on sync equals true.
+    let mut t = Test::new_with_params(
+        "wal_pre_meta_swap",
+        1,                              // commit_concurrency,
+        1000000,                        // hashtable_buckets,
+        Some(PanicOnSyncMode::PostWal), // panic_on_sync
+        true,                           // clean
+    );
+
+    for i in 0..1000 {
+        common::set_balance(&mut t, i, 1000);
+    }
+
+    let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        t.commit();
+    }));
+    assert!(r.is_err());
+    drop(t);
+
+    // Re-open the db without cleaning the DB dir and without panic on sync.
+    let mut t = Test::new_with_params(
+        "wal_pre_meta_swap",
+        1,       // commit_concurrency,
+        1000000, // hashtable_buckets,
+        None,    // panic_on_sync
+        false,   // clean
+    );
+
+    // DB should open cleanly and not have any incomplete changes; the WAL is too new and will be
+    // discarded.
+    for i in 0..1000 {
+        assert_eq!(common::read_balance(&mut t, i), None);
+    }
 }


### PR DESCRIPTION
Our sync order of operations is:
  1. WAL + beatree shadow pages
  2. meta update
  3. destructive hash-table writes
  4. WAL truncate

specifically, the WAL is for crash consistency in situations after step 2: the beatree has the new values but the hash-table buckets might be incompletely altered.

therefore, a crash _before_ step (2) has completed should not lead to a WAL recovery. This PR fixes and tests this by adding the `sync_seqn` to the WAL and checking during recovery.
