### PR TITLE
refactor: rework session API

### DIFF
--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Result};
 use futures::SinkExt as _;
-use nomt::{Blake3Hasher, Nomt};
+use nomt::{Blake3Hasher, Nomt, SessionParams};
 use std::future::Future;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::{
@@ -250,7 +250,7 @@ impl Agent {
     }
 
     async fn commit(&mut self, changeset: Vec<KeyValueChange>) -> Result<()> {
-        let session = self.nomt.begin_session();
+        let session = self.nomt.begin_session(SessionParams::default());
         let mut actuals = Vec::with_capacity(changeset.len());
         for change in changeset {
             match change {
@@ -263,7 +263,10 @@ impl Agent {
             }
         }
 
-        tokio::task::block_in_place(|| self.nomt.update_and_commit(session, actuals))?;
+        tokio::task::block_in_place(|| {
+            let finished = self.nomt.finish_session(session, actuals);
+            self.nomt.commit_finished(finished)
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
This is a first stab at reworking the API of NOMT. For initial review and as a base for discussion.

Motivation:
  1. Future-proofing. We should be able to add more parameters to commits and sessions without causing a breakage.
  2. Limit combinatorial explosion of options. `update`/`commit`/`prove` led to 4 separate functions on NOMT for all their combinations. Adding additional variants would have caused a further explosion.
  3. Allow multiple sessions to exist. Now that the page cache only reflects the on-disk state, there is no reason not to have multiple sessions existing at once, as long as there is only ever a single writer.

Limitations of this PR:
  - splitting `finish_session` and `commit_finished` is a bit clunky.
  - needs a locking scheme to make writes safe
  - needs a check to ensure that commits are always sequential (we should maybe use the previous root for this purpose)
