### PR TITLE
refactor: page cache / merklization / bitbox overhaul for overlays

### DIFF
--- a/nomt/src/merkle/page_set.rs
+++ b/nomt/src/merkle/page_set.rs
@@ -1,0 +1,64 @@
+//! A set of pages that the page walker draws upon and which is filled by `Seek`ing.
+
+use nomt_core::page_id::PageId;
+use std::collections::HashMap;
+
+use crate::{
+    io::PagePool,
+    page_cache::{Page, PageMut},
+    store::{BucketIndex, BucketInfo, SharedMaybeBucketIndex},
+};
+
+/// The mode to use when determining bucket indices for fresh pages.
+#[derive(Clone, Copy)]
+pub enum FreshPageBucketMode {
+    #[allow(dead_code)]
+    WithDependents,
+    WithoutDependents,
+}
+
+pub struct PageSet {
+    map: HashMap<PageId, (Page, BucketInfo)>,
+    page_pool: PagePool,
+    fresh_page_bucket_mode: FreshPageBucketMode,
+}
+
+impl PageSet {
+    pub fn new(page_pool: PagePool, mode: FreshPageBucketMode) -> Self {
+        PageSet {
+            map: HashMap::new(),
+            page_pool,
+            fresh_page_bucket_mode: mode,
+        }
+    }
+
+    fn fresh_bucket_info(&self) -> BucketInfo {
+        match self.fresh_page_bucket_mode {
+            FreshPageBucketMode::WithDependents => {
+                BucketInfo::FreshOrDependent(SharedMaybeBucketIndex::new(None))
+            }
+            FreshPageBucketMode::WithoutDependents => BucketInfo::FreshWithNoDependents,
+        }
+    }
+
+    /// Insert a page with a known bucket index.
+    pub fn insert(&mut self, page_id: PageId, page: Page, bucket_index: BucketIndex) {
+        self.map
+            .insert(page_id, (page, BucketInfo::Known(bucket_index)));
+    }
+}
+
+impl super::page_walker::PageSet for PageSet {
+    fn fresh(&self, page_id: &PageId) -> (PageMut, BucketInfo) {
+        let page = PageMut::pristine_empty(&self.page_pool, &page_id);
+        let bucket_info = self.fresh_bucket_info();
+
+        (page, bucket_info)
+    }
+
+    fn get(&self, page_id: &PageId) -> Option<(Page, BucketInfo)> {
+        self.map
+            .get(&page_id)
+            .map(|(p, bucket_info)| (p.clone(), bucket_info.clone()))
+    }
+}


### PR DESCRIPTION
With this PR, I overhauled the merklization pipeline (page cache / page walker / bitbox) in preparation for overlay changes.

Significant changes:
  - Page cache now only stores completely clean pages, i.e. pages submitted for write, and updates are outside of the critical path.
  - Page cache pages are no longer an `Option`. Either the page is allocated, or it is not. This simplifies some logic.
  - Introduced a `DirtyPage` struct which tracks bucket information (including buckets not yet allocated)
  - Introduced a `PageSet` used by `Seek` / `PageWalker`. The page walker, instead of drawing on the page cache directly, will only take pages from the `PageSet`. It is populated by `Seek`. In the future, `Seek` will draw on the live overlay, the page cache, or the disk in order to populate the page set.
  - Removed the `MerkleTransaction` and `BucketAllocator`. Bucket allocation is now done directly in-line in bitbox `prepare_sync`.
  - Introduced a `store::BucketInfo` which is used to encode whether a bucket is known or as-yet-unallocated. There is a variant here which allows the bucket allocation for fresh pages to propagate through dependent overlays with some shared `Arc` state.


Merkle warm-ups are broken as-of this PR. I will address it in a follow-up, but this was already getting quite large.
