### PR TITLE
fix(torture): change pgid of the agent

### DIFF
--- a/torture/src/spawn.rs
+++ b/torture/src/spawn.rs
@@ -102,6 +102,10 @@ fn spawn_child_with_sock(socket_fd: RawFd) -> Result<std::process::Child> {
     }
 
     let mut cmd = Command::new(program);
+    // Override the PGID of the spawned process. The motivation for this is ^C handling. To handle
+    // ^C the shell will send the SIGINT to all processes in the process group. We are handling
+    // SIGINT manually in the supervisor process.
+    cmd.process_group(0);
     unsafe {
         cmd.pre_exec(move || {
             // Duplicate the socket_fd to the CANARY_SOCKET_FD.


### PR DESCRIPTION
When the user presses ^C the shell sends the SIGINT
to the entire process group. That is, not only the
supervisor gets SIGINT but also all the agents.

That creates a race: the child dies first and
the supervisor registers it's as a failure and
flags for investigation.

creating it in another pg solves this