### PR TITLE
feat: add `spawn_task` and `join_task` utilities

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -49,6 +49,7 @@ mod rw_pass_cell;
 mod seglog;
 mod store;
 mod sys;
+mod task;
 
 mod io;
 

--- a/nomt/src/task.rs
+++ b/nomt/src/task.rs
@@ -1,0 +1,36 @@
+pub type TaskResult<R> = std::thread::Result<R>;
+
+/// Spawn the given task within the given ThreadPool.
+/// Use the provided Sender to send the result of the task execution.
+///
+/// The result will contain the effective result or the payload
+/// of the panic that occurred.
+pub fn spawn_task<F, R>(
+    thread_pool: &threadpool::ThreadPool,
+    task: F,
+    tx: crossbeam_channel::Sender<TaskResult<R>>,
+) where
+    R: Send + 'static,
+    F: FnOnce() -> R + Send + 'static,
+{
+    thread_pool.execute(move || {
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| task()));
+        let _ = tx.send(res);
+    });
+}
+
+/// Blocks waiting for completion of the task spawned with [`spawn_task`].
+/// It requires the receiver associated to the sender used to spawn the task.
+///
+/// Panics if the sender is dropped.
+pub fn join_task<R>(receiver: &crossbeam_channel::Receiver<TaskResult<R>>) -> R
+where
+    R: Send + 'static,
+{
+    // UNWRAP: The sender is not expected to be dropped by the spawned task.
+    let res = receiver.recv().unwrap();
+    match res {
+        Ok(res) => res,
+        Err(err_payload) => std::panic::resume_unwind(err_payload),
+    }
+}


### PR DESCRIPTION
Utilities used to have an error handling approach that follows two rules:
+ Fail fast: If a panic occurs in a worker thread, the main thread waiting
for that worker to complete will also panic, printing the original panic payload.
+ Forward errors that do not depend on non-mt logic.

The utilities do not cover any type of context propagation. I tried many solutions to add context to the panics and error results of the task, but I couldn't find a proper way to provide context for both in a nice way. Open to suggestions! 
I decided to push the utilities anyway because with just a few lines of code they achieve the desired goals and simplify the codebase. You will see this in the next PR on this stack.
