### PR TITLE
feat(torture): add `sample-snapshot` option

### DIFF
--- a/torture/src/supervisor/cli.rs
+++ b/torture/src/supervisor/cli.rs
@@ -92,8 +92,13 @@ pub struct WorkloadParams {
     #[arg(long = "ensure-changeset")]
     pub ensure_changeset: bool,
 
-    /// Whether to ensure the correctness of the state after every crash.
+    /// Whether to ensure the correctness of the entire state after every crash or rollback.
     #[clap(default_value = "false")]
-    #[arg(long = "ensure-snapshot")]
+    #[arg(long = "ensure-snapshot", conflicts_with = "sample_snapshot")]
     pub ensure_snapshot: bool,
+
+    /// Whether to randomly sample the state after every crash or rollback.
+    #[clap(default_value = "false")]
+    #[arg(long = "sample-snapshot")]
+    pub sample_snapshot: bool,
 }


### PR DESCRIPTION
Together with `ensure-snapshot` they cover two different ways of
checking the validity of the state after a crash or a rollback happened.
`ensure-snapshot` checks the entire state while `sample-snapshot` just
checks a random subset of the state.