### PR TITLE
refactor: defer bucket info dependent allocation to post-merklization

### DIFF
--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -52,9 +52,9 @@ use nomt_core::{
 };
 
 use crate::{
+    merkle::BucketInfo,
     page_cache::{Page, PageMut},
     page_diff::PageDiff,
-    store::BucketInfo,
 };
 
 /// The output of the page walker.
@@ -602,14 +602,13 @@ impl<H: NodeHasher> PageWalker<H> {
 #[cfg(test)]
 mod tests {
     use super::{
-        trie, Node, NodeHasherExt, Output, PageSet, PageWalker, TriePosition, UpdatedPage,
-        ROOT_PAGE_ID,
+        trie, BucketInfo, Node, NodeHasherExt, Output, PageSet, PageWalker, TriePosition,
+        UpdatedPage, ROOT_PAGE_ID,
     };
     use crate::{
         io::PagePool,
         page_cache::{Page, PageMut},
         page_diff::PageDiff,
-        store::BucketInfo,
         Blake3Hasher,
     };
     use bitvec::prelude::*;
@@ -663,13 +662,13 @@ mod tests {
     impl PageSet for MockPageSet {
         fn fresh(&self, page_id: &PageId) -> (PageMut, BucketInfo) {
             let page = PageMut::pristine_empty(&self.page_pool, page_id);
-            (page, BucketInfo::FreshWithNoDependents)
+            (page, BucketInfo::Fresh)
         }
 
         fn get(&self, page_id: &PageId) -> Option<(Page, BucketInfo)> {
             self.inner
                 .get(page_id)
-                .map(|p| (p.clone(), BucketInfo::FreshWithNoDependents))
+                .map(|p| (p.clone(), BucketInfo::Fresh))
         }
     }
 

--- a/nomt/src/merkle/seek.rs
+++ b/nomt/src/merkle/seek.rs
@@ -8,11 +8,11 @@ use crate::{
     },
     io::{CompleteIo, FatPage, IoHandle},
     page_cache::{Page, PageCache, PageMut},
-    store::{BucketIndex, BucketInfo, PageLoad, PageLoader},
+    store::{BucketIndex, PageLoad, PageLoader},
     HashAlgorithm,
 };
 
-use super::{page_set::PageSet, LiveOverlay};
+use super::{page_set::PageSet, BucketInfo, LiveOverlay};
 
 use nomt_core::{
     page::DEPTH,

--- a/nomt/src/merkle/worker.rs
+++ b/nomt/src/merkle/worker.rs
@@ -69,11 +69,7 @@ pub(super) fn run_warm_up<H: HashAlgorithm>(
     let page_io_receiver = io_handle.receiver().clone();
 
     // We always run with `WithoutDependents` here, and the mode is adjusted later, during `update`.
-    let page_set = PageSet::new(
-        io_handle.page_pool().clone(),
-        super::page_set::FreshPageBucketMode::WithoutDependents,
-        None,
-    );
+    let page_set = PageSet::new(io_handle.page_pool().clone(), None);
 
     let seeker = Seeker::<H>::new(
         params.root,
@@ -223,15 +219,7 @@ fn update<H: HashAlgorithm>(
 
     let mut output = WorkerOutput::new(shared.witness);
 
-    let mut page_set = PageSet::new(
-        page_pool,
-        if shared.into_overlay {
-            super::page_set::FreshPageBucketMode::WithDependents
-        } else {
-            super::page_set::FreshPageBucketMode::WithoutDependents
-        },
-        warm_page_set,
-    );
+    let mut page_set = PageSet::new(page_pool, warm_page_set);
 
     let updater = RangeUpdater::<H>::new(root, shared.clone(), write_pass, &page_cache);
 


### PR DESCRIPTION
The motivation here is to avoid specifying whether merklization will target an overlay or not at the beginning of a session. This frees up more changes to the API later.
