### PR TITLE
fix: extend range, do not respond during merge

### DIFF
--- a/nomt/src/beatree/ops/update/branch_stage.rs
+++ b/nomt/src/beatree/ops/update/branch_stage.rs
@@ -309,22 +309,29 @@ fn run_worker(
 
     for (key, op) in &changeset[worker_params.op_range.clone()] {
         // ensure key is in scope for branch updater. if not, digest it. merge rightwards until
-        //    done _or_ key is in scope.
+        // done _or_ key is in scope.
         while !branch_updater.is_in_scope(&key) {
+            // After `digest`, some changed items could have been produced and they could be used
+            // to respond to the left neighbor. However, we should only respond if we are sure that
+            // we will not introduce changed items with smaller separators later on.
             let k = if let BranchDigestResult::NeedsMerge(cutoff) =
                 branch_updater.digest(&mut new_branch_state)
             {
+                // If we are dealing with a NeedsMerge, there is a high probability that the `branch_updater`
+                // has a new pending branch which still needs to be constructed with a separator smaller
+                // than the last entry in the `leaves_tracker`.
                 cutoff
             } else {
+                // If the `branch_updater` has finished the last digest, we are safe to try to respond.
+                try_answer_left_neighbor(
+                    &mut pending_left_request,
+                    &mut worker_params,
+                    &mut new_branch_state.branches_tracker,
+                    has_finished_workload,
+                );
+
                 *key
             };
-
-            try_answer_left_neighbor(
-                &mut pending_left_request,
-                &mut worker_params,
-                &mut new_branch_state.branches_tracker,
-                has_finished_workload,
-            );
 
             has_extended_range = false;
             if worker_params.range.high.map_or(false, |high| k >= high) {
@@ -346,13 +353,6 @@ fn run_worker(
 
     while let BranchDigestResult::NeedsMerge(cutoff) = branch_updater.digest(&mut new_branch_state)
     {
-        try_answer_left_neighbor(
-            &mut pending_left_request,
-            &mut worker_params,
-            &mut new_branch_state.branches_tracker,
-            has_finished_workload,
-        );
-
         has_extended_range = false;
         if worker_params
             .range


### PR DESCRIPTION
If the leaf or branch updater just returned a `NeedsMerge`
do not try to answer within the range extension protocol.