### PR TITLE
torture: exercise keys that already were used before

### DIFF
--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -203,8 +203,6 @@ impl Agent {
                 }
             }
         }
-        // sort by ascending key
-        actuals.sort_by(|(a, _), (b, _)| a.cmp(b));
         self.nomt.commit(session, actuals)?;
         Ok(())
     }

--- a/torture/src/message.rs
+++ b/torture/src/message.rs
@@ -16,6 +16,16 @@ pub enum KeyValueChange {
     /// A key-value pair was deleted.
     Delete(Key),
 }
+
+impl KeyValueChange {
+    /// Returns the key that this changes pertains to.
+    pub fn key(&self) -> &Key {
+        match *self {
+            KeyValueChange::Insert(ref key, _) | KeyValueChange::Delete(ref key) => key,
+        }
+    }
+}
+
 /// The parameters for the [`ToAgent::Init`] message.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InitPayload {


### PR DESCRIPTION
This changeset changes the key generation so that not every key is random every time. Instead, a key that was already generated will be returned with some probability.