### PR TITLE
fix: label pages in WAL recovery

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -442,6 +442,9 @@ fn recover(
                 }
                 page_diff.unpack_changed_nodes(&changed_nodes, &mut page);
 
+                // Label the page.
+                page[PAGE_SIZE - 32..].copy_from_slice(&page_id);
+
                 ht_fd.write_all_at(&page, pn * PAGE_SIZE as u64)?;
             }
         }


### PR DESCRIPTION
WAL recovery wrote the nodes into pages, but not the page ID.

That meant that fresh pages which are recovered only from the WAL would not be probeable and would be treated as misprobes, silently losing data. The fix is to set the page ID on WAL recovery.
