### PR TITLE
feat(torture): use workload config for OpenPayload

### DIFF
--- a/torture/src/supervisor/config.rs
+++ b/torture/src/supervisor/config.rs
@@ -174,6 +174,10 @@ impl WorkloadConfiguration {
         })
     }
 
+    pub fn is_rollback_enable(&self) -> bool {
+        self.rollback > 0.0
+    }
+
     pub fn no_new_keys(&self) -> bool {
         self.new_key == 0.0
     }

--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -697,17 +697,7 @@ impl Workload {
     ///
     /// If the agent has run out of storage, we will turn off the `ENOSPC` error and try again.
     async fn ensure_agent_open_db(&mut self) -> anyhow::Result<()> {
-        let rollback = if self.config.rollback > 0.0 {
-            Some(self.config.max_rollback_commits)
-        } else {
-            None
-        };
-        let outcome = self
-            .agent
-            .as_mut()
-            .unwrap()
-            .open(self.config.bitbox_seed, rollback)
-            .await?;
+        let outcome = self.agent.as_mut().unwrap().open(&self.config).await?;
 
         match outcome {
             OpenOutcome::Success => (),
@@ -723,12 +713,7 @@ impl Workload {
                     .unwrap()
                     .set_trigger_enospc(false);
 
-                let outcome = self
-                    .agent
-                    .as_mut()
-                    .unwrap()
-                    .open(self.config.bitbox_seed, rollback)
-                    .await?;
+                let outcome = self.agent.as_mut().unwrap().open(&self.config).await?;
                 assert!(matches!(outcome, OpenOutcome::Success));
             }
             OpenOutcome::UnknownFailure(err) => {


### PR DESCRIPTION
This pr brings `torture` to a proper multi-workload executor functioning state.

Everything required to execute and debug multiple workloads should be in place. Now, follow-up PRs will contain all the workload configuration generation because currently, they are hardcoded.
