### PR TITLE
chore: doc(hidden) on Metrics

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -535,6 +535,7 @@ impl<T: HashAlgorithm> Nomt<T> {
 
     /// Return Nomt's metrics.
     /// To collect them, they need to be activated at [`Nomt`] creation
+    #[doc(hidden)]
     pub fn metrics(&self) -> Metrics {
         self.metrics.clone()
     }


### PR DESCRIPTION
Right now Metrics is not public and, even though it's it exposed through
[`Nomt::metrics`] it is not really useable.

Ideally, we should expose Metrics. However, right now Metrics is not really good
fit for the end-user API and requires rework.

Until then — hide it from the public API.