### PR TITLE
fix(torture): handle poisoning

### DIFF
--- a/torture/src/logging.rs
+++ b/torture/src/logging.rs
@@ -76,7 +76,7 @@ pub fn init_supervisor() {
         .expect("Failed to set supervisor subscriber");
 }
 
-pub fn init_agent(agent_id: &str, workdir: &Path) {
+pub fn init_agent(agent_id: &str, workdir: &impl AsRef<Path>) {
     // Console layer with ANSI colors
     let console_layer = fmt::layer()
         .with_writer(io::stdout)
@@ -98,7 +98,7 @@ pub fn init_agent(agent_id: &str, workdir: &Path) {
     let file = std::fs::File::options()
         .create(true)
         .append(true)
-        .open(workdir.join("agent.log"))
+        .open(workdir.as_ref().join("agent.log"))
         .unwrap();
 
     // TODO: this has an issue currently. While the ANSI is false the colors are not disabled


### PR DESCRIPTION
when the database gets ENOSPC it becomes poisoned and it is required to
recreate it in order to perform further changes to the database.

this commit does that.

To get there, it was necessary to split initing of the agent (happens at
most once per agent process) from opening a NOMT instance (can happen
multiple times). Note that opening carries the fields such as
`bitbox_seed` and `rollback` which might not be useful each time. This
is by design, because we might want to test what happens if you do
change it from open to open.