### PR TITLE
refactor(benchtop) make sp-trie/sov-db features of benchtop

### DIFF
--- a/benchtop/Cargo.toml
+++ b/benchtop/Cargo.toml
@@ -26,23 +26,27 @@ lru = "0.12.5"
 libc = "0.2.155"
 
 # sov-db
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk" }
-sov-schema-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk" }
-sov-prover-storage-manager = { git = "https://github.com/Sovereign-Labs/sovereign-sdk" }
-jmt = { git = "https://github.com/penumbra-zone/jmt.git", rev = "1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk", optional = true }
+sov-schema-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk", optional = true }
+sov-prover-storage-manager = { git = "https://github.com/Sovereign-Labs/sovereign-sdk", optional = true }
+jmt = { git = "https://github.com/penumbra-zone/jmt.git", rev = "1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6", optional = true }
 
 # sp-trie
-sp-trie = "32.0.0"
-sp-state-machine = "0.35.0"
-trie-db = "0.28.0"
-hash-db = "0.16.0"
-sp-core = "31.0.0"
-kvdb = "0.13.0"
-kvdb-rocksdb = "0.19.0"
-array-bytes = "6.1"
+sp-trie = { version = "32.0.0", optional = true }
+sp-state-machine = { version = "0.35.0", optional = true }
+trie-db = { version = "0.28.0", optional = true }
+hash-db = { version = "0.16.0", optional = true }
+sp-core = { version = "31.0.0", optional = true }
+kvdb = { version = "0.13.0", optional = true }
+kvdb-rocksdb = { version = "0.19.0", optional = true }
+array-bytes = { version = "6.1", optional = true }
 
 # nomt
 nomt = { path = "../nomt" }
 
 [profile.release]
 debug = true
+
+[features]
+sov-db=["dep:sov-db", "sov-schema-db", "sov-prover-storage-manager", "jmt" ]
+sp-trie=["dep:sp-trie", "sp-state-machine", "trie-db", "hash-db", "sp-core", "kvdb", "kvdb-rocksdb", "array-bytes" ]

--- a/benchtop/src/main.rs
+++ b/benchtop/src/main.rs
@@ -2,8 +2,12 @@ mod backend;
 mod cli;
 mod custom_workload;
 mod nomt;
+
+#[cfg(feature = "sov-db")]
 mod sov_db;
+#[cfg(feature = "sp-trie")]
 mod sp_trie;
+
 mod timer;
 mod transfer_workload;
 mod workload;


### PR DESCRIPTION
This'll avoid the need to compile large dependencies like RocksDB when building benchtop exclusively for testing NOMT.
