### PR TITLE
fix: compute leaf root correctly on startup

### DIFF
--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -123,6 +123,10 @@ impl Test {
         self.session = Some(self.nomt.begin_session());
         x
     }
+
+    pub fn root(&self) -> Node {
+        self.nomt.root()
+    }
 }
 
 pub fn read_balance(t: &mut Test, id: u64) -> Option<u64> {

--- a/nomt/tests/compute_root.rs
+++ b/nomt/tests/compute_root.rs
@@ -1,0 +1,38 @@
+mod common;
+
+use common::Test;
+use nomt::NodeKind;
+
+#[test]
+fn root_on_empty_db() {
+    let t = Test::new("compute_root_empty");
+    let root = t.root();
+    assert_eq!(NodeKind::of(&root), NodeKind::Terminator);
+}
+
+#[test]
+fn root_on_leaf() {
+    {
+        let mut t = Test::new("compute_root_leaf");
+        t.write([1; 32], Some(vec![1, 2, 3]));
+        t.commit();
+    }
+
+    let t = Test::new_with_params("compute_root_leaf", 1, 1, None, false);
+    let root = t.root();
+    assert_eq!(NodeKind::of(&root), NodeKind::Leaf);
+}
+
+#[test]
+fn root_on_internal() {
+    {
+        let mut t = Test::new("compute_root_internal");
+        t.write([0; 32], Some(vec![1, 2, 3]));
+        t.write([1; 32], Some(vec![1, 2, 3]));
+        t.commit();
+    }
+
+    let t = Test::new_with_params("compute_root_internal", 1, 1, None, false);
+    let root = t.root();
+    assert_eq!(NodeKind::of(&root), NodeKind::Internal);
+}


### PR DESCRIPTION
After removing leaf children, the root page is now empty if the DB holds only a single item. This now differentiates the TERMINATOR and leaf cases by iterating the database.
