### PR TITLE
refactor: introduce Root type for public API

### DIFF
--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use nomt::{
-    Blake3Hasher, KeyReadWrite, Node, Nomt, Options, SessionParams, Witness, WitnessMode,
+    Blake3Hasher, KeyReadWrite, Nomt, Options, Root, SessionParams, Witness, WitnessMode,
     WitnessedOperations,
 };
 use sha2::Digest;
@@ -10,7 +10,7 @@ const NOMT_DB_FOLDER: &str = "nomt_db";
 pub struct NomtDB;
 
 impl NomtDB {
-    pub fn commit_batch() -> Result<(Node, Node, Witness, WitnessedOperations)> {
+    pub fn commit_batch() -> Result<(Root, Root, Witness, WitnessedOperations)> {
         // Define the options used to open NOMT
         let mut opts = Options::new();
         opts.path(NOMT_DB_FOLDER);

--- a/examples/witness_verification/src/main.rs
+++ b/examples/witness_verification/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
         // Constructing the verified operations
         let verified = witnessed_path
             .inner
-            .verify::<Blake3Hasher>(&witnessed_path.path.path(), prev_root)
+            .verify::<Blake3Hasher>(&witnessed_path.path.path(), prev_root.into_inner())
             .unwrap();
 
         // Among all read operations performed the ones that interact
@@ -86,8 +86,8 @@ fn main() -> Result<()> {
     }
 
     assert_eq!(
-        proof::verify_update::<Blake3Hasher>(prev_root, &updates).unwrap(),
-        new_root,
+        proof::verify_update::<Blake3Hasher>(prev_root.into_inner(), &updates).unwrap(),
+        new_root.into_inner(),
     );
 
     Ok(())

--- a/nomt/src/overlay.rs
+++ b/nomt/src/overlay.rs
@@ -17,7 +17,7 @@
 //! Creating a new overlay is an O(n) operation in the amount of changes relative to the parent,
 //! both in terms of new changes and outdated ancestors.
 
-use crate::{beatree::ValueChange, store::DirtyPage};
+use crate::{beatree::ValueChange, store::DirtyPage, Root};
 use nomt_core::{
     page_id::PageId,
     trie::{KeyPath, Node},
@@ -36,8 +36,8 @@ pub struct Overlay {
 
 impl Overlay {
     /// Get the merkle root at this overlay.
-    pub fn root(&self) -> Node {
-        self.inner.root
+    pub fn root(&self) -> Root {
+        Root(self.inner.root)
     }
 
     /// Check whether the parent of this overlay matches the provided marker.

--- a/nomt/tests/add_remove.rs
+++ b/nomt/tests/add_remove.rs
@@ -31,7 +31,7 @@ fn add_remove_1000() {
             accounts += 1;
         }
         {
-            root = t.commit().0;
+            root = t.commit().0.into_inner();
         }
 
         assert_eq!(root, common::expected_root(accounts));
@@ -46,7 +46,7 @@ fn add_remove_1000() {
             common::kill(&mut t, accounts);
         }
         {
-            root = t.commit().0;
+            root = t.commit().0.into_inner();
         }
 
         assert_eq!(root, common::expected_root(accounts));

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use nomt::{
-    KeyPath, KeyReadWrite, Node, Nomt, Options, Overlay, PanicOnSyncMode, Session, SessionParams,
-    Witness, WitnessMode, WitnessedOperations,
+    KeyPath, KeyReadWrite, Node, Nomt, Options, Overlay, PanicOnSyncMode, Root, Session,
+    SessionParams, Witness, WitnessMode, WitnessedOperations,
 };
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -116,7 +116,7 @@ impl Test {
         }
     }
 
-    pub fn commit(&mut self) -> (Node, Witness, WitnessedOperations) {
+    pub fn commit(&mut self) -> (Root, Witness, WitnessedOperations) {
         let session = mem::take(&mut self.session).unwrap();
         let mut actual_access: Vec<_> = mem::take(&mut self.access).into_iter().collect();
         actual_access.sort_by_key(|(k, _)| *k);
@@ -168,7 +168,7 @@ impl Test {
         self.session = Some(self.nomt.begin_session(params));
     }
 
-    pub fn root(&self) -> Node {
+    pub fn root(&self) -> Root {
         self.nomt.root()
     }
 }

--- a/nomt/tests/compute_root.rs
+++ b/nomt/tests/compute_root.rs
@@ -7,7 +7,7 @@ use nomt::NodeKind;
 fn root_on_empty_db() {
     let t = Test::new("compute_root_empty");
     let root = t.root();
-    assert_eq!(NodeKind::of(&root), NodeKind::Terminator);
+    assert_eq!(NodeKind::of(&root.into_inner()), NodeKind::Terminator);
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn root_on_leaf() {
 
     let t = Test::new_with_params("compute_root_leaf", 1, 1, None, false);
     let root = t.root();
-    assert_eq!(NodeKind::of(&root), NodeKind::Leaf);
+    assert_eq!(NodeKind::of(&root.into_inner()), NodeKind::Leaf);
 }
 
 #[test]
@@ -34,5 +34,5 @@ fn root_on_internal() {
 
     let t = Test::new_with_params("compute_root_internal", 1, 1, None, false);
     let root = t.root();
-    assert_eq!(NodeKind::of(&root), NodeKind::Internal);
+    assert_eq!(NodeKind::of(&root.into_inner()), NodeKind::Internal);
 }

--- a/nomt/tests/fill_and_empty.rs
+++ b/nomt/tests/fill_and_empty.rs
@@ -72,7 +72,7 @@ fn fill_and_empty(seed: [u8; 16], commit_concurrency: usize) {
         }
     }
 
-    assert_eq!([0; 32], t.commit().0);
+    assert!(t.commit().0.is_empty());
 }
 
 fn rand_key(rng: &mut impl Rng) -> [u8; 32] {

--- a/nomt/tests/overlay.rs
+++ b/nomt/tests/overlay.rs
@@ -46,7 +46,7 @@ fn overlay_root_calculation() {
     let overlay_a = test.update().0;
 
     assert_eq!(
-        overlay_a.root(),
+        overlay_a.root().into_inner(),
         expected_root(vec![([1; 32], vec![1, 2, 3])]),
     );
 
@@ -55,7 +55,7 @@ fn overlay_root_calculation() {
     let overlay_b = test.update().0;
 
     assert_eq!(
-        overlay_b.root(),
+        overlay_b.root().into_inner(),
         expected_root(vec![([1; 32], vec![1, 2, 3]), ([2; 32], vec![4, 5, 6])]),
     );
 
@@ -65,7 +65,7 @@ fn overlay_root_calculation() {
     let overlay_c = test.update().0;
 
     assert_eq!(
-        overlay_c.root(),
+        overlay_c.root().into_inner(),
         expected_root(vec![
             ([1; 32], vec![7, 8, 9]),
             ([2; 32], vec![4, 5, 6]),

--- a/nomt/tests/rollback.rs
+++ b/nomt/tests/rollback.rs
@@ -74,14 +74,14 @@ fn test_rollback_to_initial() {
     nomt.commit_finished(finished).unwrap();
 
     assert_eq!(
-        nomt.root(),
+        nomt.root().into_inner(),
         hex!("c6e25744545ddabdaf0a95201f8285e670ee9b3e0c1ced4a3006baafd1ac2fdf")
     );
 
     let result = nomt.rollback(1);
     assert!(result.is_ok());
     assert_eq!(
-        nomt.root(),
+        nomt.root().into_inner(),
         hex!("0000000000000000000000000000000000000000000000000000000000000000")
     );
 }
@@ -193,7 +193,7 @@ impl TestPlan {
             let finished = nomt.finish_session(session, operations);
             nomt.commit_finished(finished).unwrap();
             let post_root = nomt.root();
-            expected_roots.push(post_root);
+            expected_roots.push(post_root.into_inner());
         }
 
         Self {
@@ -261,11 +261,11 @@ impl TestPlan {
             }
         }
 
-        if nomt.root() != self.expected_roots[commit_ix] {
+        if nomt.root().into_inner() != self.expected_roots[commit_ix] {
             errors.push(format!(
-                "wrong root: expected {:x?}, found {:x?}",
+                "wrong root: expected {:x?}, found {}",
                 hex::encode(self.expected_roots[commit_ix]),
-                hex::encode(nomt.root())
+                hex::encode(nomt.root().into_inner())
             ));
         }
 

--- a/nomt/tests/witness_check.rs
+++ b/nomt/tests/witness_check.rs
@@ -47,7 +47,7 @@ fn produced_witness_validity() {
     for (i, witnessed_path) in witness.path_proofs.iter().enumerate() {
         let verified = witnessed_path
             .inner
-            .verify::<Blake3Hasher>(&witnessed_path.path.path(), prev_root)
+            .verify::<Blake3Hasher>(&witnessed_path.path.path(), prev_root.into_inner())
             .unwrap();
         for read in witnessed
             .reads
@@ -86,7 +86,7 @@ fn produced_witness_validity() {
     }
 
     assert_eq!(
-        proof::verify_update::<Blake3Hasher>(prev_root, &updates).unwrap(),
-        new_root,
+        proof::verify_update::<Blake3Hasher>(prev_root.into_inner(), &updates).unwrap(),
+        new_root.into_inner(),
     );
 }


### PR DESCRIPTION
This introduces a newtype for the root of the trie for the public API. It comes with pretty-printing and the `is_empty` utility function. 
