### PR TITLE
feat(torture): agent more granular configuration

### DIFF
--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -257,7 +257,13 @@ impl Agent {
         let mut o = nomt::Options::new();
         o.path(workdir.join("nomt_db"));
         o.bitbox_seed(open_params.bitbox_seed);
-        o.hashtable_buckets(500_000);
+        o.hashtable_buckets(open_params.hashtable_buckets);
+        o.warm_up(open_params.warm_up);
+        o.preallocate_ht(open_params.preallocate_ht);
+        o.page_cache_size(open_params.page_cache_size);
+        o.leaf_cache_size(open_params.leaf_cache_size);
+        o.prepopulate_page_cache(open_params.prepopulate_page_cache);
+        o.page_cache_upper_levels(open_params.page_cache_upper_levels);
         if let Some(n_commits) = open_params.rollback {
             o.rollback(true);
             o.max_rollback_log_len(n_commits);

--- a/torture/src/message.rs
+++ b/torture/src/message.rs
@@ -56,6 +56,24 @@ pub struct OpenPayload {
     /// Whether the agent is supposed to handle rollbacks.
     /// If `Some`, the maximum number of supported blocks in a single rollback is specified.
     pub rollback: Option<u32>,
+    /// The number of commit workers.
+    pub commit_concurrency: usize,
+    /// The number of io_uring instances.
+    pub io_workers: usize,
+    /// The number of pages within the ht.
+    pub hashtable_buckets: u32,
+    /// Whether merkle page fetches should be warmed up while sessions are ongoing.
+    pub warm_up: bool,
+    /// Whether to preallocate the hashtable file.
+    pub preallocate_ht: bool,
+    /// The maximum size of the page cache.
+    pub page_cache_size: usize,
+    /// The maximum size of the leaf cache.
+    pub leaf_cache_size: usize,
+    /// Whether to prepopulate the upper layers of the page cache on startup.
+    pub prepopulate_page_cache: bool,
+    /// Number of upper layers contained in the cache.
+    pub page_cache_upper_levels: usize,
 }
 
 /// The parameters for the [`ToAgent::Commit`] message.

--- a/torture/src/supervisor/controller.rs
+++ b/torture/src/supervisor/controller.rs
@@ -54,6 +54,15 @@ impl SpawnedAgentController {
             .send_request(crate::message::ToAgent::Open(crate::message::OpenPayload {
                 bitbox_seed,
                 rollback,
+                commit_concurrency: 6,
+                io_workers: 3,
+                hashtable_buckets: 500_000,
+                warm_up: false,
+                preallocate_ht: true,
+                page_cache_size: 256,
+                leaf_cache_size: 256,
+                prepopulate_page_cache: false,
+                page_cache_upper_levels: 2,
             }))
             .await?;
         match response {


### PR DESCRIPTION
Update the `OpenPayload` to contain all the open options that nomt supports.
