### PR TITLE
feat: graceful shutdown IO workers

### DIFF
--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -97,13 +97,13 @@ struct IoPacket {
 /// Create an I/O worker managing an io_uring and sending responses back via channels to a number
 /// of handles.
 pub fn start_io_pool(io_workers: usize, iopoll: bool, page_pool: PagePool) -> IoPool {
-    let sender = platform::start_io_worker(io_workers, iopoll);
+    let sender = platform::start_io_worker(page_pool.clone(), io_workers, iopoll);
     IoPool { sender, page_pool }
 }
 
 #[cfg(test)]
 pub fn start_test_io_pool(io_workers: usize, page_pool: PagePool) -> IoPool {
-    let sender = platform::start_io_worker(io_workers, false);
+    let sender = platform::start_io_worker(page_pool.clone(), io_workers, false);
     IoPool { sender, page_pool }
 }
 


### PR DESCRIPTION
Mainly this changeset makes the io-uring workers exit when the command
rx channel hung up, instead of just spinning endlessly.

Additionally, this makes sure that the page pool is retained until the
very end of each io workers' lifetime. This ensures that there is no
use-after-free wrt to pagepool's buffers.