### PR TITLE
refactor: increment `sync_seqn` after meta update

### DIFF
--- a/nomt/src/store/sync.rs
+++ b/nomt/src/store/sync.rs
@@ -38,8 +38,7 @@ impl Sync {
         page_cache: PageCache,
         updated_pages: impl IntoIterator<Item = (PageId, DirtyPage)> + Send + 'static,
     ) -> anyhow::Result<()> {
-        self.sync_seqn += 1;
-        let sync_seqn = self.sync_seqn;
+        let sync_seqn = self.sync_seqn + 1;
 
         let mut bitbox_sync = bitbox.sync();
         let mut beatree_sync = beatree.sync();
@@ -73,6 +72,7 @@ impl Sync {
             rollback_end_live,
         };
         Meta::write(&shared.io_pool.page_pool(), &shared.meta_fd, &new_meta)?;
+        self.sync_seqn += 1;
 
         if let Some(PanicOnSyncMode::PostMeta) = self.panic_on_sync {
             panic!("panic_on_sync is true (post-meta)");
@@ -88,7 +88,6 @@ impl Sync {
         if let Some(ref rollback) = rollback_sync {
             rollback.wait_post_meta()?;
         }
-
         Ok(())
     }
 }


### PR DESCRIPTION
Incrementing `sync_seqn` right away within the sync function lead to a scenarion where if an error occurred whithin the `sync` process the nomt instance would get poisoned, but the same instance if queried would return the following `sync_seqn` which was never applied.
What did in this pr I'm not sure if solves entirely the problem, maybe it just moves it in a less painful place (that makes torture to work fine).

Updating it after having update the Meta means that we reflect the state on disk, but if a failure occur during the write of the ht the instance get poisoned, the sync_seqn fetch from the same instance would be correct but it would not be able to read a correct state because there would be a pending WAL batch to be applied to the ht.
