### PR TITLE
fix(ci): run rw_pass_cell only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: RUSTFLAGS="--cfg loom" cargo test rw_pass_cell --release --workspace
+      - run: RUSTFLAGS="--cfg loom" cargo test -p nomt --release --lib rw_pass_cell
   doc:
     name: NOMT - doc
     runs-on: ubuntu-latest
@@ -60,4 +60,3 @@ jobs:
           targets: x86_64-apple-darwin
       # Build only the NOMT crate. Not everything builds cleanly under this configuration.
       - run: cargo check --verbose -p nomt --locked --target x86_64-apple-darwin
-


### PR DESCRIPTION
The run cmd line is slightly incorrect. First it specifies --release
and --workspace flags before the test name. The test name is the
first positional argument which makes the arguments following
after it ignored.

However, we are not interested in running tests under loom across
all the workspace, we want to run only rw_pass_cell tests.

To achieve this we pass `-p nomt` to limit the tests to that crate
only. We also pass `--lib` to avoid running external tests (under
`nomt/tests`) because there are no loom tests in there.