### PR TITLE
draft: poseidon2 (plonky3) integration in benchtop

### DIFF
--- a/benchtop/Cargo.lock
+++ b/benchtop/Cargo.lock
@@ -480,10 +480,15 @@ dependencies = [
  "jmt",
  "kvdb",
  "kvdb-rocksdb",
+ "lazy_static",
  "libc",
  "lru",
  "nomt",
+ "p3-field",
+ "p3-koala-bear",
+ "p3-symmetric",
  "rand",
+ "rand_chacha",
  "rand_distr",
  "rayon",
  "ruint",
@@ -1483,6 +1488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+
+[[package]]
 name = "generator"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -2290,6 +2310,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -2324,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -2340,6 +2361,18 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "nums"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3c74f925fb8cfc49a8022f2afce48a0683b70f9e439885594e84c5edbf5b01"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -2380,6 +2413,135 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p3-dft"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "nums",
+ "p3-maybe-rayon",
+ "p3-util",
+ "rand",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-koala-bear"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "p3-field",
+ "p3-mds",
+ "p3-monty-31",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
+ "rand",
+ "serde",
+ "tracing",
+ "transpose",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+
+[[package]]
+name = "p3-mds"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
+ "rand",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "itertools 0.14.0",
+ "num-bigint",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
+ "rand",
+ "serde",
+ "tracing",
+ "transpose",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "gcd",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "rand",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.1.0"
+source = "git+https://github.com/plonky3/plonky3#95f9774c435a629a7331d4fbabdb3f5a2b300de0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "parity-bip39"
@@ -3908,6 +4070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4275,6 +4443,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/benchtop/Cargo.toml
+++ b/benchtop/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { version = "1.0.75" }
 hdrhistogram = "7.5.4"
 fxhash = "0.2.1"
 rand = "0.8.5"
+rand_chacha = "0.3.1"
 rand_distr = "0.4.3"
 sha2 = { version = "0.10.6" }
 ruint = { version = "1.12.1" }
@@ -24,6 +25,7 @@ humantime = "2.1.0"
 rayon = "1.10"
 lru = "0.12.5"
 libc = "0.2.155"
+lazy_static = "1.5"
 
 # sov-db
 sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk", optional = true }
@@ -40,6 +42,11 @@ sp-core = { version = "31.0.0", optional = true }
 kvdb = { version = "0.13.0", optional = true }
 kvdb-rocksdb = { version = "0.19.0", optional = true }
 array-bytes = { version = "6.1", optional = true }
+
+# plonky3
+p3-field = { git = "https://github.com/plonky3/plonky3" }
+p3-koala-bear = { git = "https://github.com/plonky3/plonky3" }
+p3-symmetric = { git = "https://github.com/plonky3/plonky3" }
 
 # nomt
 nomt = { path = "../nomt" }


### PR DESCRIPTION
I'm opening this PR as a placeholder, but it was interesting to integrate Poseidon2 with NOMT.

This creates a custom Poseidon2 hasher for nodes and uses the Legendre Symbol (Residue/Non-Residue)
rather than the MSB of the hash to indicate leaf/internal nodes.

This is not optimized at all but still comfortably achieves 40k+ TPS on a benchmark with 2^25 items.

Hashes are of the form `[KoalaBear; 8]`. I convert blake3 value hashes into this type by taking each 32-bit word modulo the KoalaBear prime. 

Key-paths are treated specially. Because NOMT internals require that the key-path is encoded as a bit-string, I instead limited the length of the key-path to 240 bits and treat them as 8 densely packed 30-bit limbs. i.e. a KeyPath is a `[KoalaBear; 8]` where none of the field elements (when treated as a 32-bit number) use more than 30 bits, and which are densely packed into the `[u8; 256]`
