### PR TITLE
chore: update docs for the pagecache

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -535,6 +535,7 @@ impl<T: HashAlgorithm> Nomt<T> {
 
     /// Return Nomt's metrics.
     /// To collect them, they need to be activated at [`Nomt`] creation
+    #[doc(hidden)]
     pub fn metrics(&self) -> Metrics {
         self.metrics.clone()
     }

--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -99,11 +99,9 @@ impl PageSource {
     #[cfg(test)]
     fn insert_fresh(&self, page_id: PageId) -> Page {
         match self {
-            PageSource::PageCache(ref cache) => {
-                cache.insert(page_id, PageMut::pristine_empty(), None)
-            }
+            PageSource::PageCache(ref cache) => cache.insert(page_id, PageMut::new_empty(), None),
             PageSource::PageCacheShard(ref shard) => {
-                shard.insert(page_id, PageMut::pristine_empty(), None)
+                shard.insert(page_id, PageMut::new_empty(), None)
             }
         }
     }
@@ -354,7 +352,7 @@ impl<H: NodeHasher> PageWalker<H> {
                 let stack_item = if fresh {
                     UpdatedPage {
                         page_id: child_page_id,
-                        page: PageMut::pristine_empty(),
+                        page: PageMut::new_empty(),
                         diff: PageDiff::default(),
                     }
                 } else if self
@@ -1095,8 +1093,8 @@ mod tests {
         let terminator_6 = TriePosition::from_path_and_depth(key_path![0, 0, 0, 0, 0, 1], 6);
         let terminator_7 = TriePosition::from_path_and_depth(key_path![0, 0, 0, 0, 0, 0, 1], 7);
 
-        let mut root_page = PageMut::pristine_empty();
-        let mut page1 = PageMut::pristine_empty();
+        let mut root_page = PageMut::new_empty();
+        let mut page1 = PageMut::new_empty();
 
         // we place garbage in all the sibling positions for those internal  nodes.
         {

--- a/nomt/src/merkle/seek.rs
+++ b/nomt/src/merkle/seek.rs
@@ -502,8 +502,8 @@ impl<H: HashAlgorithm> Seeker<H> {
         };
 
         let (page, bucket_index) = match page_data {
-            None => (PageMut::pristine_empty(), None),
-            Some((page, bucket)) => (PageMut::pristine_with_data(page), Some(bucket)),
+            None => (PageMut::new_empty(), None),
+            Some((page, bucket)) => (PageMut::new_with_data(page), Some(bucket)),
         };
 
         let page = self

--- a/nomt/src/page_cache.rs
+++ b/nomt/src/page_cache.rs
@@ -53,13 +53,13 @@ impl PageMut {
         }
     }
 
-    /// Create a pristine (i.e. blank) `PageMut`.
-    pub fn pristine_empty() -> PageMut {
+    /// Create a new blank `PageMut`.
+    pub fn new_empty() -> PageMut {
         PageMut { inner: None }
     }
 
-    /// Create a mutable page from raw page data.
-    pub fn pristine_with_data(data: FatPage) -> PageMut {
+    /// Create a mutable page cache page using the page pool page.
+    pub fn new_with_data(data: FatPage) -> PageMut {
         PageMut { inner: Some(data) }
     }
 
@@ -89,7 +89,7 @@ impl PageMut {
 
 impl From<FatPage> for PageMut {
     fn from(data: FatPage) -> PageMut {
-        Self::pristine_with_data(data)
+        Self::new_with_data(data)
     }
 }
 
@@ -481,8 +481,9 @@ impl PageCache {
         deferred_drop
     }
 
-    /// Evict stale pages for the cache. This should only be used after all dirty pages have been
-    /// prepared for writeout with `prepare_transaction`.
+    /// Evict LRUs.
+    ///
+    /// This should only be used after all dirty pages have been written out.
     pub fn evict(&self) {
         let shard_guards = self
             .shared


### PR DESCRIPTION
Pristine/dirty classification of pages in page cache was retired. Soon the page
cache will be only having pristine pages exclusively.