### PR TITLE
feat(torture): print hex values

### DIFF
--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -443,9 +443,9 @@ impl Workload {
                 return Err(anyhow::anyhow!(
                     "Wrong {}ith key in snapshot,\n key: {:?},\n expected value: {:?},\n found value: {:?}",
                     i,
-                    key,
-                    expected_value,
-                    value
+                    hex::encode(key),
+                    expected_value.as_ref().map(hex::encode),
+                    value.as_ref().map(hex::encode),
                 ));
             }
         }


### PR DESCRIPTION
Use hex values for displaying KVs, because dec looks very ugly.