### PR TITLE
fix: adjust `rollback_start_live` update

### DIFF
--- a/nomt/src/rollback/mod.rs
+++ b/nomt/src/rollback/mod.rs
@@ -237,8 +237,9 @@ impl Rollback {
 
         // NOTE: for now, if there is a pending truncate, we ignore everything else.
         if let Some(pending_truncate) = pending_truncate {
+            let rollback_start_live = std::cmp::min(seglog.live_range().0 .0, pending_truncate);
             return WriteoutData {
-                rollback_start_live: seglog.live_range().0 .0,
+                rollback_start_live,
                 rollback_end_live: pending_truncate,
                 prune_to_new_start_live: None,
                 prune_to_new_end_live: Some(pending_truncate),

--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -880,7 +880,7 @@ impl Workload {
                 assert!(matches!(outcome, OpenOutcome::Success));
             }
             OpenOutcome::UnknownFailure(err) => {
-                panic!("unexpected open outcome: {:?}", err);
+                return Err(anyhow::anyhow!("unexpected open outcome: {:?}", err));
             }
         }
 


### PR DESCRIPTION
When a rollback is going to erase all the commits,
`rollback_start_live` will need to be equal to `pending_truncate`.