### PR TITLE
refactor: merklize into copied pages

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -231,7 +231,7 @@ impl SyncController {
         sync_seqn: u32,
         page_cache: PageCache,
         mut merkle_tx: MerkleTransaction,
-        page_diffs: merkle::PageDiffs,
+        updated_pages: merkle::UpdatedPages,
     ) {
         let page_pool = self.db.shared.page_pool.clone();
         let bitbox = self.db.clone();
@@ -240,7 +240,7 @@ impl SyncController {
         // UNWRAP: safe because begin_sync is called only once.
         let wal_result_tx = self.wal_result_tx.take().unwrap();
         self.db.shared.sync_tp.execute(move || {
-            page_cache.prepare_transaction(page_diffs.into_iter(), &mut merkle_tx);
+            page_cache.absorb_and_populate_transaction(updated_pages, &mut merkle_tx);
 
             let mut wal_blob_builder = wal_blob_builder.lock();
             let ht_pages = bitbox.prepare_sync(

--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -53,9 +53,8 @@ use nomt_core::{
 
 use crate::{
     io::PagePool,
-    page_cache::{Page, PageCache, PageCacheShard, ShardIndex},
+    page_cache::{Page, PageCache, PageCacheShard, PageMut},
     page_diff::PageDiff,
-    rw_pass_cell::{ReadPass, RegionContains, WritePass},
 };
 
 /// The output of the page walker.
@@ -63,18 +62,22 @@ pub enum Output {
     /// A new root node.
     ///
     /// This is always the output when no parent page is supplied to the walker.
-    Root(Node, Vec<(PageId, PageDiff)>),
+    Root(Node, Vec<UpdatedPage>),
     /// Nodes to set in the bottom layer of the parent page, indexed by the position of the node
     /// to set.
     ///
     /// This is always the output when a parent page is supplied to the walker.
-    ChildPageRoots(Vec<(TriePosition, Node)>, Vec<(PageId, PageDiff)>),
+    ChildPageRoots(Vec<(TriePosition, Node)>, Vec<UpdatedPage>),
 }
 
-struct StackItem {
-    page_id: PageId,
-    page: Page,
-    diff: PageDiff,
+/// A page which was updated during the course of modifying the trie.
+pub struct UpdatedPage {
+    /// The ID of the page.
+    pub page_id: PageId,
+    /// An owned copy of the page, including the modified nodes.
+    pub page: PageMut,
+    /// A compact diff indicating all modified slots in the page.
+    pub diff: PageDiff,
 }
 
 /// The source of pages for the page walker.
@@ -93,10 +96,15 @@ impl PageSource {
         }
     }
 
+    #[cfg(test)]
     fn insert_fresh(&self, page_id: PageId) -> Page {
         match self {
-            PageSource::PageCache(ref cache) => cache.insert(page_id, None),
-            PageSource::PageCacheShard(ref shard) => shard.insert(page_id, None),
+            PageSource::PageCache(ref cache) => {
+                cache.insert(page_id, PageMut::pristine_empty(), None)
+            }
+            PageSource::PageCacheShard(ref shard) => {
+                shard.insert(page_id, PageMut::pristine_empty(), None)
+            }
         }
     }
 }
@@ -112,10 +120,10 @@ pub struct PageWalker<H> {
     parent_page: Option<(PageId, Page)>,
     child_page_roots: Vec<(TriePosition, Node)>,
     root: Node,
-    diffs: Vec<(PageId, PageDiff)>,
+    updated_pages: Vec<UpdatedPage>,
 
     // the stack contains pages (ascending) which are descendants of the parent page, if any.
-    stack: Vec<StackItem>,
+    stack: Vec<UpdatedPage>,
 
     // the sibling stack contains the previous node values of siblings on the path to the current
     // position, annotated with their depths.
@@ -145,7 +153,7 @@ impl<H: NodeHasher> PageWalker<H> {
             parent_page,
             child_page_roots: Vec::new(),
             root,
-            diffs: Vec::new(),
+            updated_pages: Vec::new(),
             stack: Vec::new(),
             sibling_stack: Vec::new(),
             prev_node: None,
@@ -168,18 +176,17 @@ impl<H: NodeHasher> PageWalker<H> {
     /// Panics if this is not greater than the previous trie position.
     pub fn advance_and_replace(
         &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
         new_pos: TriePosition,
         ops: impl IntoIterator<Item = (KeyPath, ValueHash)>,
     ) {
         if let Some(ref pos) = self.last_position {
             assert!(new_pos.path() > pos.path());
-            self.compact_up(write_pass, Some(new_pos.clone()));
+            self.compact_up(Some(new_pos.clone()));
         }
         self.last_position = Some(new_pos.clone());
         self.build_stack(new_pos);
 
-        self.replace_terminal(write_pass, ops);
+        self.replace_terminal(ops);
     }
 
     /// Advance to a given trie position and place the given node at that position.
@@ -198,19 +205,14 @@ impl<H: NodeHasher> PageWalker<H> {
     ///
     /// Panics if this falls in a page which is not a descendant of the parent page, if any.
     /// Panics if this is not greater than the previous trie position.
-    pub fn advance_and_place_node(
-        &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-        new_pos: TriePosition,
-        node: Node,
-    ) {
+    pub fn advance_and_place_node(&mut self, new_pos: TriePosition, node: Node) {
         if let Some(ref pos) = self.last_position {
             assert!(new_pos.path() > pos.path());
-            self.compact_up(write_pass, Some(new_pos.clone()));
+            self.compact_up(Some(new_pos.clone()));
         }
         self.last_position = Some(new_pos.clone());
         self.build_stack(new_pos);
-        self.place_node(write_pass, node);
+        self.place_node(node);
     }
 
     /// Advance to a given trie position without updating.
@@ -219,14 +221,10 @@ impl<H: NodeHasher> PageWalker<H> {
     ///
     /// Panics if this falls in a page which is not a descendant of the parent page, if any.
     /// Panics if this is not greater than the previous trie position.
-    pub fn advance(
-        &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-        new_pos: TriePosition,
-    ) {
+    pub fn advance(&mut self, new_pos: TriePosition) {
         if let Some(ref pos) = self.last_position {
             assert!(new_pos.path() > pos.path());
-            self.compact_up(write_pass, Some(new_pos.clone()));
+            self.compact_up(Some(new_pos.clone()));
         }
 
         let page_id = new_pos.page_id();
@@ -234,29 +232,21 @@ impl<H: NodeHasher> PageWalker<H> {
         self.last_position = Some(new_pos);
     }
 
-    fn place_node(
-        &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-        node: Node,
-    ) {
+    fn place_node(&mut self, node: Node) {
         if self.position.is_root() {
             self.prev_node = Some(self.root);
             self.root = node;
         } else {
-            self.prev_node = Some(self.node(write_pass.downgrade()));
-            self.set_node(write_pass, node);
+            self.prev_node = Some(self.node());
+            self.set_node(node);
         }
     }
 
-    fn replace_terminal(
-        &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-        ops: impl IntoIterator<Item = (KeyPath, ValueHash)>,
-    ) {
+    fn replace_terminal(&mut self, ops: impl IntoIterator<Item = (KeyPath, ValueHash)>) {
         let node = if self.position.is_root() {
             self.root
         } else {
-            self.node(write_pass.downgrade())
+            self.node()
         };
 
         self.prev_node = Some(node);
@@ -284,7 +274,7 @@ impl<H: NodeHasher> PageWalker<H> {
                 };
 
                 if zero_sibling {
-                    self.set_sibling(write_pass, trie::TERMINATOR);
+                    self.set_sibling(trie::TERMINATOR);
                 }
             };
 
@@ -315,7 +305,7 @@ impl<H: NodeHasher> PageWalker<H> {
             if self.position.is_root() {
                 self.root = node;
             } else {
-                self.set_node(write_pass, node);
+                self.set_node(node);
             }
         });
 
@@ -335,7 +325,7 @@ impl<H: NodeHasher> PageWalker<H> {
         if self.position.depth_in_page() == 1 {
             // UNWRAP: we never move up beyond the root / parent page.
             let stack_item = self.stack.pop().unwrap();
-            self.diffs.push((stack_item.page_id, stack_item.diff));
+            self.updated_pages.push(stack_item);
         }
         self.position.up(1);
     }
@@ -345,9 +335,11 @@ impl<H: NodeHasher> PageWalker<H> {
         for bit in bit_path.iter().by_vals() {
             if self.position.is_root() {
                 // UNWRAP: all pages on the path to the node should be in the cache.
-                self.stack.push(StackItem {
+                self.stack.push(UpdatedPage {
                     page_id: ROOT_PAGE_ID,
-                    page: get_page(&self.page_source, ROOT_PAGE_ID).unwrap(),
+                    page: get_page(&self.page_source, ROOT_PAGE_ID)
+                        .unwrap()
+                        .deep_copy(),
                     diff: PageDiff::default(),
                 });
             } else if self.position.depth_in_page() == DEPTH {
@@ -359,29 +351,32 @@ impl<H: NodeHasher> PageWalker<H> {
                 // UNWRAP: we never overflow the page stack.
                 let child_page_id = parent_page_id.child_page_id(child_page_index).unwrap();
 
-                let (page, diff) = if fresh {
-                    (
-                        self.page_source.insert_fresh(child_page_id.clone()),
-                        PageDiff::default(),
-                    )
+                let stack_item = if fresh {
+                    UpdatedPage {
+                        page_id: child_page_id,
+                        page: PageMut::pristine_empty(),
+                        diff: PageDiff::default(),
+                    }
+                } else if self
+                    .updated_pages
+                    .last()
+                    .map_or(false, |d| d.page_id == child_page_id)
+                {
+                    // UNWRAP: just checked
+                    self.updated_pages.pop().unwrap()
                 } else {
-                    // UNWRAP: all non-fresh pages should be in the cache.
-                    let diff = if self.diffs.last().map_or(false, |d| d.0 == child_page_id) {
-                        // UNWRAP: just checked
-                        self.diffs.pop().unwrap().1
-                    } else {
-                        PageDiff::default()
-                    };
-                    let page = get_page(&self.page_source, child_page_id.clone()).unwrap();
-
-                    (page, diff)
+                    // UNWRAP: all pages on the path to the node should be in the cache.
+                    let page = get_page(&self.page_source, child_page_id.clone())
+                        .unwrap()
+                        .deep_copy();
+                    UpdatedPage {
+                        page_id: child_page_id,
+                        page,
+                        diff: PageDiff::default(),
+                    }
                 };
 
-                self.stack.push(StackItem {
-                    page_id: child_page_id,
-                    page,
-                    diff,
-                });
+                self.stack.push(stack_item);
             }
             self.position.down(bit);
         }
@@ -394,23 +389,16 @@ impl<H: NodeHasher> PageWalker<H> {
 
     /// Conclude walking and updating and return an output - either a new root, or a list
     /// of node changes to apply to the parent page.
-    pub fn conclude(
-        mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-    ) -> Output {
-        self.compact_up(write_pass, None);
+    pub fn conclude(mut self) -> Output {
+        self.compact_up(None);
         if self.parent_page.is_none() {
-            Output::Root(self.root, self.diffs)
+            Output::Root(self.root, self.updated_pages)
         } else {
-            Output::ChildPageRoots(self.child_page_roots, self.diffs)
+            Output::ChildPageRoots(self.child_page_roots, self.updated_pages)
         }
     }
 
-    fn compact_up(
-        &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-        target_pos: Option<TriePosition>,
-    ) {
+    fn compact_up(&mut self, target_pos: Option<TriePosition>) {
         // This serves as a check to see if we have anything to compact.
         if self.stack.is_empty() {
             return;
@@ -450,7 +438,7 @@ impl<H: NodeHasher> PageWalker<H> {
         };
 
         for i in 0..compact_layers {
-            let next_node = self.compact_step(write_pass);
+            let next_node = self.compact_step();
             self.up();
 
             if self.stack.is_empty() {
@@ -467,23 +455,18 @@ impl<H: NodeHasher> PageWalker<H> {
             } else {
                 // save the final relevant sibling.
                 if i == compact_layers - 1 {
-                    self.sibling_stack.push((
-                        self.node(write_pass.downgrade()),
-                        self.position.depth() as usize,
-                    ));
+                    self.sibling_stack
+                        .push((self.node(), self.position.depth() as usize));
                 }
 
-                self.set_node(write_pass, next_node);
+                self.set_node(next_node);
             }
         }
     }
 
-    fn compact_step(
-        &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-    ) -> Node {
-        let node = self.node(write_pass.downgrade());
-        let sibling = self.sibling_node(write_pass.downgrade());
+    fn compact_step(&mut self) -> Node {
+        let node = self.node();
+        let sibling = self.sibling_node();
         let bit = self.position.peek_last_bit();
 
         match (NodeKind::of(&node), NodeKind::of(&sibling)) {
@@ -493,14 +476,14 @@ impl<H: NodeHasher> PageWalker<H> {
             }
             (NodeKind::Leaf, NodeKind::Terminator) => {
                 // compact: clear this node, move leaf up.
-                self.set_node(write_pass, trie::TERMINATOR);
+                self.set_node(trie::TERMINATOR);
 
                 node
             }
             (NodeKind::Terminator, NodeKind::Leaf) => {
                 // compact: clear sibling node, move leaf up.
                 self.position.sibling();
-                self.set_node(write_pass, trie::TERMINATOR);
+                self.set_node(trie::TERMINATOR);
 
                 sibling
             }
@@ -524,33 +507,27 @@ impl<H: NodeHasher> PageWalker<H> {
     }
 
     // read the node at the current position. panics if no current page.
-    fn node(&self, read_pass: &ReadPass<impl RegionContains<ShardIndex>>) -> Node {
+    fn node(&self) -> Node {
         let node_index = self.position.node_index();
         let stack_top = self.stack.last().unwrap();
-        stack_top.page.node(read_pass, node_index)
+        stack_top.page.node(node_index)
     }
 
     // read the sibling node at the current position. panics if no current page.
-    fn sibling_node(&self, read_pass: &ReadPass<impl RegionContains<ShardIndex>>) -> Node {
+    fn sibling_node(&self) -> Node {
         let node_index = self.position.sibling_index();
         let stack_top = self.stack.last().unwrap();
-        stack_top.page.node(read_pass, node_index)
+        stack_top.page.node(node_index)
     }
 
     // set a node in the current page at the given index. panics if no current page.
-    fn set_node(
-        &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-        node: Node,
-    ) {
+    fn set_node(&mut self, node: Node) {
         let node_index = self.position.node_index();
-        let sibling_node = self.sibling_node(write_pass.downgrade());
+        let sibling_node = self.sibling_node();
 
         // UNWRAP: if a node is being set, then a page in the stack must be present
         let stack_top = self.stack.last_mut().unwrap();
-        stack_top
-            .page
-            .set_node(&self.page_pool, write_pass, node_index, node);
+        stack_top.page.set_node(&self.page_pool, node_index, node);
 
         if self.position.is_first_layer_in_page()
             && node == TERMINATOR
@@ -563,16 +540,11 @@ impl<H: NodeHasher> PageWalker<H> {
     }
 
     // set the sibling node in the current page at the given index. panics if no current page.
-    fn set_sibling(
-        &mut self,
-        write_pass: &mut WritePass<impl RegionContains<ShardIndex>>,
-        node: Node,
-    ) {
+    fn set_sibling(&mut self, node: Node) {
         let node_index = self.position.sibling_index();
         let stack_top = self.stack.last_mut().unwrap();
-        stack_top
-            .page
-            .set_node(&self.page_pool, write_pass, node_index, node);
+        stack_top.page.set_node(&self.page_pool, node_index, node);
+
         stack_top.diff.set_changed(node_index);
     }
 
@@ -599,7 +571,7 @@ impl<H: NodeHasher> PageWalker<H> {
         self.position = position;
         let Some(page_id) = new_page_id else {
             for stack_item in self.stack.drain(..) {
-                self.diffs.push((stack_item.page_id, stack_item.diff));
+                self.updated_pages.push(stack_item);
             }
             return;
         };
@@ -620,8 +592,10 @@ impl<H: NodeHasher> PageWalker<H> {
         let mut push_count = 0;
         while Some(&cur_ancestor) != target.as_ref() {
             // UNWRAP: all pages on the path to the terminal are cached.
-            let page = get_page(&self.page_source, cur_ancestor.clone()).unwrap();
-            self.stack.push(StackItem {
+            let page = get_page(&self.page_source, cur_ancestor.clone())
+                .unwrap()
+                .deep_copy();
+            self.stack.push(UpdatedPage {
                 page_id: cur_ancestor.clone(),
                 page,
                 diff: PageDiff::default(),
@@ -659,9 +633,9 @@ fn get_page(page_source: &PageSource, page_id: PageId) -> Option<Page> {
 mod tests {
     use super::{
         trie, Node, NodeHasherExt, Output, PageCache, PagePool, PageSource, PageWalker,
-        TriePosition, ROOT_PAGE_ID,
+        TriePosition, UpdatedPage, ROOT_PAGE_ID,
     };
-    use crate::{page_diff::PageDiff, Blake3Hasher};
+    use crate::{page_cache::PageMut, page_diff::PageDiff, Blake3Hasher};
     use bitvec::prelude::*;
     use imbl::HashMap;
     use nomt_core::page_id::{ChildPageIndex, PageId, PageIdsIterator};
@@ -685,6 +659,12 @@ mod tests {
         [i; 32]
     }
 
+    fn apply(page_cache: &PageCache, updates: Vec<UpdatedPage>) {
+        for page in updates {
+            page_cache.insert_overwriting(page.page_id, page.page, None);
+        }
+    }
+
     #[test]
     #[should_panic]
     fn advance_backwards_panics() {
@@ -695,11 +675,10 @@ mod tests {
 
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
-        let mut write_pass = page_cache.new_write_pass();
         let trie_pos_a = trie_pos![1];
         let trie_pos_b = trie_pos![0];
-        walker.advance(&mut write_pass, trie_pos_a);
-        walker.advance(&mut write_pass, trie_pos_b);
+        walker.advance(trie_pos_a);
+        walker.advance(trie_pos_b);
     }
 
     #[test]
@@ -712,10 +691,9 @@ mod tests {
 
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
-        let mut write_pass = page_cache.new_write_pass();
         let trie_pos_a = trie_pos![0];
-        walker.advance(&mut write_pass, trie_pos_a.clone());
-        walker.advance(&mut write_pass, trie_pos_a);
+        walker.advance(trie_pos_a.clone());
+        walker.advance(trie_pos_a);
     }
 
     #[test]
@@ -732,9 +710,8 @@ mod tests {
             page_pool.clone(),
             Some(ROOT_PAGE_ID),
         );
-        let mut write_pass = page_cache.new_write_pass();
         let trie_pos_a = trie_pos![0, 0, 0, 0, 0, 0];
-        walker.advance(&mut write_pass, trie_pos_a);
+        walker.advance(trie_pos_a);
     }
 
     #[test]
@@ -751,8 +728,7 @@ mod tests {
             page_pool.clone(),
             Some(ROOT_PAGE_ID),
         );
-        let mut write_pass = page_cache.new_write_pass();
-        walker.advance(&mut write_pass, TriePosition::new());
+        walker.advance(TriePosition::new());
     }
 
     #[test]
@@ -764,10 +740,8 @@ mod tests {
 
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
-        let mut write_pass = page_cache.new_write_pass();
         let trie_pos_a = trie_pos![0, 0];
         walker.advance_and_replace(
-            &mut write_pass,
             trie_pos_a,
             vec![
                 (key_path![0, 0, 1, 0], val(1)),
@@ -776,16 +750,15 @@ mod tests {
         );
 
         let trie_pos_b = trie_pos![0, 1];
-        walker.advance(&mut write_pass, trie_pos_b);
+        walker.advance(trie_pos_b);
 
         let trie_pos_c = trie_pos![1];
         walker.advance_and_replace(
-            &mut write_pass,
             trie_pos_c,
             vec![(key_path![1, 0], val(3)), (key_path![1, 1], val(4))],
         );
 
-        match walker.conclude(&mut write_pass) {
+        match walker.conclude() {
             Output::Root(new_root, diffs) => {
                 assert_eq!(
                     new_root,
@@ -801,7 +774,7 @@ mod tests {
                     )
                 );
                 assert_eq!(diffs.len(), 1);
-                assert_eq!(&diffs[0].0, &ROOT_PAGE_ID);
+                assert_eq!(&diffs[0].page_id, &ROOT_PAGE_ID);
             }
             _ => unreachable!(),
         }
@@ -816,10 +789,8 @@ mod tests {
 
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
-        let mut write_pass = page_cache.new_write_pass();
 
         walker.advance_and_replace(
-            &mut write_pass,
             TriePosition::new(),
             vec![
                 (key_path![0, 1, 0, 1, 1, 0], val(1)),
@@ -827,17 +798,27 @@ mod tests {
             ],
         );
 
+        match walker.conclude() {
+            Output::Root(_, updates) => {
+                apply(&page_cache, updates);
+            }
+            _ => unreachable!(),
+        }
+
+        let page_source = PageSource::PageCache(page_cache.clone());
+        let mut walker =
+            PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
+
         walker.advance_and_replace(
-            &mut write_pass,
             trie_pos![0, 1, 0, 1, 1, 0, 0, 1],
             vec![
-                (key_path![0, 1, 0, 1, 1, 0, 0, 1, 0], val(3)),
-                (key_path![0, 1, 0, 1, 1, 0, 0, 1, 1], val(4)),
+                (key_path![0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0], val(3)),
+                (key_path![0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1], val(4)),
             ],
         );
 
-        match walker.conclude(&mut write_pass) {
-            Output::Root(new_root, diffs) => {
+        match walker.conclude() {
+            Output::Root(new_root, updates) => {
                 assert_eq!(
                     new_root,
                     nomt_core::update::build_trie::<Blake3Hasher>(
@@ -845,13 +826,13 @@ mod tests {
                         vec![
                             (key_path![0, 1, 0, 1, 1, 0], val(1)),
                             (key_path![0, 1, 0, 1, 1, 1], val(2)),
-                            (key_path![0, 1, 0, 1, 1, 0, 0, 1, 0], val(3)),
-                            (key_path![0, 1, 0, 1, 1, 0, 0, 1, 1], val(4))
+                            (key_path![0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0], val(3)),
+                            (key_path![0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1], val(4))
                         ],
                         |_| {}
                     )
                 );
-                assert_eq!(diffs.len(), 3);
+                assert_eq!(updates.len(), 3);
             }
             _ => unreachable!(),
         }
@@ -863,8 +844,6 @@ mod tests {
         let page_cache = PageCache::new(None, &crate::Options::new(), None);
         let page_source = PageSource::PageCache(page_cache.clone());
         let page_pool = PagePool::new();
-
-        let mut write_pass = page_cache.new_write_pass();
 
         let leaf_a_key_path = key_path![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         let leaf_b_pos = trie_pos![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
@@ -881,7 +860,6 @@ mod tests {
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
         walker.advance_and_replace(
-            &mut write_pass,
             TriePosition::new(),
             vec![
                 (leaf_a_key_path, val(1)),
@@ -893,8 +871,11 @@ mod tests {
             ],
         );
 
-        let new_root = match walker.conclude(&mut write_pass) {
-            Output::Root(new_root, _diffs) => new_root,
+        let new_root = match walker.conclude() {
+            Output::Root(new_root, diffs) => {
+                apply(&page_cache, diffs);
+                new_root
+            }
             _ => unreachable!(),
         };
 
@@ -902,13 +883,13 @@ mod tests {
         let mut walker =
             PageWalker::<Blake3Hasher>::new(new_root, page_source, page_pool.clone(), None);
 
-        walker.advance_and_replace(&mut write_pass, leaf_b_pos, vec![]);
-        walker.advance_and_replace(&mut write_pass, leaf_c_pos, vec![]);
-        walker.advance_and_replace(&mut write_pass, leaf_d_pos, vec![]);
-        walker.advance_and_replace(&mut write_pass, leaf_e_pos, vec![]);
-        walker.advance_and_replace(&mut write_pass, leaf_f_pos, vec![]);
+        walker.advance_and_replace(leaf_b_pos, vec![]);
+        walker.advance_and_replace(leaf_c_pos, vec![]);
+        walker.advance_and_replace(leaf_d_pos, vec![]);
+        walker.advance_and_replace(leaf_e_pos, vec![]);
+        walker.advance_and_replace(leaf_f_pos, vec![]);
 
-        match walker.conclude(&mut write_pass) {
+        match walker.conclude() {
             Output::Root(new_root, diffs) => {
                 assert_eq!(
                     new_root,
@@ -937,35 +918,30 @@ mod tests {
             page_pool.clone(),
             Some(ROOT_PAGE_ID),
         );
-        let mut write_pass = page_cache.new_write_pass();
         let trie_pos_a = trie_pos![0, 0, 0, 0, 0, 0, 0];
 
         walker.advance_and_replace(
-            &mut write_pass,
             trie_pos_a.clone(),
             vec![(key_path![0, 0, 0, 0, 0, 0, 0], val(1))],
         );
         let trie_pos_b = trie_pos![0, 0, 0, 0, 0, 0, 1];
         walker.advance_and_replace(
-            &mut write_pass,
             trie_pos_b.clone(),
             vec![(key_path![0, 0, 0, 0, 0, 0, 1], val(2))],
         );
 
         let trie_pos_c = trie_pos![0, 0, 0, 0, 0, 1, 0];
         walker.advance_and_replace(
-            &mut write_pass,
             trie_pos_c.clone(),
             vec![(key_path![0, 0, 0, 0, 0, 1, 0], val(3))],
         );
         let trie_pos_d = trie_pos![0, 0, 0, 0, 0, 1, 1];
         walker.advance_and_replace(
-            &mut write_pass,
             trie_pos_d.clone(),
             vec![(key_path![0, 0, 0, 0, 0, 1, 1], val(4))],
         );
 
-        match walker.conclude(&mut write_pass) {
+        match walker.conclude() {
             Output::ChildPageRoots(page_roots, diffs) => {
                 assert_eq!(page_roots.len(), 2);
                 assert_eq!(diffs.len(), 2);
@@ -976,7 +952,7 @@ mod tests {
                     .child_page_id(ChildPageIndex::new(1).unwrap())
                     .unwrap();
 
-                let diffed_ids = diffs.iter().map(|(id, _)| id.clone()).collect::<Vec<_>>();
+                let diffed_ids = diffs.iter().map(|p| p.page_id.clone()).collect::<Vec<_>>();
                 assert!(diffed_ids.contains(&left_page_id));
                 assert!(diffed_ids.contains(&right_page_id));
                 assert_eq!(page_roots[0].0, trie_pos![0, 0, 0, 0, 0, 0]);
@@ -1016,7 +992,6 @@ mod tests {
         let page_cache = PageCache::new(None, &crate::Options::new(), None);
         let page_source = PageSource::PageCache(page_cache.clone());
         let page_pool = PagePool::new();
-        let mut write_pass = page_cache.new_write_pass();
 
         let path_1 = key_path![0, 0, 0, 0];
         let path_2 = key_path![1, 0, 0, 0];
@@ -1030,7 +1005,6 @@ mod tests {
             let mut walker =
                 PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
             walker.advance_and_replace(
-                &mut write_pass,
                 TriePosition::new(),
                 vec![
                     (path_1, val(1)),
@@ -1041,8 +1015,11 @@ mod tests {
                 ],
             );
 
-            match walker.conclude(&mut write_pass) {
-                Output::Root(new_root, _) => new_root,
+            match walker.conclude() {
+                Output::Root(new_root, diffs) => {
+                    apply(&page_cache, diffs);
+                    new_root
+                }
                 _ => unreachable!(),
             }
         };
@@ -1069,35 +1046,30 @@ mod tests {
         // the sibling stack will be populated as we go.
 
         walker.advance_and_replace(
-            &mut write_pass,
             TriePosition::from_path_and_depth(path_1, 4),
             vec![(path_1, val(11))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..0]);
 
         walker.advance_and_replace(
-            &mut write_pass,
             TriePosition::from_path_and_depth(path_2, 4),
             vec![(path_2, val(12))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..1]);
 
         walker.advance_and_replace(
-            &mut write_pass,
             TriePosition::from_path_and_depth(path_3, 4),
             vec![(path_3, val(13))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..2]);
 
         walker.advance_and_replace(
-            &mut write_pass,
             TriePosition::from_path_and_depth(path_4, 4),
             vec![(path_4, val(14))],
         );
         assert_eq!(walker.siblings(), &expected_siblings[..3]);
 
         walker.advance_and_replace(
-            &mut write_pass,
             TriePosition::from_path_and_depth(path_5, 4),
             vec![(path_5, val(15))],
         );
@@ -1111,8 +1083,6 @@ mod tests {
         let page_source = PageSource::PageCache(page_cache.clone());
         let page_pool = PagePool::new();
 
-        let mut write_pass = page_cache.new_write_pass();
-
         // this is going to create new leaves, with internal nodes going up to the root.
         let leaf_1 = key_path![0, 0, 0, 0, 0, 0, 0, 0];
         let leaf_2 = key_path![0, 0, 0, 0, 0, 0, 0, 1];
@@ -1125,101 +1095,53 @@ mod tests {
         let terminator_6 = TriePosition::from_path_and_depth(key_path![0, 0, 0, 0, 0, 1], 6);
         let terminator_7 = TriePosition::from_path_and_depth(key_path![0, 0, 0, 0, 0, 0, 1], 7);
 
-        let root_page = page_cache.insert(ROOT_PAGE_ID, None);
-        let page1 = page_cache.insert(terminator_7.page_id().unwrap(), None);
+        let mut root_page = PageMut::pristine_empty();
+        let mut page1 = PageMut::pristine_empty();
 
         // we place garbage in all the sibling positions for those internal  nodes.
         {
             let garbage: Node = val(69);
 
-            root_page.set_node(
-                &page_pool,
-                &mut write_pass,
-                terminator_1.node_index(),
-                garbage,
-            );
-            root_page.set_node(
-                &page_pool,
-                &mut write_pass,
-                terminator_2.node_index(),
-                garbage,
-            );
-            root_page.set_node(
-                &page_pool,
-                &mut write_pass,
-                terminator_3.node_index(),
-                garbage,
-            );
-            root_page.set_node(
-                &page_pool,
-                &mut write_pass,
-                terminator_4.node_index(),
-                garbage,
-            );
-            root_page.set_node(
-                &page_pool,
-                &mut write_pass,
-                terminator_5.node_index(),
-                garbage,
-            );
-            root_page.set_node(
-                &page_pool,
-                &mut write_pass,
-                terminator_6.node_index(),
-                garbage,
-            );
-            page1.set_node(
-                &page_pool,
-                &mut write_pass,
-                terminator_7.node_index(),
-                garbage,
-            );
+            root_page.set_node(&page_pool, terminator_1.node_index(), garbage);
+            root_page.set_node(&page_pool, terminator_2.node_index(), garbage);
+            root_page.set_node(&page_pool, terminator_3.node_index(), garbage);
+            root_page.set_node(&page_pool, terminator_4.node_index(), garbage);
+            root_page.set_node(&page_pool, terminator_5.node_index(), garbage);
+            root_page.set_node(&page_pool, terminator_6.node_index(), garbage);
+            page1.set_node(&page_pool, terminator_7.node_index(), garbage);
         }
+
+        page_cache.insert(ROOT_PAGE_ID, root_page, None);
+        page_cache.insert(terminator_7.page_id().unwrap(), page1, None);
 
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
 
         walker.advance_and_replace(
-            &mut write_pass,
             TriePosition::new(),
             vec![(leaf_1, val(1)), (leaf_2, val(2))],
         );
 
-        let Output::Root(_, _) = walker.conclude(&mut write_pass) else {
-            panic!()
-        };
+        match walker.conclude() {
+            Output::Root(_, diffs) => {
+                apply(&page_cache, diffs);
+            }
+            _ => panic!(),
+        }
+
+        let root_page = page_cache.get(ROOT_PAGE_ID).unwrap();
+        let page1 = page_cache.get(terminator_7.page_id().unwrap()).unwrap();
 
         // building the internal nodes must zero the garbage slots, now, anything reachable from the
         // root is consistent.
         {
-            assert_eq!(
-                root_page.node(write_pass.downgrade(), terminator_1.node_index()),
-                trie::TERMINATOR
-            );
-            assert_eq!(
-                root_page.node(write_pass.downgrade(), terminator_2.node_index()),
-                trie::TERMINATOR
-            );
-            assert_eq!(
-                root_page.node(write_pass.downgrade(), terminator_3.node_index()),
-                trie::TERMINATOR
-            );
-            assert_eq!(
-                root_page.node(write_pass.downgrade(), terminator_4.node_index()),
-                trie::TERMINATOR
-            );
-            assert_eq!(
-                root_page.node(write_pass.downgrade(), terminator_5.node_index()),
-                trie::TERMINATOR
-            );
-            assert_eq!(
-                root_page.node(write_pass.downgrade(), terminator_6.node_index()),
-                trie::TERMINATOR
-            );
-            assert_eq!(
-                page1.node(write_pass.downgrade(), terminator_7.node_index()),
-                trie::TERMINATOR
-            );
+            assert_eq!(root_page.node(terminator_1.node_index()), trie::TERMINATOR);
+            assert_eq!(root_page.node(terminator_2.node_index()), trie::TERMINATOR);
+            assert_eq!(root_page.node(terminator_3.node_index()), trie::TERMINATOR);
+            assert_eq!(root_page.node(terminator_4.node_index()), trie::TERMINATOR);
+            assert_eq!(root_page.node(terminator_5.node_index()), trie::TERMINATOR);
+            assert_eq!(root_page.node(terminator_6.node_index()), trie::TERMINATOR);
+            assert_eq!(page1.node(terminator_7.node_index()), trie::TERMINATOR);
         }
     }
 
@@ -1229,7 +1151,6 @@ mod tests {
         let page_cache = PageCache::new(None, &crate::Options::new(), None);
         let page_source = PageSource::PageCache(page_cache.clone());
         let page_pool = PagePool::new();
-        let mut write_pass = page_cache.new_write_pass();
 
         let leaf_a_key_path = key_path![0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0];
         let leaf_b_key_path = key_path![0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1];
@@ -1247,7 +1168,6 @@ mod tests {
             let mut walker =
                 PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
             walker.advance_and_replace(
-                &mut write_pass,
                 TriePosition::new(),
                 vec![
                     (leaf_a_key_path, val(1)),
@@ -1256,8 +1176,11 @@ mod tests {
                 ],
             );
 
-            match walker.conclude(&mut write_pass) {
-                Output::Root(new_root, _diffs) => new_root,
+            match walker.conclude() {
+                Output::Root(new_root, diffs) => {
+                    apply(&page_cache, diffs);
+                    new_root
+                }
                 _ => unreachable!(),
             }
         };
@@ -1267,12 +1190,16 @@ mod tests {
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
 
         // Remove leaf B. This should clear page 2.
-        walker.advance_and_replace(&mut write_pass, leaf_b_pos, vec![]);
+        walker.advance_and_replace(leaf_b_pos, vec![]);
 
-        let root = match walker.conclude(&mut write_pass) {
-            Output::Root(new_root, diffs) => {
-                let diffs: HashMap<PageId, PageDiff> = diffs.into_iter().collect();
+        let root = match walker.conclude() {
+            Output::Root(new_root, updates) => {
+                let diffs: HashMap<PageId, PageDiff> = updates
+                    .iter()
+                    .map(|p| (p.page_id.clone(), p.diff.clone()))
+                    .collect();
                 assert!(diffs.get(&page_id_2).unwrap().cleared());
+                apply(&page_cache, updates);
                 new_root
             }
             _ => unreachable!(),
@@ -1283,11 +1210,14 @@ mod tests {
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
 
         // Now removing leaf C will clear page 1 and the root page.
-        walker.advance_and_replace(&mut write_pass, leaf_c_pos, vec![]);
+        walker.advance_and_replace(leaf_c_pos, vec![]);
 
-        match walker.conclude(&mut write_pass) {
-            Output::Root(_new_root, diffs) => {
-                let diffs: HashMap<PageId, PageDiff> = diffs.into_iter().collect();
+        match walker.conclude() {
+            Output::Root(_new_root, updates) => {
+                let diffs: HashMap<PageId, PageDiff> = updates
+                    .iter()
+                    .map(|p| (p.page_id.clone(), p.diff.clone()))
+                    .collect();
                 assert!(diffs.get(&root_page).unwrap().cleared());
                 assert!(diffs.get(&page_id_1).unwrap().cleared());
             }
@@ -1301,7 +1231,6 @@ mod tests {
         let page_cache = PageCache::new(None, &crate::Options::new(), None);
         let page_source = PageSource::PageCache(page_cache.clone());
         let page_pool = PagePool::new();
-        let mut write_pass = page_cache.new_write_pass();
 
         // Leaves a and b are siblings at positions 2 and 3 on page `page_id_1`.
         // Upon deletion, the page walker will compact up, clearing the page diff
@@ -1325,16 +1254,18 @@ mod tests {
             let mut walker =
                 PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
             walker.advance_and_replace(
-                &mut write_pass,
                 TriePosition::new(),
                 vec![(leaf_a_key_path, val(1)), (leaf_b_key_path, val(2))],
             );
 
-            let Output::Root(new_root, diffs) = walker.conclude(&mut write_pass) else {
+            let Output::Root(new_root, updates) = walker.conclude() else {
                 panic!();
             };
 
-            let diffs: HashMap<PageId, PageDiff> = diffs.into_iter().collect();
+            let diffs: HashMap<PageId, PageDiff> = updates
+                .iter()
+                .map(|p| (p.page_id.clone(), p.diff.clone()))
+                .collect();
             let diff = diffs.get(&page_id_1).unwrap().clone();
             let mut expected_diff = PageDiff::default();
             expected_diff.set_changed(0);
@@ -1342,6 +1273,8 @@ mod tests {
             expected_diff.set_changed(2);
             expected_diff.set_changed(3);
             assert_eq!(diff, expected_diff);
+
+            apply(&page_cache, updates);
             new_root
         };
 
@@ -1349,21 +1282,23 @@ mod tests {
         let mut walker =
             PageWalker::<Blake3Hasher>::new(root, page_source, page_pool.clone(), None);
 
-        walker.advance_and_replace(&mut write_pass, a_pos, vec![]);
-        walker.advance_and_replace(&mut write_pass, b_pos, vec![]);
+        walker.advance_and_replace(a_pos, vec![]);
+        walker.advance_and_replace(b_pos, vec![]);
         // During this step, the clear bit is set during the first compaction
         // and later it is expected to be removed.
         walker.advance_and_replace(
-            &mut write_pass,
             cd_pos,
             vec![(leaf_c_key_path, val(3)), (leaf_d_key_path, val(4))],
         );
 
-        let Output::Root(_new_root, diffs) = walker.conclude(&mut write_pass) else {
+        let Output::Root(_new_root, updates) = walker.conclude() else {
             panic!();
         };
         // No page is expected to be cleared.
-        let diffs: HashMap<PageId, PageDiff> = diffs.into_iter().collect();
+        let diffs: HashMap<PageId, PageDiff> = updates
+            .iter()
+            .map(|p| (p.page_id.clone(), p.diff.clone()))
+            .collect();
         assert!(!diffs.get(&page_id_1).unwrap().cleared());
         assert!(!diffs.get(&page_id_2).unwrap().cleared());
     }

--- a/nomt/src/rw_pass_cell/mod.rs
+++ b/nomt/src/rw_pass_cell/mod.rs
@@ -23,6 +23,8 @@
 //! assert_eq!(cell.read(&read_pass).get(), 42);
 //! ```
 
+#![allow(dead_code)]
+
 #[cfg(loom)]
 mod loom_tests;
 

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -257,7 +257,7 @@ impl Store {
         &self,
         value_tx: ValueTransaction,
         page_cache: PageCache,
-        page_diffs: merkle::PageDiffs,
+        updated_pages: merkle::UpdatedPages,
     ) -> anyhow::Result<()> {
         let mut sync = self.sync.lock();
 
@@ -268,7 +268,7 @@ impl Store {
             self.shared.values.clone(),
             self.shared.rollback.clone(),
             page_cache,
-            page_diffs,
+            updated_pages,
         )
         .unwrap();
         Ok(())

--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -34,7 +34,7 @@ impl Sync {
         beatree: beatree::Tree,
         rollback: Option<rollback::Rollback>,
         page_cache: PageCache,
-        page_diffs: merkle::PageDiffs,
+        updated_pages: merkle::UpdatedPages,
     ) -> anyhow::Result<()> {
         self.sync_seqn += 1;
         let sync_seqn = self.sync_seqn;
@@ -48,7 +48,7 @@ impl Sync {
             bucket_allocator: bitbox.bucket_allocator(),
             new_pages: Vec::new(),
         };
-        bitbox_sync.begin_sync(sync_seqn, page_cache, merkle_tx, page_diffs);
+        bitbox_sync.begin_sync(sync_seqn, page_cache, merkle_tx, updated_pages);
         beatree_sync.begin_sync(value_tx.batch);
         if let Some(ref mut rollback) = rollback_sync {
             rollback.begin_sync();


### PR DESCRIPTION
There are two reasons to do this:
  1. Perf. We copy the pages anyway during sync and it's currently a single-threaded bottleneck. Doing it during `commit` where we have more threads would be best.
  2. Overlays. Overlays can't mutate pages in place, so they need to be copied.

I suspect that this will actually be _faster_ than `master` for commit-concurrency > 1. However, I will also benchmark for commit-concurrency = 1 (note: I remove the copies during writeout only further upstack, so the benchmarks will be there)

This seems to obviate the read/write pass stuff, so if perf holds up we should likely just remove those in follow-up PRs.