### PR TITLE
opt: [BREAKING] use twox_64 for bucket hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "tempfile",
  "thread_local",
  "threadpool",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1903,6 +1904,15 @@ dependencies = [
  "env_logger 0.11.6",
  "log",
  "trickfs",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/benchtop/Cargo.lock
+++ b/benchtop/Cargo.lock
@@ -2239,7 +2239,6 @@ dependencies = [
  "ahash 0.8.11",
  "anyhow",
  "bitvec",
- "blake3",
  "cfg-if",
  "crossbeam",
  "crossbeam-channel",
@@ -2256,6 +2255,7 @@ dependencies = [
  "slab",
  "thread_local",
  "threadpool",
+ "twox-hash 2.1.0",
 ]
 
 [[package]]
@@ -3607,7 +3607,7 @@ dependencies = [
  "digest 0.10.7",
  "sha2 0.10.8",
  "sha3",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -3621,7 +3621,7 @@ dependencies = [
  "digest 0.10.7",
  "sha2 0.10.8",
  "sha3",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -4309,6 +4309,15 @@ dependencies = [
  "digest 0.10.7",
  "rand",
  "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -16,7 +16,7 @@ nomt-core = { path = "../core", default-features = false, features = ["std"] }
 parking_lot = { version = "0.12.3", features = ["arc_lock", "send_guard"] }
 threadpool = "1.8.1"
 bitvec = { version = "1" }
-blake3 = "1.5.1"
+twox-hash = "2.1.0"
 fxhash = "0.2.1"
 dashmap = "5.5.3"
 crossbeam = "0.8.4"
@@ -46,6 +46,7 @@ criterion = "0.3"
 lazy_static = "1.5.0"
 hex = "0.4.3"
 quickcheck = "1.0.3"
+blake3 = "1.5.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -680,12 +680,9 @@ fn hash_page_id(page_id: &PageId, seed: &[u8; 16]) -> u64 {
 }
 
 fn hash_raw_page_id(page_id: [u8; 32], seed: &[u8; 16]) -> u64 {
-    let mut buf = [0u8; 8];
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(&page_id);
-    hasher.update(&seed[..]);
-    buf.copy_from_slice(&hasher.finalize().as_bytes()[..8]);
-    u64::from_le_bytes(buf)
+    // UNWRAP: 8 byte slice can always be transformed into 8 byte array.
+    let seed_u64 = u64::from_be_bytes(seed[..8].try_into().unwrap());
+    twox_hash::xxhash3_64::Hasher::oneshot_with_seed(seed_u64, &page_id)
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
A seeded twox is suitable for this purpose - each node will have its own map. While it may be possible to convince publicly-accessible RPC nodes to leak information that enables a HashDoS, it seems unlikely for sequencers to leak it. 

Furthermore, the complexity of such an attack is limited by the fact that the inputs are Page IDs. In order to write to a particular page ID, the attacker would first need to create accounts (against a cryptographic hash function) that land in those pages. 

Computing the blake3 hash of each written bucket was quite CPU-intensive, and so using twox ought to be much faster.
