### PR TITLE
feat(benchtop): add overlay support

### DIFF
--- a/benchtop/src/backend.rs
+++ b/benchtop/src/backend.rs
@@ -23,6 +23,7 @@ impl Backend {
         hashtable_buckets: Option<u32>,
         page_cache_size: Option<usize>,
         leaf_cache_size: Option<usize>,
+        overlay_window_length: usize,
     ) -> DB {
         match self {
             Backend::SovDB => DB::Sov(SovDB::open(reset)),
@@ -33,6 +34,7 @@ impl Backend {
                 hashtable_buckets,
                 page_cache_size,
                 leaf_cache_size,
+                overlay_window_length,
             )),
             Backend::SpTrie => DB::SpTrie(SpTrieDB::open(reset)),
         }

--- a/benchtop/src/cli.rs
+++ b/benchtop/src/cli.rs
@@ -154,6 +154,14 @@ pub struct WorkloadParams {
     /// Only used with the Nomt backend.
     #[arg(long = "leaf-cache-size")]
     pub leaf_cache_size: Option<usize>,
+
+    /// The size of the window of in-memory overlays to use. 0 (default) means that changes are
+    /// committed directly to disk. Any value above 0 means that a rolling window of workloads are
+    /// committed first into memory and then into disk.
+    /// Only used with the Nomt backend.
+    #[arg(long = "overlay-window-length")]
+    #[clap(default_value = "0")]
+    pub overlay_window_length: usize,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -33,6 +33,7 @@ pub fn init(params: InitParams) -> Result<()> {
         workload_params.hashtable_buckets,
         workload_params.page_cache_size,
         workload_params.leaf_cache_size,
+        0,
     );
     db.execute(None, &mut *init, None);
 
@@ -53,6 +54,7 @@ pub fn run(params: RunParams) -> Result<()> {
         workload_params.hashtable_buckets,
         workload_params.page_cache_size,
         workload_params.leaf_cache_size,
+        workload_params.overlay_window_length,
     );
 
     if params.reset {

--- a/nomt/src/overlay.rs
+++ b/nomt/src/overlay.rs
@@ -44,7 +44,7 @@ impl Overlay {
     /// If the provided marker is `None`, then this checks that this overlay doesn't have a parent.
     pub(super) fn parent_matches_marker(&self, marker: Option<&OverlayMarker>) -> bool {
         match (self.inner.data.parent_status.as_ref(), marker) {
-            (None, None) => true,
+            (None, _) => true,
             (Some(parent), Some(marker)) => parent.ptr_eq(&marker.0),
             _ => false,
         }


### PR DESCRIPTION
I ran some benchmarks (details in slack) on the overlay work in this stack.

I observed performance at about par (43 vs 45k TPS) on master in the base case. But when running with overlays, I observed faster performance (70k TPS for a single overlay - a bit baffling, will discuss offline but seems to have uncovered a route for additional optimization) 
