### PR TITLE
feat: update* functions in NOMT API

### DIFF
--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -65,7 +65,9 @@ impl NomtDB {
         let _timer_guard_commit = timer.as_mut().map(|t| t.record_span("commit_and_prove"));
         let mut actual_access: Vec<_> = access.into_iter().collect();
         actual_access.sort_by_key(|(k, _)| *k);
-        self.nomt.commit_and_prove(session, actual_access).unwrap();
+        self.nomt
+            .update_commit_and_prove(session, actual_access)
+            .unwrap();
     }
 
     // note: this is only intended to be used with workloads which are disjoint, i.e. no workload
@@ -118,7 +120,9 @@ impl NomtDB {
             .flatten()
             .collect();
         actual_access.sort_by_key(|(k, _)| *k);
-        self.nomt.commit_and_prove(session, actual_access).unwrap();
+        self.nomt
+            .update_commit_and_prove(session, actual_access)
+            .unwrap();
     }
 
     pub fn print_metrics(&self) {

--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -55,7 +55,7 @@ impl NomtDB {
         // The final step in handling a session involves committing all changes
         // to update the trie structure and obtaining the new root of the trie,
         // along with a witness and the witnessed operations.
-        let (root, witness, witnessed) = nomt.commit_and_prove(session, actual_access)?;
+        let (root, witness, witnessed) = nomt.update_commit_and_prove(session, actual_access)?;
 
         Ok((prev_root, root, witness, witnessed))
     }

--- a/examples/read_value/src/main.rs
+++ b/examples/read_value/src/main.rs
@@ -25,7 +25,8 @@ fn main() -> Result<()> {
     // we will prove the read.
     session.warm_up(key_path);
 
-    let _witness = nomt.commit_and_prove(session, vec![(key_path, KeyReadWrite::Read(value))])?;
+    let _witness =
+        nomt.update_commit_and_prove(session, vec![(key_path, KeyReadWrite::Read(value))])?;
 
     Ok(())
 }

--- a/fuzz/fuzz_targets/api_surface.rs
+++ b/fuzz/fuzz_targets/api_surface.rs
@@ -28,7 +28,7 @@ fuzz_target!(|run: Run| {
                             session.warm_up(key_path);
                         }
                         SessionCall::CommitAndProve { keys } => {
-                            let _ = db.commit_and_prove(session, keys);
+                            let _ = db.update_commit_and_prove(session, keys);
                             break;
                         }
                         SessionCall::Drop => {

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -119,7 +119,10 @@ impl Test {
         let session = mem::take(&mut self.session).unwrap();
         let mut actual_access: Vec<_> = mem::take(&mut self.access).into_iter().collect();
         actual_access.sort_by_key(|(k, _)| *k);
-        let x = self.nomt.commit_and_prove(session, actual_access).unwrap();
+        let x = self
+            .nomt
+            .update_commit_and_prove(session, actual_access)
+            .unwrap();
         self.session = Some(self.nomt.begin_session());
         x
     }

--- a/nomt/tests/rollback.rs
+++ b/nomt/tests/rollback.rs
@@ -40,7 +40,7 @@ fn test_rollback_disabled() {
     );
 
     let session = nomt.begin_session();
-    nomt.commit(
+    nomt.update_and_commit(
         session,
         vec![(
             hex!("0000000000000000000000000000000000000000000000000000000000000001"),
@@ -64,7 +64,7 @@ fn test_rollback_to_initial() {
     );
 
     let session = nomt.begin_session();
-    nomt.commit(
+    nomt.update_and_commit(
         session,
         vec![(
             hex!("0000000000000000000000000000000000000000000000000000000000000001"),
@@ -189,7 +189,7 @@ impl TestPlan {
                 operations.push((key.clone(), KeyReadWrite::Write(None)));
             }
             operations.sort_by_key(|(key, _)| key.clone());
-            nomt.commit(session, operations).unwrap();
+            nomt.update_and_commit(session, operations).unwrap();
             let post_root = nomt.root();
             expected_roots.push(post_root);
         }
@@ -214,7 +214,7 @@ impl TestPlan {
                 operations.push((key.clone(), KeyReadWrite::Write(None)));
             }
             operations.sort_by_key(|(key, _)| key.clone());
-            nomt.commit(session, operations).unwrap();
+            nomt.update_and_commit(session, operations).unwrap();
         }
     }
 
@@ -429,7 +429,7 @@ fn test_rollback_change_history() {
     let session = nomt.begin_session();
     let new_key = KeyPath::from([0xAA; 32]);
     let new_value = vec![0xBB; 32];
-    nomt.commit(
+    nomt.update_and_commit(
         session,
         vec![(new_key, KeyReadWrite::Write(Some(new_value.clone())))],
     )
@@ -462,7 +462,7 @@ fn test_rollback_read_then_write() {
     let session = nomt.begin_session();
     let key = KeyPath::from([0xAA; 32]);
     let original_value = vec![0xBB; 32];
-    nomt.commit(
+    nomt.update_and_commit(
         session,
         vec![(key, KeyReadWrite::Write(Some(original_value.clone())))],
     )
@@ -475,7 +475,7 @@ fn test_rollback_read_then_write() {
     let session = nomt.begin_session();
     assert_eq!(session.read(key).unwrap(), Some(original_value.clone()));
     let new_value = vec![0xCC; 32];
-    nomt.commit(
+    nomt.update_and_commit(
         session,
         vec![(
             key,

--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -205,7 +205,7 @@ impl Agent {
                 }
             }
         }
-        self.nomt.commit(session, actuals)?;
+        self.nomt.update_and_commit(session, actuals)?;
         Ok(())
     }
 


### PR DESCRIPTION
These are all unimplemented at the moment, but gives a hint of what the API would look like.

I do think there is a combinatorial explosion (especially if we split out `sync` in the future). This is just an initial approach to get started and then we can do a full API pass later to make it nice.
