### PR TITLE
feat(torture):reverted changeset on previous state

### DIFF
--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -111,7 +111,6 @@ pub async fn run(input: UnixStream) -> Result<()> {
                     .await?;
             }
             ToAgent::Query(key) => {
-                trace!("query: {}", hex::encode(key));
                 let value = agent.query(key)?;
                 stream
                     .send(Envelope {

--- a/torture/src/supervisor/comms.rs
+++ b/torture/src/supervisor/comms.rs
@@ -88,7 +88,6 @@ impl RequestResponse {
     // Requests the value of the key from the agent.
     #[allow(dead_code)]
     pub async fn send_request_query(&self, key: message::Key) -> anyhow::Result<Option<Vec<u8>>> {
-        trace!(key = hex::encode(&key), "sending storage query");
         match self
             .send_request(crate::message::ToAgent::Query(key))
             .await?


### PR DESCRIPTION
Make sure that any reverted changes did not alter
already present values. To do this, compare them with
the values of the previous state maintained by the supervisor.