### PR TITLE
fix: warm-up page set creation

### DIFF
--- a/nomt/src/merkle/page_set.rs
+++ b/nomt/src/merkle/page_set.rs
@@ -1,7 +1,7 @@
 //! A set of pages that the page walker draws upon and which is filled by `Seek`ing.
 
 use nomt_core::page_id::PageId;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     io::PagePool,
@@ -18,15 +18,21 @@ pub enum FreshPageBucketMode {
 
 pub struct PageSet {
     map: HashMap<PageId, (Page, BucketInfo)>,
+    warm_up_map: Option<Arc<HashMap<PageId, (Page, BucketInfo)>>>,
     page_pool: PagePool,
     fresh_page_bucket_mode: FreshPageBucketMode,
 }
 
 impl PageSet {
-    pub fn new(page_pool: PagePool, mode: FreshPageBucketMode) -> Self {
+    pub fn new(
+        page_pool: PagePool,
+        mode: FreshPageBucketMode,
+        warmed_up: Option<FrozenSharedPageSet>,
+    ) -> Self {
         PageSet {
             map: HashMap::new(),
             page_pool,
+            warm_up_map: warmed_up.map(|x| x.0),
             fresh_page_bucket_mode: mode,
         }
     }
@@ -44,6 +50,19 @@ impl PageSet {
     pub fn insert(&mut self, page_id: PageId, page: Page, bucket_info: BucketInfo) {
         self.map.insert(page_id, (page, bucket_info));
     }
+
+    /// Freeze this page-set and make a shareable version of it. This returns a frozen page set
+    /// containing all insertions into this map.
+    pub fn freeze(self) -> FrozenSharedPageSet {
+        FrozenSharedPageSet(Arc::new(self.map))
+    }
+
+    fn get_warmed_up(&self, page_id: &PageId) -> Option<(Page, BucketInfo)> {
+        self.warm_up_map
+            .as_ref()
+            .and_then(|m| m.get(page_id))
+            .map(|(p, b)| (p.clone(), b.clone()))
+    }
 }
 
 impl super::page_walker::PageSet for PageSet {
@@ -58,6 +77,7 @@ impl super::page_walker::PageSet for PageSet {
         self.map
             .get(&page_id)
             .map(|(p, bucket_info)| (p.clone(), bucket_info.clone()))
+            .or_else(|| self.get_warmed_up(page_id))
             .map(|(p, b)| {
                 if let (FreshPageBucketMode::WithDependents, &BucketInfo::FreshWithNoDependents) =
                     (self.fresh_page_bucket_mode, &b)
@@ -74,3 +94,7 @@ impl super::page_walker::PageSet for PageSet {
             })
     }
 }
+
+/// A frozen, shared page set. This is cheap to clone.
+#[derive(Clone)]
+pub struct FrozenSharedPageSet(Arc<HashMap<PageId, (Page, BucketInfo)>>);


### PR DESCRIPTION
The `PageSet` created for overlays broke warm-ups and this PR fixes it.

Prior to overlays, warmed up pages were inserted into the global page cache and the page walker drew from it, so the pages were guaranteed to be available to update workers.

However, with the `PageSet` refactor we needed a way for the working page-set gathered by warm-ups to be made available to the workers. I opted to do that in this PR by creating a wrapper around an `Arc<HashMap>` that stores all the warmed-up pages, and pass this to the workers as a fallback.
