### PR TITLE
fix(torture): handle large overflow values

### DIFF
--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -164,12 +164,7 @@ impl WorkloadState {
         // - Different power of two sizes.
         // - Change it to be a non-even.
         let len = if self.rng.gen_bool(self.biases.overflow) {
-            // TODO: handle multiple overflow page scenario.
-            // Currently, using a value that is too large causes the channel to hang
-            // when the agent is responding with the queried value.
-            // However MAX_LEAF_VALUE_SIZE is 1332 thus 2000 is enough
-            // to test simple overflow values where only one additional page is used.
-            2000
+            32 * 1024
         } else {
             32
         };


### PR DESCRIPTION
Spawning a blocking task to handle the reception of the message is a workaround to make it possible to handle large overflow values.
Using the standard `timeout(self.shared.timeout, rx).await??;` does not work, it hangs when the expected value to be received is larger than 15KiB.

The problem seems to be strictly related to the interaction between `tokio::time::timeout` and `tokio::sync::oneshot::Receiver`.

A simple code like the following perfectly works.
  ```rust
        let message = loop {
            tokio::time::sleep(Duration::from_millis(1)).await;
            if let Ok(something) = rx.try_recv() {
                break something;
            }
        };
  ```

It seems that the `Future` implementation of `tokio::sync::oneshot::Receiver` switches from being non-blocking to blocking if the size of the message gets bigger than 15KiB.

But I also found [this](https://github.com/tokio-rs/tokio/issues/6682), which is a bug within the timeout function in a couple of versions ago (solved in 1.38.1, we are in 1.42), maybe it is not entirely solved.
