### PR TITLE
feat(torture): latency injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1368,6 +1375,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -1902,6 +1919,9 @@ dependencies = [
  "fuser",
  "libc",
  "log",
+ "rand",
+ "rand_distr",
+ "rand_pcg",
  "tempfile",
 ]
 

--- a/torture/src/supervisor/comms.rs
+++ b/torture/src/supervisor/comms.rs
@@ -160,12 +160,7 @@ pub fn run(stream: UnixStream) -> (RequestResponse, impl Future<Output = anyhow:
         SymmetricalBincode::default(),
     );
 
-    // macOS is way slower for some reason. Workaround by increasing the timeout.
-    let timeout = if cfg!(target_os = "macos") {
-        Duration::from_secs(10)
-    } else {
-        Duration::from_secs(5)
-    };
+    let timeout = Duration::from_secs(20);
 
     let shared = Arc::new(Shared {
         reqno: AtomicU64::new(0),

--- a/trickfs/Cargo.toml
+++ b/trickfs/Cargo.toml
@@ -12,6 +12,9 @@ fuser = { version = "0.15.1", features = ["abi-7-23"] }
 libc = "0.2.169"
 log = "0.4.22"
 tempfile = "3.15.0"
+rand = "0.8.5"
+rand_pcg = "0.3.1"
+rand_distr = "0.4.3"
 
 [dev-dependencies]
 env_logger = "0.11.6"

--- a/trickfs/src/latency.rs
+++ b/trickfs/src/latency.rs
@@ -1,0 +1,91 @@
+use std::{
+    collections::VecDeque,
+    sync::mpsc::{self, Receiver, RecvTimeoutError, Sender},
+    time::{Duration, Instant},
+};
+
+use rand::SeedableRng;
+use rand_distr::Distribution;
+
+/// Max possible delay, in micros, used as injected latency.
+const MAX_LATENCY_MICROS: u64 = 1500;
+type Reply = Box<dyn FnOnce() + Send + 'static>;
+
+/// An injector of latencies.
+///
+/// This allows to schedule replies after a certain delay.
+/// Delays are randomly chosen following a Pareto Distribution.
+/// 80% of the delay will be below 20% of MAX_LATENCY_MICROS
+pub struct LatencyInjector {
+    rng: rand_pcg::Pcg64,
+    distr: rand_distr::Pareto<f64>,
+    tx: Sender<(Reply, Duration)>,
+}
+
+impl LatencyInjector {
+    pub fn new(seed: u64) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let _ = std::thread::spawn(|| scheduler(rx));
+        Self {
+            rng: rand_pcg::Pcg64::seed_from_u64(seed),
+            distr: rand_distr::Pareto::new(1.0, 1.16).unwrap(),
+            tx,
+        }
+    }
+
+    pub fn schedule_reply(&mut self, reply: Reply) {
+        // Shift and scale, values above 100.0 (0.05%) are clipped to MAX_LATENCY_MICROS.
+        let f = f64::min((self.distr.sample(&mut self.rng) - 1.0) / 100.0, 1.0);
+        let micros = (f * MAX_LATENCY_MICROS as f64).round() as u64;
+        let delay = Duration::from_micros(micros);
+        self.tx.send((reply, delay)).unwrap();
+    }
+}
+
+/// Task used to execute every scheduled reply.
+fn scheduler(rx: Receiver<(Reply, Duration)>) {
+    let mut scheduled: VecDeque<(Reply, Instant)> = VecDeque::new();
+    loop {
+        let (_, deadline) = match scheduled.front() {
+            Some((reply, deadline)) => (reply, deadline),
+            None => {
+                // Nothing scheduled, wait for next reply.
+                match rx.recv() {
+                    Ok((reply, delay)) => {
+                        schedule_new_reply(&mut scheduled, reply, delay);
+                    }
+                    Err(_) => break,
+                }
+                continue;
+            }
+        };
+
+        // Wait for a new reply to be scheduled or until we reach the deadline
+        // of the first reply in the queue.
+        let timeout = deadline.saturating_duration_since(std::time::Instant::now());
+        match rx.recv_timeout(timeout) {
+            Ok((reply, delay)) => schedule_new_reply(&mut scheduled, reply, delay),
+            Err(RecvTimeoutError::Timeout) => {
+                let (reply, _) = scheduled.pop_front().unwrap();
+                reply();
+            }
+            Err(RecvTimeoutError::Disconnected) => break,
+        };
+    }
+
+    // Answer to all pending replies.
+    for (reply, _) in scheduled {
+        reply();
+    }
+}
+
+/// Insert the reply into the scheduled queue following an order by the deadlines.
+fn schedule_new_reply(scheduled: &mut VecDeque<(Reply, Instant)>, reply: Reply, delay: Duration) {
+    let deadline = std::time::Instant::now() + delay.clone();
+    // If two replies happen to have the same deadline, then they will be kept in FIFO order.
+    let idx = match scheduled.binary_search_by_key(&deadline, |(_, d)| *d) {
+        Ok(idx) => idx + 1,
+        Err(idx) => idx,
+    };
+    scheduled.insert(idx, (reply, deadline));
+}

--- a/trickfs/trickmnt/src/main.rs
+++ b/trickfs/trickmnt/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
-    let handle = trickfs::spawn_trick(args.mountpoint).unwrap();
+    let handle = trickfs::spawn_trick(args.mountpoint, 0).unwrap();
     waitline();
     drop(handle);
 


### PR DESCRIPTION
The following pr introduces 'Latency Injection' within `Trickfs`. This can be triggered by the `TrickHandle`, and if triggered, every `trickfs` operation will be subject to a scheduled reply after a certain delay.

Notes:
1. In order to deal with latencies, the timeout for waiting for agent replies needed to be increased, as sometimes there were quite big delays.
2. Two of the most crucial `trickfs` operations are read and write, which I tried to keep simple while injecting latencies. For writes, they happen immediately but the reply of things getting written is scheduled. The same applies to reads, where things are copied into the scheduled reply. This latter part introduces some latency by itself, but it does not significantly impact the code with lifetimes or check if memory got modified in the meantime.
3. To keep `torture` reproducible to a certain extent, I added a seed to `trickfs`, which also needs to be specified in all other occasions. Let me know if you have a better approach to handle this while keeping it reproducible.

Closes THR-114
