### PR TITLE
feat(torture): agent concurrent reads

### DIFF
--- a/torture/src/message.rs
+++ b/torture/src/message.rs
@@ -79,6 +79,10 @@ pub struct OpenPayload {
 /// The parameters for the [`ToAgent::Commit`] message.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CommitPayload {
+    /// The set of keys that should be read.
+    pub reads: Vec<Key>,
+    /// The number of concurrent readers.
+    pub read_concurrency: usize,
     /// The set of changes that the child should commit.
     ///
     /// There must be no duplicate keys in the set.


### PR DESCRIPTION
Add to the `CommitPayload` a vector of keys that need to be read from the session before applying the changeset.
Not only are the keys to read specified, but also the amount of concurrency with which the reads should be performed.
