### PR TITLE
chore: clarify that the utilization is spot

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -491,7 +491,7 @@ impl PageLoad {
     }
 }
 
-/// Describes the utilization of buckets in the hash-table.
+/// Describes the utilization of buckets in the hash-table at a point in time.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct HashTableUtilization {
     /// The maximum number of buckets in the hash-table.

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -241,7 +241,7 @@ impl Store {
         &self.shared.io_pool
     }
 
-    /// Get the hash-table bucket counts.
+    /// Get the current hash-table bucket counts.
     pub fn hash_table_utilization(&self) -> HashTableUtilization {
         self.shared.pages.utilization()
     }


### PR DESCRIPTION
Clarify that the utilization metrics are spot, i.e. point in time. So the user
don't think that they can obtain a single object and call the occupancy method.