### PR TITLE
chore(torture): address multiple left todos

### DIFF
--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -234,7 +234,12 @@ impl Agent {
         o.path(workdir.join("nomt_db"));
         o.bitbox_seed(init.bitbox_seed);
         o.hashtable_buckets(500_000);
-        o.rollback(init.rollback);
+        if let Some(n_commits) = init.rollback {
+            o.rollback(true);
+            o.max_rollback_log_len(n_commits);
+        } else {
+            o.rollback(false);
+        }
         let nomt = Nomt::open(o)?;
         Ok(Self {
             workdir,

--- a/torture/src/message.rs
+++ b/torture/src/message.rs
@@ -47,7 +47,8 @@ pub struct InitPayload {
     /// Only used upon creation a new NOMT db.
     pub bitbox_seed: [u8; 16],
     /// Whether the agent is supposed to handle rollbacks.
-    pub rollback: bool,
+    /// If `Some`, the maximum amount of supported blocks in a single rollback is specified.
+    pub rollback: Option<u32>,
 }
 
 /// The parameters for the [`ToAgent::Commit`] message.

--- a/torture/src/supervisor/cli.rs
+++ b/torture/src/supervisor/cli.rs
@@ -92,9 +92,9 @@ pub struct WorkloadParams {
     ///
     /// The effective number of commits used for each rollback is randomly generated in the range
     /// 0..max_rollback_commits.
-    #[clap(default_value = "10")]
+    #[clap(default_value = "100")]
     #[arg(long = "max-rollback-commits")]
-    pub max_rollback_commits: usize,
+    pub max_rollback_commits: u32,
 
     /// Whether to ensure the correct application of the changest after every commit.
     #[clap(default_value = "false")]

--- a/torture/src/supervisor/controller.rs
+++ b/torture/src/supervisor/controller.rs
@@ -33,7 +33,7 @@ impl SpawnedAgentController {
         workdir: String,
         workload_id: u64,
         bitbox_seed: [u8; 16],
-        rollback: bool,
+        rollback: Option<u32>,
     ) -> Result<()> {
         // Assign a unique ID to the agent.
         static AGENT_COUNT: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
+ More sophisticated value generation.
+ Use the `max_rollback_blocks` cli argument as nomt option for `max_rollback_log_len`.
+ More sophisticated new key generation.

  To prove my claim on the amount of probabilities for a given amount of shared bytes, you can check some tests I did [here]( https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=5aaa317ab9e7e2bc62662ffe415e837d).
