### PR TITLE
chore: page pool discipline

### DIFF
--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -574,7 +574,7 @@ impl PageLoader {
 
         let data_page_index = self.shared.store.data_page_index(bucket.0);
 
-        let page = io_handle.page_pool().alloc_fat_page();
+        let page = self.shared.page_pool.alloc_fat_page();
         let command = IoCommand {
             kind: IoKind::Read(self.shared.ht_fd.as_raw_fd(), data_page_index, page),
             user_data,

--- a/nomt/src/io/mod.rs
+++ b/nomt/src/io/mod.rs
@@ -176,10 +176,6 @@ impl IoHandle {
         &self.completion_receiver
     }
 
-    pub fn page_pool(&self) -> &PagePool {
-        &self.io_pool.page_pool
-    }
-
     pub fn io_pool(&self) -> &IoPool {
         &self.io_pool
     }

--- a/nomt/src/merkle/worker.rs
+++ b/nomt/src/merkle/worker.rs
@@ -66,10 +66,11 @@ pub(super) fn run_warm_up<H: HashAlgorithm>(
 ) {
     let page_loader = params.store.page_loader();
     let io_handle = params.store.io_pool().make_handle();
+    let page_pool = params.store.io_pool().page_pool().clone();
     let page_io_receiver = io_handle.receiver().clone();
 
     // We always run with `WithoutDependents` here, and the mode is adjusted later, during `update`.
-    let page_set = PageSet::new(io_handle.page_pool().clone(), None);
+    let page_set = PageSet::new(page_pool, None);
 
     let seeker = Seeker::<H>::new(
         params.root,


### PR DESCRIPTION
Accessing page_pool via IoHandle is convenience but is a poor
discipline. I've tried to do some refactoring on IoPool and IoHandle and
noticed that it's kind of complicated because those things tie us up. At
the same time it is unnecessary. I decided to scrap the refactor for
now, but decided to salvage this part.