### PR TITLE
feat: poison

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -311,6 +311,19 @@ impl<T: HashAlgorithm> Nomt<T> {
         self.store.sync_seqn()
     }
 
+    /// Whether the database is poisoned.
+    ///
+    /// A database becomes poisoned when an error occurred during a commit operation.
+    ///
+    /// From this point on, the database is in an inconsistent state and should be considered
+    /// read-only. Any further modifying operations will return an error.
+    ///
+    /// In order to recover from a poisoned database, the application should discard this instance
+    /// and create a new one.
+    pub fn is_poisoned(&self) -> bool {
+        self.store.is_poisoned()
+    }
+
     /// Create a new [`Session`] object with the given parameters.
     ///
     /// The [`Session`] is a read-only handle on the database and is used to create a changeset to

--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -51,9 +51,8 @@ impl Sync {
             rollback.begin_sync();
         }
 
-        // TODO: comprehensive error handling is coming later.
-        bitbox_sync.wait_pre_meta().unwrap();
-        let beatree_meta_wd = beatree_sync.wait_pre_meta().unwrap();
+        bitbox_sync.wait_pre_meta()?;
+        let beatree_meta_wd = beatree_sync.wait_pre_meta()?;
         let (rollback_start_live, rollback_end_live) = match rollback_sync {
             Some(ref rollback) => rollback.wait_pre_meta(),
             None => (0, 0),
@@ -90,8 +89,7 @@ impl Sync {
         beatree_sync.post_meta();
 
         if let Some(ref rollback) = rollback_sync {
-            // TODO: comprehensive error handling is coming later.
-            rollback.wait_post_meta().unwrap();
+            rollback.wait_post_meta()?;
         }
 
         Ok(())


### PR DESCRIPTION
In case the database encounters an IO error during the commit, there
will be some intermediate partial changes to the database.

It is possible to recover from them, however, in the interest of
reducing complexity, we mark the database as poisoned and reject any
further modification attempts. That allows NOMT to avoid spreading the
recovery logic all around but concentrate it in the startup logic.