### PR TITLE
feat: warm_up thread propagates errors

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -609,7 +609,7 @@ impl<T: HashAlgorithm> Session<T> {
 
         let merkle_update_handle = self
             .merkle_updater
-            .update_and_prove::<T>(compact_actuals, self.witness_mode.0);
+            .update_and_prove::<T>(compact_actuals, self.witness_mode.0)?;
 
         let mut tx = self.store.new_value_tx();
         for (path, read_write) in actuals {

--- a/nomt/src/store/mod.rs
+++ b/nomt/src/store/mod.rs
@@ -231,7 +231,7 @@ impl Store {
         let io_handle = self.io_pool().make_handle();
         let mut page_load = page_loader.start_load(page_id);
         loop {
-            if !page_loader.probe(&mut page_load, &io_handle, 0)? {
+            if !page_loader.probe(&mut page_load, &io_handle, 0) {
                 return Ok(None);
             }
 

--- a/nomt/src/store/page_loader.rs
+++ b/nomt/src/store/page_loader.rs
@@ -14,18 +14,12 @@ impl PageLoader {
     }
 
     /// Advance the state of the given page load, blocking the current thread.
-    /// Fails if the I/O pool is down.
     ///
-    /// Panics if the page load needs a completion.
+    /// Panics if the page load needs a completion or if the I/O pool is down.
     ///
-    /// This returns `Ok(true)` if the page request has been submitted and a completion will be
-    /// coming. `Ok(false)` means that the page is guaranteed to be fresh.
-    pub fn probe(
-        &self,
-        load: &mut PageLoad,
-        io_handle: &IoHandle,
-        user_data: u64,
-    ) -> anyhow::Result<bool> {
+    /// This returns `true` if the page request has been submitted and a completion will be
+    /// coming. `false` means that the page is guaranteed to be fresh.
+    pub fn probe(&self, load: &mut PageLoad, io_handle: &IoHandle, user_data: u64) -> bool {
         self.inner.probe(load, io_handle, user_data)
     }
 }


### PR DESCRIPTION
Also include some changes to ensure that every I/O error
is correctly propagated, while everything else causes a panic.