### PR TITLE
opt: do not copy pages before bitbox writeout

### DIFF
--- a/nomt/src/bitbox/writeout.rs
+++ b/nomt/src/bitbox/writeout.rs
@@ -9,6 +9,7 @@ use std::{
     fs::File,
     io::{Seek as _, SeekFrom, Write},
     os::fd::AsRawFd as _,
+    sync::Arc,
 };
 
 use crate::io::{FatPage, IoCommand, IoHandle, IoKind};
@@ -30,7 +31,7 @@ pub(super) fn truncate_wal(mut wal_fd: &File) -> anyhow::Result<()> {
 pub(super) fn write_ht(
     io_handle: IoHandle,
     ht_fd: &File,
-    mut ht: Vec<(u64, FatPage)>,
+    mut ht: Vec<(u64, Arc<FatPage>)>,
 ) -> anyhow::Result<()> {
     let mut sent = 0;
 
@@ -38,7 +39,7 @@ pub(super) fn write_ht(
     for (pn, page) in ht {
         io_handle
             .send(IoCommand {
-                kind: IoKind::Write(ht_fd.as_raw_fd(), pn, page),
+                kind: IoKind::WriteArc(ht_fd.as_raw_fd(), pn, page),
                 user_data: 0,
             })
             .unwrap();

--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -23,7 +23,6 @@ pub use page_pool::{FatPage, PagePool};
 pub enum IoKind {
     Read(RawFd, u64, FatPage),
     Write(RawFd, u64, FatPage),
-    #[allow(dead_code)]
     WriteArc(RawFd, u64, Arc<FatPage>),
     WriteRaw(RawFd, u64, Page),
 }

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -398,7 +398,7 @@ impl PageCache {
     ) {
         let mut apply_page = |page_id,
                               bucket: &mut Option<BucketIndex>,
-                              page_data: Option<&FatPage>,
+                              page_data: Option<&Arc<FatPage>>,
                               page_diff: PageDiff| {
             match (page_data, *bucket) {
                 (None, Some(known_bucket)) => {
@@ -410,7 +410,7 @@ impl PageCache {
                     *bucket = None;
                 }
                 (Some(page), maybe_bucket) if !page_diff.cleared() => {
-                    let new_bucket = tx.write_page(page_id, maybe_bucket, page, page_diff);
+                    let new_bucket = tx.write_page(page_id, maybe_bucket, page.clone(), page_diff);
                     *bucket = Some(new_bucket);
                 }
                 _ => {} // empty pages which had no known bucket. don't write or delete.
@@ -441,7 +441,7 @@ impl PageCache {
                 apply_page(
                     updated_page.page_id,
                     bucket,
-                    page_data.as_ref().map(|x| &**x),
+                    page_data.as_ref(),
                     updated_page.diff,
                 );
                 continue;
@@ -462,7 +462,7 @@ impl PageCache {
             apply_page(
                 updated_page.page_id,
                 bucket,
-                cache_entry.page_data.as_ref().map(|x| &**x),
+                cache_entry.page_data.as_ref(),
                 updated_page.diff,
             );
         }

--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -44,7 +44,6 @@ impl Sync {
         let mut rollback_sync = rollback.map(|rollback| rollback.sync());
 
         let merkle_tx = MerkleTransaction {
-            page_pool: shared.page_pool.clone(),
             bucket_allocator: bitbox.bucket_allocator(),
             new_pages: Vec::new(),
         };


### PR DESCRIPTION
This uses the new `WriteArc` I/O command to avoid a page copy when writing to bitbox. This is currently a major bottleneck during `sync`, since these page copies are single-threaded and we now copy pages during merkle commit (needed for overlays). 
