### PR TITLE
refactor: have page cache handle writing page ID rather than bitbox

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -140,9 +140,7 @@ impl DB {
         for (page_id, BucketIndex(bucket), page_info) in changes {
             // let's extract its bucket
             match page_info {
-                Some((mut page, page_diff)) => {
-                    page[PAGE_SIZE - 32..].copy_from_slice(&page_id.encode());
-
+                Some((page, page_diff)) => {
                     // update meta map with new info
                     let hash = hash_page_id(&page_id, &self.shared.seed);
                     let meta_map_changed = meta_map.hint_not_match(bucket as usize, hash);


### PR DESCRIPTION
This is a general refactor (good separation of concerns) but also prepares bitbox to receive unowned pages and remove the need to copy before writing.

I also killed the `PageData` struct in `page_cache` , instead opting for `PageMut` and `Page` to wrap `Option<FatPage>` and `Option<Arc<FatPage>>` directly. Because pages are now copy-on-write and need to be explicitly reinsterted into the cache, we don't need to worry about `None` becoming `Some` in one view but not being reflected in the version within the cache.
