### PR TITLE
refactor: remove unneeded branch in PageWalker::down

### DIFF
--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -350,13 +350,6 @@ impl<H: NodeHasher> PageWalker<H> {
                         diff: PageDiff::default(),
                         bucket_info,
                     }
-                } else if self
-                    .updated_pages
-                    .last()
-                    .map_or(false, |d| d.page_id == child_page_id)
-                {
-                    // UNWRAP: just checked
-                    self.updated_pages.pop().unwrap()
                 } else {
                     // UNWRAP: all pages on the path to the node should be in the cache.
                     let (page, bucket_info) = page_set.get(&child_page_id).unwrap();


### PR DESCRIPTION
After removing leaf children, it is no longer possible for the page walker to revisit a page.

This previously occurred when we:
  1. Removed leaf children (push, pop)
  2. Wrote more nodes into the page afterwards (push)

But now all pages are visited exactly one time.
