### PR TITLE
refactor(page_cache): introduce a sub-cache for merkle pages below a fixed depth

### DIFF
--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -156,6 +156,11 @@ impl PageId {
         &self.path[..]
     }
 
+    /// Get the depth of the page ID. The depth of the [`ROOT_PAGE_ID`] is 0.
+    pub fn depth(&self) -> usize {
+        self.path.len()
+    }
+
     /// Construct the Child PageId given the previous PageId and the child index.
     ///
     /// Child index must be a 6 bit integer, two most significant bits must be zero.


### PR DESCRIPTION
This puts all pages with level <= 3 into a "fixed level cache" hash-map.
Cache eviction will never remove these pages and they can only be removed if the page itself is deleted.

This will be followed up by a PR for prepopulation.
