### PR TITLE
chore: comment the bitbox truncate WAL routine

### DIFF
--- a/nomt/src/bitbox/writeout.rs
+++ b/nomt/src/bitbox/writeout.rs
@@ -22,9 +22,15 @@ pub(super) fn write_wal(mut wal_fd: &File, wal_blob: &[u8]) -> anyhow::Result<()
     Ok(())
 }
 
-pub(super) fn truncate_wal(mut wal_fd: &File) -> anyhow::Result<()> {
+/// Truncates the WAL file to zero length.
+///
+/// Conditionally syncs the file to disk.
+pub(super) fn truncate_wal(mut wal_fd: &File, do_sync: bool) -> anyhow::Result<()> {
     wal_fd.set_len(0)?;
     wal_fd.seek(SeekFrom::Start(0))?;
+    if do_sync {
+        wal_fd.sync_all()?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
This changeset does change the behavior.

Before:

1. we did not do fsync after truncating WAL in bitbox post meta.
2. we did not do fsync after truncating WAL after recovery.

Now:

1. We still do **not** fsync after truncation in bitbox post meta.
2. We now do fsync after truncating WAL after recovery.

The main motivation of this changeset is to document the existing bitbox post-meta behavior.