### PR TITLE
feat: tighten read of branch node

### DIFF
--- a/nomt/src/beatree/branch/node.rs
+++ b/nomt/src/beatree/branch/node.rs
@@ -122,6 +122,11 @@ impl BranchNode {
     }
 
     fn cells_mut(&mut self) -> &mut [[u8; 2]] {
+        let cells_end = BRANCH_NODE_HEADER_SIZE + self.n() as usize * 2;
+        assert!(cells_end < BRANCH_NODE_BODY_SIZE);
+
+        // SAFETY: This creates a slice of length 2 * N starting at index BRANCH_NODE_HEADER_SIZE.
+        // This is ensured to be within the bounds of the page by the assertion above.
         unsafe {
             std::slice::from_raw_parts_mut(
                 self.page[BRANCH_NODE_HEADER_SIZE..BRANCH_NODE_HEADER_SIZE + 2].as_ptr()
@@ -176,7 +181,12 @@ impl BranchNode {
     }
 
     pub fn node_pointers_mut(&mut self) -> &mut [[u8; 4]] {
-        let node_pointers_init = BRANCH_NODE_SIZE - self.n() as usize * 4;
+        let node_pointers_byte_len = self.n() as usize * 4;
+        assert!(node_pointers_byte_len < BRANCH_NODE_SIZE);
+
+        let node_pointers_init = BRANCH_NODE_SIZE - node_pointers_byte_len;
+        // SAFETY: This creates a slice of length 4 * N aligned with the end of the node.
+        // This is ensured to be within the bounds of the page by the assertion above.
         unsafe {
             std::slice::from_raw_parts_mut(
                 self.page[node_pointers_init..].as_mut_ptr() as *mut [u8; 4],
@@ -223,6 +233,11 @@ impl<'a> BranchNodeView<'a> {
     }
 
     fn cells(&self) -> &[[u8; 2]] {
+        let cells_end = BRANCH_NODE_HEADER_SIZE + self.n() as usize * 2;
+        assert!(cells_end < BRANCH_NODE_BODY_SIZE);
+
+        // SAFETY: This creates a slice of length 2 * N starting at index BRANCH_NODE_HEADER_SIZE.
+        // This is ensured to be within the bounds of the page by the assertion above.
         unsafe {
             std::slice::from_raw_parts(
                 self.inner[BRANCH_NODE_HEADER_SIZE..BRANCH_NODE_HEADER_SIZE + 2].as_ptr()
@@ -308,7 +323,12 @@ impl<'a> BranchNodeView<'a> {
     }
 
     pub fn node_pointers(&self) -> &[[u8; 4]] {
-        let node_pointers_init = BRANCH_NODE_SIZE - self.n() as usize * 4;
+        let node_pointers_byte_len = self.n() as usize * 4;
+        assert!(node_pointers_byte_len < BRANCH_NODE_SIZE);
+
+        let node_pointers_init = BRANCH_NODE_SIZE - node_pointers_byte_len;
+        // SAFETY: This creates a slice of length 4 * N aligned with the end of the node.
+        // This is ensured to be within the bounds of the page by the assertion above.
         unsafe {
             std::slice::from_raw_parts(
                 self.inner[node_pointers_init..].as_ptr() as *const [u8; 4],


### PR DESCRIPTION
The structure of a branch node is the following:
+ bbn_pn: u32
+ n: u16
+ prefix_compressed: u16
+ prefix_len: u16
+ cells: u16[n]
+ prefix: bitvec[prefix_len]
+ separators: bitvec
+ padding
+ node_pointers: leaf_node_page_number[n]

The unsafety in the module is driven by reading `cells` and `node_pointers` as slices with the number of elements given by `n`. Ensuring that `n` leads to a read within the bounds of the `FatPage` will make the read panic instead of some other errors.

Every other read passes through an access of the `FatPage`, so any out of bounds access will lead to a panic.

Closes THR-63