### PR TITLE
trickfs: add trickmnt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 dependencies = [
  "backtrace",
 ]
@@ -1889,6 +1889,17 @@ dependencies = [
  "libc",
  "log",
  "tempfile",
+]
+
+[[package]]
+name = "trickmnt"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.5.23",
+ "env_logger 0.11.6",
+ "log",
+ "trickfs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,14 @@
 [workspace]
 resolver = "2"
-members = ["core", "nomt", "fuzz", "torture", "examples/*", "trickfs"]
+members = [
+    "core",
+    "nomt",
+    "fuzz",
+    "torture",
+    "examples/*",
+    "trickfs",
+    "trickfs/trickmnt",
+]
 exclude = ["benchtop"]
 
 [workspace.package]

--- a/trickfs/README.md
+++ b/trickfs/README.md
@@ -2,6 +2,16 @@
 
 A FUSE filesystem useful for failure injection.
 
+# Using trickfs.
+
+Typically you would not need to run trickfs directly, because it should be used as a dependency
+in other projects. However, if you want to test the filesystem, you can do so by running the
+following command:
+
+```sh
+cargo run --release --bin trickmnt
+```
+
 # Building
 
 Building the project requires fuse3 and fuse to be available. On Ubuntu, you can install them with

--- a/trickfs/src/main.rs
+++ b/trickfs/src/main.rs
@@ -1,9 +1,0 @@
-fn main() {
-    let _ = env_logger::builder()
-        .filter_level(log::LevelFilter::Trace)
-        .init();
-    let handle = trickfs::spawn_trick("/tmp/trick").unwrap();
-    println!("running...");
-    std::io::stdin().read_line(&mut String::new()).unwrap();
-    drop(handle);
-}

--- a/trickfs/trickmnt/Cargo.toml
+++ b/trickfs/trickmnt/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "trickfs"
+name = "trickmnt"
 version = "0.1.0"
 authors.workspace = true
 homepage.workspace = true
@@ -8,10 +8,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-fuser = { version = "0.15.1", features = ["abi-7-23"] }
-libc = "0.2.169"
-log = "0.4.22"
-tempfile = "3.15.0"
-
-[dev-dependencies]
+trickfs = { path = ".." }
+clap = { version = "4.3.5", features = ["derive"] }
 env_logger = "0.11.6"
+log = "0.4.22"
+anyhow = "1.0.95"

--- a/trickfs/trickmnt/src/main.rs
+++ b/trickfs/trickmnt/src/main.rs
@@ -1,0 +1,28 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the directory where trickfs will be mounted
+    #[arg(short, long, default_value = "/tmp/trick")]
+    mountpoint: String,
+}
+
+fn waitline() {
+    log::info!("press return to stop...");
+    let _ = std::io::stdin().read_line(&mut String::new());
+}
+
+fn main() -> anyhow::Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let args = Args::parse();
+
+    let handle = trickfs::spawn_trick(args.mountpoint).unwrap();
+    waitline();
+    drop(handle);
+
+    Ok(())
+}


### PR DESCRIPTION
adds a binary target called `trickmnt` to quickly mount a trickfs
locally.