### PR TITLE
refactor: add WriteArc io command

### DIFF
--- a/nomt/src/io/linux.rs
+++ b/nomt/src/io/linux.rs
@@ -143,6 +143,12 @@ fn submission_entry(command: &mut IoCommand) -> squeue::Entry {
                 .offset(page_index * PAGE_SIZE as u64)
                 .build()
         }
+        IoKind::WriteArc(fd, page_index, ref page) => {
+            let page: &[u8] = &*page;
+            opcode::Write::new(types::Fd(fd), page.as_ptr(), PAGE_SIZE as u32)
+                .offset(page_index * PAGE_SIZE as u64)
+                .build()
+        }
         IoKind::WriteRaw(fd, page_index, ref page) => {
             opcode::Write::new(types::Fd(fd), page.as_ptr(), PAGE_SIZE as u32)
                 .offset(page_index * PAGE_SIZE as u64)

--- a/nomt/src/io/unix.rs
+++ b/nomt/src/io/unix.rs
@@ -45,6 +45,15 @@ fn execute(mut command: IoCommand) -> CompleteIo {
                     (page_index * PAGE_SIZE as u64) as libc::off_t,
                 )
             },
+            IoKind::WriteArc(fd, page_index, ref page) => unsafe {
+                let page: &[u8] = &*page;
+                libc::pwrite(
+                    fd,
+                    page.as_ptr() as *const libc::c_void,
+                    PAGE_SIZE as libc::size_t,
+                    (page_index * PAGE_SIZE as u64) as libc::off_t,
+                )
+            },
             IoKind::WriteRaw(fd, page_index, ref mut page) => unsafe {
                 libc::pwrite(
                     fd,


### PR DESCRIPTION
This adds a `WriteArc` I/O command which writes out of an `Arc<FatPage>`. In the follow-up PR this is used to avoid copying in bitbox writeout.
