### PR TITLE
fix(torture): debugger timeout

### DIFF
--- a/torture/src/supervisor/pbt.rs
+++ b/torture/src/supervisor/pbt.rs
@@ -2,8 +2,14 @@
 //!
 //! This uses the grug-brain developer approach: just invoke the LLDB or GDB to get the backtrace.
 
-use std::path::Path;
-use tokio::{fs, process::Command};
+use futures::future::join3;
+use std::{path::Path, time::Duration};
+use tokio::{
+    fs,
+    io::{AsyncRead, AsyncReadExt as _},
+    process::Command,
+    time::timeout,
+};
 use which::which;
 
 pub async fn collect_process_backtrace(filename: &Path, pid: u32) -> anyhow::Result<()> {
@@ -17,21 +23,56 @@ pub async fn collect_process_backtrace(filename: &Path, pid: u32) -> anyhow::Res
     };
 
     // Run the command using a shell
-    let output = Command::new("sh")
+    // Spawn the command using a shell so that we have a Child handle.
+    let mut child = Command::new("sh")
         .arg("-c")
         .arg(&command_str)
-        .output()
-        .await?;
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("{} failed: {}", command_str, stderr);
+    let mut stdout_pipe = child.stdout.take().expect("stdout pipe");
+    let mut stderr_pipe = child.stderr.take().expect("stderr pipe");
+
+    async fn read_pipe(pipe: &mut (impl AsyncRead + Unpin)) -> anyhow::Result<String> {
+        let mut reader = tokio::io::BufReader::new(pipe);
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).await?;
+        let stdout = String::from_utf8(buf)?;
+        Ok(stdout)
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout_fut = read_pipe(&mut stdout_pipe);
+    let stderr_fut = read_pipe(&mut stderr_pipe);
+
+    let (exit_code, stdout, stderr) = match timeout(
+        Duration::from_secs(5),
+        join3(child.wait(), stdout_fut, stderr_fut),
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(_) => {
+            // Timed out.
+            //
+            // Do the best-effort attempt at killing the child process.
+            //
+            // FIXME: Ideally we kill not just the child process but the entire process group.
+            tokio::spawn(async move { child.kill().await });
+            anyhow::bail!("Debugger command timed out after 5 seconds");
+        }
+    };
+
+    let exit_code = exit_code?;
+    let stderr = stderr?;
+    let stdout = stdout?;
+
+    if !exit_code.success() {
+        anyhow::bail!("command '{}' failed: {}", command_str, stderr);
+    }
 
     // Write the backtrace into the file specified by filename.
-    fs::write(&filename, stdout.as_ref()).await?;
+    fs::write(&filename, &stdout).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Sometimes it can happen that a process can get stuck in an
uninterruptable state. This can sometimes happen during IO. In that
case, the supervisor will get stuck collecting the backtrace. This
changeset prevents that.