### PR TITLE
expose sync_seqn

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -258,6 +258,12 @@ impl<T: HashAlgorithm> Nomt<T> {
         self.store.load_value(path)
     }
 
+    /// Returns the current sync sequence number.
+    #[doc(hidden)]
+    pub fn sync_seqn(&self) -> u32 {
+        self.store.sync_seqn()
+    }
+
     /// Creates a new [`Session`] object, that serves a purpose of capturing the reads and writes
     /// performed by the application, updating the trie and creating a [`Witness`], allowing to
     /// re-execute the same operations without having access to the full trie.

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -188,6 +188,10 @@ impl Store {
         })
     }
 
+    pub fn sync_seqn(&self) -> u32 {
+        self.sync.lock().sync_seqn
+    }
+
     /// Returns a handle to the rollback object. `None` if the rollback feature is not enabled.
     pub fn rollback(&self) -> Option<&Rollback> {
         self.shared.rollback.as_ref()


### PR DESCRIPTION
Makes the sync_seqn number accessible. Helps to detect whether a commit succeeded or not.

Closes THR-86
