### PR TITLE
refactor(torture): probabilities handling

### DIFF
--- a/torture/src/supervisor/cli.rs
+++ b/torture/src/supervisor/cli.rs
@@ -63,29 +63,29 @@ pub struct WorkloadParams {
     #[arg(long = "random-size")]
     pub random_size: bool,
 
-    /// When exercising a new commit, the probability of causing it to crash.
+    /// When executing a workload iteration ,this is the probability of executing a rollback
+    /// instead of a commit.
     ///
     /// Accepted values are in the range of 0 to 100
-    #[clap(default_value = "20")]
+    #[clap(default_value = "30")]
     #[clap(value_parser=clap::value_parser!(u8).range(0..=100))]
-    #[arg(long = "commit-crash")]
-    pub crash: u8,
-
-    /// Instead of exercising a new commit, this is the probability of executing a rollback.
-    ///
-    /// Accepted values are in the range of 0 to 100
-    #[clap(default_value = "5")]
-    #[clap(value_parser=clap::value_parser!(u8).range(0..=100))]
-    #[arg(long = "rollback")]
+    #[arg(long = "rollback-bias")]
     pub rollback: u8,
 
-    /// Instead of exercising a new commit, this is the probability of executing a rollback
-    /// and causing it to crash.
+    /// When executing a commit this is the probability of causing it to crash.
     ///
     /// Accepted values are in the range of 0 to 100
-    #[clap(default_value = "5")]
+    #[clap(default_value = "30")]
     #[clap(value_parser=clap::value_parser!(u8).range(0..=100))]
-    #[arg(long = "rollback-crash")]
+    #[arg(long = "commit-crash-bias")]
+    pub commit_crash: u8,
+
+    /// When executing a rollback this is the probability of causing it to crash.
+    ///
+    /// Accepted values are in the range of 0 to 100
+    #[clap(default_value = "30")]
+    #[clap(value_parser=clap::value_parser!(u8).range(0..=100))]
+    #[arg(long = "rollback-crash-bias")]
     pub rollback_crash: u8,
 
     /// The max amount of commits involved in a rollback.


### PR DESCRIPTION
Define a `rollback-bias` argument which defines the probability
of executing a rollback instead of a commit.
Add then `rollback-crash-bias` and `commit-crash-bias`,  two
arguments to define the probability of causing to crash respectively
the rollback or the commit when they would be performed.

This is based on what @pepyakin pointed out [here](https://github.com/thrumdev/nomt/pull/706#discussion_r1922495335)