### PR TITLE
feat(torture): spawn multiple parallel workloads

### DIFF
--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -304,7 +304,7 @@ impl Workload {
     pub fn new(
         seed: u64,
         workload_dir: TempDir,
-        workload_params: &WorkloadParams,
+        workload_params: WorkloadParams,
         workload_id: u64,
     ) -> anyhow::Result<Self> {
         // TODO: Make the workload size configurable and more sophisticated.


### PR DESCRIPTION
Prepare the supervisor to be able to spawn multiple
workloads in parallel.
Logging all workloads to the same stdout was incomprehensible.
Now, each workload that is being orchestrated by the supervisor
and the relative agent will log into the same file at `workload_dir/log`.

NOTE: I also removed some TODOs from the logging module because 
I was not having any problem with ANSI colors.
