### PR TITLE
benchtop: print max rss

### DIFF
--- a/benchtop/Cargo.lock
+++ b/benchtop/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "jmt",
  "kvdb",
  "kvdb-rocksdb",
+ "libc",
  "lru",
  "nomt",
  "rand",

--- a/benchtop/Cargo.toml
+++ b/benchtop/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 
 # benchmarking
-clap = { version = "4.4.8" , features = ["derive"] }
+clap = { version = "4.4.8", features = ["derive"] }
 anyhow = { version = "1.0.75" }
 hdrhistogram = "7.5.4"
 fxhash = "0.2.1"
@@ -23,6 +23,7 @@ serde = "1.0.199"
 humantime = "2.1.0"
 rayon = "1.10"
 lru = "0.12.5"
+libc = "0.2.155"
 
 # sov-db
 sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk" }

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -92,6 +92,21 @@ pub fn run(params: RunParams) -> Result<()> {
 
     db.print_metrics();
     timer.print(workload_params.size);
+    print_max_rss();
 
     Ok(())
+}
+
+fn print_max_rss() {
+    let max_rss = get_max_rss().unwrap_or(0);
+    println!("max rss: {} MiB", max_rss / 1024);
+    fn get_max_rss() -> Option<usize> {
+        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+        let ret = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+        if ret == 0 {
+            Some(usage.ru_maxrss as usize)
+        } else {
+            None
+        }
+    }
 }


### PR DESCRIPTION
It might be interesting to know how much memory the benchtop
process consumed at its peak, so print it at the end of
execution.