### PR TITLE
feat(ci): strict rustdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
   doc:
     name: NOMT - doc
     runs-on: ubuntu-latest
+    env:
+      # Treat rustdoc warnings as errors.
+      RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Make the errors, such as broken links and other stuff as errors. We don't want
master printing warnings when building docs, as we don't want dangling links.