### PR TITLE
chore: remove unused unsafe impl.

### DIFF
--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -78,8 +78,6 @@ impl IoKind {
     }
 }
 
-unsafe impl Send for IoKind {}
-
 pub struct IoCommand {
     pub kind: IoKind,
     // note: this isn't passed to io_uring, it's higher-level userdata.


### PR DESCRIPTION
This was needed when the IoKind enum contained raw pointers to the pages.
Nowadays it doesn't.