### PR TITLE
refactor: put node hasher in charge of labeling nodes and determining kinds

### DIFF
--- a/benchtop/src/nomt.rs
+++ b/benchtop/src/nomt.rs
@@ -1,7 +1,7 @@
 use crate::{backend::Transaction, timer::Timer, workload::Workload};
 use fxhash::FxHashMap;
 use nomt::{
-    Blake3Hasher, KeyPath, KeyReadWrite, Nomt, Options, Overlay, Session, SessionParams,
+    trie::KeyPath, Blake3Hasher, KeyReadWrite, Nomt, Options, Overlay, Session, SessionParams,
     WitnessMode,
 };
 use sha2::Digest;

--- a/core/src/proof/path_proof.rs
+++ b/core/src/proof/path_proof.rs
@@ -1,8 +1,6 @@
 //! Proving and verifying inclusion, non-inclusion, and updates to the trie.
 
-use crate::trie::{
-    self, InternalData, KeyPath, LeafData, Node, NodeHasher, NodeHasherExt, NodeKind, TERMINATOR,
-};
+use crate::trie::{self, InternalData, KeyPath, LeafData, Node, NodeHasher, NodeKind, TERMINATOR};
 use crate::trie_pos::TriePosition;
 
 use bitvec::prelude::*;
@@ -295,7 +293,7 @@ pub fn verify_update<H: NodeHasher>(
                 *sibling
             };
 
-            match (NodeKind::of(&cur_node), NodeKind::of(&sibling)) {
+            match (NodeKind::of::<H>(&cur_node), NodeKind::of::<H>(&sibling)) {
                 (NodeKind::Terminator, NodeKind::Terminator) => {}
                 (NodeKind::Leaf, NodeKind::Terminator) => {}
                 (NodeKind::Terminator, NodeKind::Leaf) => {

--- a/fuzz/fuzz_targets/api_surface.rs
+++ b/fuzz/fuzz_targets/api_surface.rs
@@ -5,7 +5,9 @@ use std::collections::{HashMap, HashSet};
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 
-use nomt::{Blake3Hasher, KeyPath, KeyReadWrite, Nomt, Options, SessionParams, Value, WitnessMode};
+use nomt::{
+    trie::KeyPath, Blake3Hasher, KeyReadWrite, Nomt, Options, SessionParams, Value, WitnessMode,
+};
 
 fuzz_target!(|run: Run| {
     let db = open_db(run.commit_concurrency);

--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -46,7 +46,7 @@ use bitvec::prelude::*;
 use nomt_core::{
     page::DEPTH,
     page_id::{PageId, ROOT_PAGE_ID},
-    trie::{self, KeyPath, Node, NodeHasher, NodeHasherExt, NodeKind, ValueHash, TERMINATOR},
+    trie::{self, KeyPath, Node, NodeHasher, NodeKind, ValueHash, TERMINATOR},
     trie_pos::TriePosition,
     update::WriteNode,
 };
@@ -230,7 +230,7 @@ impl<H: NodeHasher> PageWalker<H> {
 
         self.prev_node = Some(node);
 
-        assert!(!trie::is_internal(&node));
+        assert!(!trie::is_internal::<H>(&node));
 
         let start_position = self.position.clone();
 
@@ -247,9 +247,9 @@ impl<H: NodeHasher> PageWalker<H> {
                 // we assume pages are not necessarily zeroed. therefore, there might be
                 // some garbage in the sibling slot we need to clear out.
                 let zero_sibling = if self.position.peek_last_bit() {
-                    trie::is_terminator(&internal_data.left)
+                    trie::is_terminator::<H>(&internal_data.left)
                 } else {
-                    trie::is_terminator(&internal_data.right)
+                    trie::is_terminator::<H>(&internal_data.right)
                 };
 
                 if zero_sibling {
@@ -454,7 +454,7 @@ impl<H: NodeHasher> PageWalker<H> {
         let sibling = self.sibling_node();
         let bit = self.position.peek_last_bit();
 
-        match (NodeKind::of(&node), NodeKind::of(&sibling)) {
+        match (NodeKind::of::<H>(&node), NodeKind::of::<H>(&sibling)) {
             (NodeKind::Terminator, NodeKind::Terminator) => {
                 // compact terminators.
                 trie::TERMINATOR
@@ -602,8 +602,8 @@ impl<H: NodeHasher> PageWalker<H> {
 #[cfg(test)]
 mod tests {
     use super::{
-        trie, BucketInfo, Node, NodeHasherExt, Output, PageSet, PageWalker, TriePosition,
-        UpdatedPage, ROOT_PAGE_ID,
+        trie, BucketInfo, Node, NodeHasher, Output, PageSet, PageWalker, TriePosition, UpdatedPage,
+        ROOT_PAGE_ID,
     };
     use crate::{
         io::PagePool,

--- a/nomt/src/merkle/seek.rs
+++ b/nomt/src/merkle/seek.rs
@@ -47,9 +47,9 @@ impl SeekRequest {
         key: KeyPath,
         root: Node,
     ) -> SeekRequest {
-        let state = if trie::is_terminator(&root) {
+        let state = if trie::is_terminator::<H>(&root) {
             RequestState::Completed(None)
-        } else if trie::is_leaf(&root) {
+        } else if trie::is_leaf::<H>(&root) {
             RequestState::begin_leaf_fetch::<H>(read_transaction, overlay, &TriePosition::new())
         } else {
             RequestState::Seeking
@@ -133,14 +133,14 @@ impl SeekRequest {
                 self.siblings.push(page.node(self.position.sibling_index()));
             }
 
-            if trie::is_leaf(&cur_node) {
+            if trie::is_leaf::<H>(&cur_node) {
                 self.state =
                     RequestState::begin_leaf_fetch::<H>(read_transaction, overlay, &self.position);
                 if let RequestState::FetchingLeaf(_, _) = self.state {
                     do_leaf_fetch = true;
                 }
                 break;
-            } else if trie::is_terminator(&cur_node) {
+            } else if trie::is_terminator::<H>(&cur_node) {
                 self.state = RequestState::Completed(None);
                 return;
             }

--- a/nomt/tests/add_remove.rs
+++ b/nomt/tests/add_remove.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::Test;
 use hex_literal::hex;
-use nomt::Node;
+use nomt::trie::Node;
 
 #[test]
 fn add_remove_1000() {

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -1,6 +1,7 @@
 use nomt::{
-    KeyPath, KeyReadWrite, Node, Nomt, Options, Overlay, PanicOnSyncMode, Root, Session,
-    SessionParams, Witness, WitnessMode,
+    trie::{KeyPath, Node},
+    KeyReadWrite, Nomt, Options, Overlay, PanicOnSyncMode, Root, Session, SessionParams, Witness,
+    WitnessMode,
 };
 use std::{
     collections::{hash_map::Entry, HashMap},

--- a/nomt/tests/compute_root.rs
+++ b/nomt/tests/compute_root.rs
@@ -1,13 +1,16 @@
 mod common;
 
 use common::Test;
-use nomt::NodeKind;
+use nomt::{trie::NodeKind, Blake3Hasher};
 
 #[test]
 fn root_on_empty_db() {
     let t = Test::new("compute_root_empty");
     let root = t.root();
-    assert_eq!(NodeKind::of(&root.into_inner()), NodeKind::Terminator);
+    assert_eq!(
+        NodeKind::of::<Blake3Hasher>(&root.into_inner()),
+        NodeKind::Terminator
+    );
 }
 
 #[test]
@@ -20,7 +23,10 @@ fn root_on_leaf() {
 
     let t = Test::new_with_params("compute_root_leaf", 1, 1, None, false);
     let root = t.root();
-    assert_eq!(NodeKind::of(&root.into_inner()), NodeKind::Leaf);
+    assert_eq!(
+        NodeKind::of::<Blake3Hasher>(&root.into_inner()),
+        NodeKind::Leaf
+    );
 }
 
 #[test]
@@ -34,5 +40,8 @@ fn root_on_internal() {
 
     let t = Test::new_with_params("compute_root_internal", 1, 1, None, false);
     let root = t.root();
-    assert_eq!(NodeKind::of(&root.into_inner()), NodeKind::Internal);
+    assert_eq!(
+        NodeKind::of::<Blake3Hasher>(&root.into_inner()),
+        NodeKind::Internal
+    );
 }

--- a/nomt/tests/rollback.rs
+++ b/nomt/tests/rollback.rs
@@ -1,5 +1,5 @@
 use hex_literal::hex;
-use nomt::{Blake3Hasher, KeyPath, KeyReadWrite, Nomt, Options, SessionParams, Value};
+use nomt::{trie::KeyPath, Blake3Hasher, KeyReadWrite, Nomt, Options, SessionParams, Value};
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::PathBuf,

--- a/nomt/tests/witness_check.rs
+++ b/nomt/tests/witness_check.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::Test;
-use nomt::{proof, Blake3Hasher, LeafData};
+use nomt::{proof, trie::LeafData, Blake3Hasher};
 
 #[test]
 fn produced_witness_validity() {


### PR DESCRIPTION
1. Export a couple more things from the NOMT crate root that make it possible to implement a NodeHasher
2. Make determining the node kind a function of the NodeHasher, and give the NodeHasher the responsibility of labeling nodes.
