### PR TITLE
chore: migrate lower-level components to io err

### DIFF
--- a/nomt/src/beatree/mod.rs
+++ b/nomt/src/beatree/mod.rs
@@ -457,7 +457,7 @@ impl SyncController {
     /// with updating the manifest.
     ///
     /// This must be called after [`Self::begin_sync`].
-    pub fn wait_pre_meta(&mut self) -> anyhow::Result<SyncData> {
+    pub fn wait_pre_meta(&mut self) -> std::io::Result<SyncData> {
         self.inner.sync.bbn_fsync.wait()?;
         self.inner.sync.ln_fsync.wait()?;
 

--- a/nomt/src/bitbox/writeout.rs
+++ b/nomt/src/bitbox/writeout.rs
@@ -14,7 +14,7 @@ use std::{
 
 use crate::io::{FatPage, IoCommand, IoHandle, IoKind};
 
-pub(super) fn write_wal(mut wal_fd: &File, wal_blob: &[u8]) -> anyhow::Result<()> {
+pub(super) fn write_wal(mut wal_fd: &File, wal_blob: &[u8]) -> std::io::Result<()> {
     wal_fd.set_len(0)?;
     wal_fd.seek(SeekFrom::Start(0))?;
     wal_fd.write_all(wal_blob)?;
@@ -25,7 +25,7 @@ pub(super) fn write_wal(mut wal_fd: &File, wal_blob: &[u8]) -> anyhow::Result<()
 /// Truncates the WAL file to zero length.
 ///
 /// Conditionally syncs the file to disk.
-pub(super) fn truncate_wal(mut wal_fd: &File, do_sync: bool) -> anyhow::Result<()> {
+pub(super) fn truncate_wal(mut wal_fd: &File, do_sync: bool) -> std::io::Result<()> {
     wal_fd.set_len(0)?;
     wal_fd.seek(SeekFrom::Start(0))?;
     if do_sync {
@@ -38,7 +38,7 @@ pub(super) fn write_ht(
     io_handle: IoHandle,
     ht_fd: &File,
     mut ht: Vec<(u64, Arc<FatPage>)>,
-) -> anyhow::Result<()> {
+) -> std::io::Result<()> {
     let mut sent = 0;
 
     ht.sort_unstable_by_key(|item| item.0);

--- a/nomt/src/rollback/mod.rs
+++ b/nomt/src/rollback/mod.rs
@@ -262,7 +262,7 @@ impl Rollback {
         &self,
         new_start_live: Option<u64>,
         new_end_live: Option<u64>,
-    ) -> anyhow::Result<()> {
+    ) -> std::io::Result<()> {
         if let Some(new_start_live) = new_start_live {
             let mut seglog = self.shared.seglog.lock();
             seglog.prune_back(new_start_live.into())?;
@@ -279,7 +279,7 @@ pub struct SyncController {
     rollback: Rollback,
     wd: Arc<Mutex<Option<WriteoutData>>>,
     wd_cv: Arc<Condvar>,
-    post_meta: Arc<Mutex<Option<anyhow::Result<()>>>>,
+    post_meta: Arc<Mutex<Option<std::io::Result<()>>>>,
     post_meta_cv: Arc<Condvar>,
 }
 
@@ -343,7 +343,7 @@ impl SyncController {
     }
 
     /// Wait until the post-meta writeout completes.
-    pub fn wait_post_meta(&self) -> anyhow::Result<()> {
+    pub fn wait_post_meta(&self) -> std::io::Result<()> {
         let mut post_meta = self.post_meta.lock();
         self.post_meta_cv
             .wait_while(&mut post_meta, |post_meta| post_meta.is_none());

--- a/nomt/src/store/meta.rs
+++ b/nomt/src/store/meta.rs
@@ -137,13 +137,13 @@ impl Meta {
         }
     }
 
-    pub fn read(page_pool: &PagePool, fd: &File) -> Result<Self> {
+    pub fn read(page_pool: &PagePool, fd: &File) -> std::io::Result<Self> {
         let page = io::read_page(page_pool, fd, 0)?;
         let meta = Meta::decode(&page[..META_SIZE]);
         Ok(meta)
     }
 
-    pub fn write(page_pool: &PagePool, fd: &File, meta: &Meta) -> Result<()> {
+    pub fn write(page_pool: &PagePool, fd: &File, meta: &Meta) -> std::io::Result<()> {
         let mut page = page_pool.alloc_fat_page();
         meta.encode_to(&mut page.as_mut()[..META_SIZE]);
         fd.write_all_at(&page[..], 0)?;

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -306,7 +306,7 @@ impl Store {
             self.shared
                 .poisoned
                 .store(true, std::sync::atomic::Ordering::Relaxed);
-            return Err(e);
+            anyhow::bail!(e);
         }
         Ok(())
     }

--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -37,7 +37,7 @@ impl Sync {
         rollback: Option<rollback::Rollback>,
         page_cache: PageCache,
         updated_pages: impl IntoIterator<Item = (PageId, DirtyPage)> + Send + 'static,
-    ) -> anyhow::Result<()> {
+    ) -> std::io::Result<()> {
         self.sync_seqn += 1;
         let sync_seqn = self.sync_seqn;
 


### PR DESCRIPTION
This reduces the scope of errors that could be thrown by the components
deliberately.