### PR TITLE
fix: fix up errors coming from rustdoc

### DIFF
--- a/nomt/src/beatree/iterator.rs
+++ b/nomt/src/beatree/iterator.rs
@@ -21,7 +21,7 @@ use super::{
 ///
 /// This combines the in-memory overlays with the state of the leaf pages on the disk.
 /// This iterator does not handle the fetching of pages internally, but instead provides the needed
-/// page numbers. The [`ReadTransaction`]` will provide facilities for dispatching I/O with a
+/// page numbers. The [`super::ReadTransaction`]` will provide facilities for dispatching I/O with a
 /// provided handle.
 ///
 /// This is not a normal Rust iterator, due to its need to block. Furthermore, it is a streaming

--- a/nomt/src/io/fsyncer.rs
+++ b/nomt/src/io/fsyncer.rs
@@ -59,8 +59,11 @@ impl Fsyncer {
     ///
     /// # Panics
     ///
-    /// Panics if there is an outstanding fsync operation that hasn't been consumed by [`wait()`] yet.
-    /// Make sure to call [`wait()`] to consume any previous fsync result before issuing a new request.
+    /// Panics if there is an outstanding fsync operation that hasn't been consumed by
+    /// [`Self::wait()`] yet.
+    ///
+    /// Make sure to call [`Self::wait()`] to consume any previous fsync result before issuing a new
+    /// request.
     pub fn fsync(&self) {
         let mut s_guard = self.shared.s.lock();
         assert!(matches!(&*s_guard, State::Idle));

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -613,9 +613,9 @@ impl<T: HashAlgorithm> Nomt<T> {
 ///
 /// The session enables the application to perform reads and prepare writes.
 ///
-/// When the session is finished, the application can [commit][`Nomt::commit_and_prove`] the changes
-/// and create a [`Witness`] that can be used to prove the correctness of replaying the same
-/// operations.
+/// When the session is finished, the application can confirm the changes by calling
+/// [`Nomt::update`] or others and create a [`Witness`] that can be used to prove the correctness
+/// of replaying the same operations.
 pub struct Session {
     store: Store,
     merkle_updater: Option<Updater>, // always `Some` during lifecycle.
@@ -666,13 +666,15 @@ impl Session {
     /// Important considerations:
     /// 1. This function does not perform deduplication. Calling it multiple times for the same key
     ///    will result in multiple load operations, which can be wasteful.
-    /// 2. The definitive set of values to be committed is determined by the [`Nomt::commit`] call.
+    /// 2. The definitive set of values to be updated is determined by the update (e.g.
+    ///    [`Nomt::update`]) call.
+    ///
     ///    It's safe to call this function for keys that may not ultimately be written, and keys
     ///    not marked here but included in the final set will still be preserved.
     /// 3. While this function helps optimize I/O, it's not strictly necessary for correctness.
     ///    The commit process will ensure all required prior values are preserved.
-    /// 4. If the path is given to [`Nomt::commit`] with the `ReadThenWrite` operation, calling
-    ///    this function is not needed as the prior value will be taken from there.
+    /// 4. If the path is given to [`Nomt::update`] (and others) with the `ReadThenWrite` operation,
+    ///    calling this function is not needed as the prior value will be taken from there.
     ///
     /// For best performance, call this function once for each key you expect to write during the
     /// session, except for those that will be part of a `ReadThenWrite` operation. The earlier

--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -204,7 +204,7 @@ pub struct Workload {
     workload_id: u64,
     /// The seed for bitbox generated for this workload.
     bitbox_seed: [u8; 16],
-    /// Data collected to evaluate the average commit time [ns].
+    /// Data collected to evaluate the average commit time in nanoseconds.
     tot_commit_time: u64,
     n_successfull_commit: u64,
     /// Whether to ensure the correct application of the changest after every commit.


### PR DESCRIPTION
Since we are going to rehaul the API and docs anyway I only did a halfassed pass to silence the warnings in order to disallow them in the next PR.