### PR TITLE
fix(torture): move snapshot check

### DIFF
--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -113,7 +113,7 @@ pub async fn run(input: UnixStream) -> Result<()> {
             ToAgent::Rollback(n_blocks) => {
                 let start = std::time::Instant::now();
                 agent.rollback(n_blocks)?;
-                tracing::info!("rollback took {:?}", start.elapsed().as_millis());
+                tracing::info!("rollback took {}ms", start.elapsed().as_millis());
                 stream
                     .send(Envelope {
                         reqno,


### PR DESCRIPTION
Previously, the check was made immediately after respawning the child,
which implied a check of the snapshot over a non-up-to-date
`state.last_snapshot()`, leading to incorrect checks.