### PR TITLE
fix: first leaf mut have a separator of all 0

### DIFF
--- a/nomt/src/beatree/ops/update/tests.rs
+++ b/nomt/src/beatree/ops/update/tests.rs
@@ -288,7 +288,12 @@ fn is_valid_leaf_stage_output(
     expected_values.retain(|k, _| !deletions.contains(k));
 
     let mut found_underfull_leaf = false;
-    for (_, new_pn) in output.leaf_changeset.into_iter() {
+    for (separator, new_pn) in output.leaf_changeset.into_iter() {
+        if separator == [0; 32] && new_pn.is_none() {
+            // First leaf with separator of all 0 cannot be eliminated.
+            return false;
+        }
+
         let Some(new_pn) = new_pn else { continue };
         let page = leaf_reader.query(new_pn);
         let leaf_node = LeafNode { inner: page };


### PR DESCRIPTION
What this pr implements is a function to enforce that the separator of the first leaf in the beatree is all 0.

The reason for opting for a new function is to avoid adding complexity to the leaf_stage logic. Carrying around information about the first leaf would have required a lot of modifications here and there. Now, instead, that rule is enforced by only the new function and the `unwrap_or` within the `LeafUpdater::separate` function. Additionally, this edge case is very unlikely, and the function will, for the most part, return after the first check. The goal was to minimize the impact on the critical path and reduce code complexity while maintaining the rule's validity.

Closes THR-91
