### PR TITLE
feat(torture): if agent hangs print its bt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1830,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trickfs",
+ "which",
 ]
 
 [[package]]
@@ -2030,6 +2040,18 @@ checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/torture/Cargo.toml
+++ b/torture/Cargo.toml
@@ -26,3 +26,4 @@ hex = "0.4.3"
 futures-util = "0.3.31"
 clap = { version = "4.5.23", features = ["derive"] }
 trickfs = { path = "../trickfs" }
+which = "4"

--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -29,13 +29,6 @@ pub async fn run(input: UnixStream) -> Result<()> {
     let pid = std::process::id();
     trace!(pid, "Child process started");
 
-    // Make the process non-dumpable.
-    //
-    // We expect this process to abort on a crash, so we don't want to leave lots of core dumps
-    // behind.
-    #[cfg(target_os = "linux")]
-    nix::sys::prctl::set_dumpable(false)?;
-
     let mut stream = Stream::new(input);
     let workdir = initialize(&mut stream).await?;
     let mut agent = Agent::new();

--- a/torture/src/supervisor/controller.rs
+++ b/torture/src/supervisor/controller.rs
@@ -83,6 +83,17 @@ impl SpawnedAgentController {
     pub fn rr(&self) -> &comms::RequestResponse {
         &self.rr
     }
+
+    /// Returns the PID of the agent process.
+    ///
+    /// Returns `None` if the agent is torn down.
+    pub fn pid(&self) -> Option<u32> {
+        if self.torn_down.load(Ordering::Relaxed) {
+            None
+        } else {
+            self.child.id()
+        }
+    }
 }
 
 /// Spawns an agent process creating a controller.

--- a/torture/src/supervisor/mod.rs
+++ b/torture/src/supervisor/mod.rs
@@ -17,6 +17,7 @@ use workload::Workload;
 mod cli;
 mod comms;
 mod controller;
+mod pbt;
 mod workload;
 
 /// The entrypoint for the supervisor part of the program.

--- a/torture/src/supervisor/pbt.rs
+++ b/torture/src/supervisor/pbt.rs
@@ -1,0 +1,53 @@
+//! Collection of process backtraces.
+//!
+//! This uses the grug-brain developer approach: just invoke the LLDB or GDB to get the backtrace.
+
+use std::path::Path;
+use tokio::{fs, process::Command};
+use which::which;
+
+pub async fn collect_process_backtrace(filename: &Path, pid: u32) -> anyhow::Result<()> {
+    // Determine which debugger tool to use.
+    let command_str = if which("lldb").is_ok() {
+        lldb(pid)
+    } else if which("gdb").is_ok() {
+        gdb(pid)
+    } else {
+        anyhow::bail!("no lldb or gdb in PATH")
+    };
+
+    // Run the command using a shell
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(&command_str)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("{} failed: {}", command_str, stderr);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Write the backtrace into the file specified by filename.
+    fs::write(&filename, stdout.as_ref()).await?;
+
+    Ok(())
+}
+
+/// Generate the lldb command for obtaining the backtrace.
+fn lldb(pid: u32) -> String {
+    format!(
+        "lldb -p {} -o \"thread backtrace all\" -o \"detach\" -o \"quit\"",
+        pid
+    )
+}
+
+/// Generate the gdb command for obtaining the backtrace.
+fn gdb(pid: u32) -> String {
+    format!(
+        "gdb -p {} -batch -ex \"thread apply all bt\" -ex \"detach\" -ex \"quit\"",
+        pid
+    )
+}


### PR DESCRIPTION
To aid debugging cases where the agent got deadlocked (or just timed
out), print the backtrace of every thread of the agent process.

This PR removes dumpable(false) so the caveat might apply. We need the agent process to be dumpable because otherwise we cannot trace it and no debugger can be attached.