### PR TITLE
fix(torture): allow reproducibility of workloads

### DIFF
--- a/torture/src/supervisor/cli.rs
+++ b/torture/src/supervisor/cli.rs
@@ -1,28 +1,49 @@
-use clap::{Args, Parser};
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 pub struct Cli {
-    /// The 8-byte seed to use for the random number generator.
-    ///
-    /// If not provided, a random seed will be generated.
-    pub seed: Option<u64>,
+    #[command(subcommand)]
+    pub command: Commands,
+}
 
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Execute swarm testing. Multiple workloads will be executed at the same
+    /// time, enabling and disabling different nomt features.
+    Swarm(SwarmParams),
+    /// Execute a single workload given a seed.
+    Run(RunParams),
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct SwarmParams {
     /// The maximum number of failures before the supervisor stops.
     ///
     /// If not provided, the supervisor will stop after the first failure.
     #[arg(short, long, default_value_t = 1)]
     pub flag_limit: usize,
 
-    #[clap(flatten)]
-    pub swarm_params: SwarmParams,
+    /// Folder that will be used as the working directory by the Supervisor.
+    /// It will contain all workload folders.
+    #[arg(long = "workdir")]
+    pub workdir: Option<String>,
 }
 
 #[derive(Clone, Debug, Args)]
-pub struct SwarmParams {
+pub struct RunParams {
+    /// The 8-byte seed to use for the random number generator.
+    pub seed: u64,
+
+    /// Amount of disk space in bytes assigned to the workload. [Default: 20GiB]
+    #[arg(short = 'd', long, default_value_t = 20 * 1024 * 1024 * 1024)]
+    pub assigned_disk: u64,
+
+    /// Amount of memory in bytes assigned to the workload. [Default: 3GiB]
+    #[arg(short = 'm' ,long, default_value_t = 3 * 1024 * 1024 * 1024)]
+    pub assigned_memory: u64,
+
     /// Folder that will be used as the working directory by the Supervisor.
-    /// It will contain all workload folders.
-    ///
-    /// It does not work in conjunction with `trickfs` option.
+    /// It will contain the folder of the workload that it is being executed.
     #[arg(long = "workdir")]
     pub workdir: Option<String>,
 }

--- a/torture/src/supervisor/config.rs
+++ b/torture/src/supervisor/config.rs
@@ -116,10 +116,9 @@ pub struct WorkloadConfiguration {
 }
 
 impl WorkloadConfiguration {
-    pub fn new(
+    fn new_inner(
         rng: &mut rand_pcg::Pcg64,
-        resource_alloc: Arc<Mutex<ResourceAllocator>>,
-        workload_id: u64,
+        avail_bytes: impl Fn(bool) -> Result<u64, ResourceExhaustation>,
     ) -> Result<Self, ResourceExhaustation> {
         let swarm_features = swarm::new_features_set(rng);
 
@@ -133,16 +132,7 @@ impl WorkloadConfiguration {
             })
             .is_some();
 
-        let avail_bytes = {
-            let mut allocator = resource_alloc.lock().unwrap();
-            if trickfs {
-                allocator.alloc_memory(workload_id)?;
-                allocator.assigned_memory(workload_id)
-            } else {
-                allocator.alloc(workload_id)?;
-                allocator.assigned_disk(workload_id)
-            }
-        };
+        let avail_bytes = avail_bytes(trickfs)?;
 
         let mut bitbox_seed = [0u8; 16];
         rng.fill_bytes(&mut bitbox_seed);
@@ -211,6 +201,39 @@ impl WorkloadConfiguration {
         }
 
         Ok(config)
+    }
+
+    pub fn new(
+        rng: &mut rand_pcg::Pcg64,
+        workload_id: u64,
+        resource_alloc: Arc<Mutex<ResourceAllocator>>,
+    ) -> Result<Self, ResourceExhaustation> {
+        let avail_bytes = |trickfs: bool| {
+            let mut allocator = resource_alloc.lock().unwrap();
+            if trickfs {
+                allocator.alloc_memory(workload_id)?;
+                Ok(allocator.assigned_resources(workload_id).memory)
+            } else {
+                allocator.alloc(workload_id)?;
+                Ok(allocator.assigned_resources(workload_id).disk)
+            }
+        };
+        Self::new_inner(rng, avail_bytes)
+    }
+
+    pub fn new_with_resources(
+        rng: &mut rand_pcg::Pcg64,
+        assigned_disk: u64,
+        assigned_memory: u64,
+    ) -> Self {
+        let avail_bytes = |trickfs: bool| {
+            if trickfs {
+                Ok(assigned_disk)
+            } else {
+                Ok(assigned_memory)
+            }
+        };
+        Self::new_inner(rng, avail_bytes).unwrap()
     }
 
     pub fn enable_ensure_snapshot(&mut self) {

--- a/torture/src/supervisor/mod.rs
+++ b/torture/src/supervisor/mod.rs
@@ -9,8 +9,9 @@ use std::{
 
 use anyhow::Result;
 use clap::Parser;
-use cli::{Cli, SwarmParams};
-use resource::{ResourceAllocator, ResourceExhaustation};
+use cli::{Cli, RunParams, SwarmParams};
+use resource::{AssignedResources, ResourceAllocator, ResourceExhaustation};
+use tempfile::TempDir;
 use tokio::{
     signal::unix::{signal, SignalKind},
     task::{self, JoinHandle, JoinSet},
@@ -36,18 +37,18 @@ mod workload;
 pub async fn run() -> Result<()> {
     logging::init_supervisor();
 
-    let cli = Cli::parse();
-    let seed = cli.seed.unwrap_or_else(rand::random);
-
     // Create a cancellation token and spawn the control loop task passing the token to it and
     // wait until the control loop task finishes or the user interrupts it.
     let ct = CancellationToken::new();
-    let control_loop_jh = task::spawn(control_loop(
-        ct.clone(),
-        seed,
-        cli.swarm_params,
-        cli.flag_limit,
-    ));
+
+    let cli = Cli::parse();
+    let swarm_params = match cli.command {
+        cli::Commands::Swarm(swarm_params) => swarm_params,
+        cli::Commands::Run(run_params) => return run_single_workload(ct, run_params).await,
+    };
+    let seed = rand::random();
+
+    let control_loop_jh = task::spawn(control_loop(ct.clone(), seed, swarm_params));
     match join_interruptable(control_loop_jh, ct).await {
         ExitReason::Finished => {
             exit(0);
@@ -153,6 +154,10 @@ async fn join_interruptable(
 pub struct InvestigationFlag {
     /// Seed used to generate the workload.
     seed: u64,
+    /// Amount of disk, in bytes, that was assigned to the workload.
+    assigned_disk: u64,
+    /// Amount of memory, in bytes, that was assigned to the workload.
+    assigned_memory: u64,
     workload_id: u64,
     /// The directory the agent was working in.
     workdir: PathBuf,
@@ -160,21 +165,14 @@ pub struct InvestigationFlag {
     reason: anyhow::Error,
 }
 
-fn prepare_workload(
-    workdir_path: PathBuf,
-    seed: u64,
-    workload_id: u64,
-    resource_alloc: Arc<Mutex<ResourceAllocator>>,
-) -> Result<Workload, ResourceExhaustation> {
+fn init_workload_dir(workdir_path: PathBuf, workload_id: u64) -> TempDir {
     let mut workload_dir_builder = tempfile::Builder::new();
     workload_dir_builder.prefix("torture-");
     let suffix = format!("-workload-{}", workload_id);
     workload_dir_builder.suffix(&suffix);
-    let workload_dir = workload_dir_builder
+    workload_dir_builder
         .tempdir_in(workdir_path)
-        .expect("Failed to create a temp dir");
-
-    Workload::new(seed, workload_dir, workload_id, resource_alloc.clone())
+        .expect("Failed to create a temp dir")
 }
 
 /// Run the workload until either it either finishes, errors or gets cancelled.
@@ -188,6 +186,7 @@ async fn run_workload(
     mut workload: Workload,
 ) -> Result<Option<InvestigationFlag>> {
     let workload_dir_path = workload.workload_dir_path();
+    let AssignedResources { disk, memory } = workload.assigned_resources();
     let result = workload
         .run(cancel_token)
         .with_subscriber(logging::workload_subscriber(&workload_dir_path))
@@ -198,6 +197,8 @@ async fn run_workload(
         Err(err) => Ok(Some(InvestigationFlag {
             seed,
             workload_id,
+            assigned_disk: disk,
+            assigned_memory: memory,
             // `TempDir::into_path` persists the TempDir to disk.
             workdir: workload.into_workload_dir().into_path(),
             reason: err,
@@ -207,9 +208,12 @@ async fn run_workload(
 
 fn print_flag(flag: &InvestigationFlag) {
     warn!(
-        "Flagged for investigation:\n  seed={seed}\n  workload_id={workload_id}\n  \
-        workdir={workdir}\n  reason={reason}",
+        "Flagged for investigation:\n  seed={seed}\n  assigned_disk={assigned_disk}\n  \
+         assigned_memory={assigned_memory}\n  workload_id={workload_id}\n   workdir={workdir}\n  \
+         reason={reason}",
         seed = flag.seed,
+        assigned_disk = flag.assigned_disk,
+        assigned_memory = flag.assigned_memory,
         workload_id = flag.workload_id,
         workdir = flag.workdir.display(),
         reason = flag.reason,
@@ -227,7 +231,6 @@ async fn control_loop(
     cancel_token: CancellationToken,
     seed: u64,
     mut swarm_params: SwarmParams,
-    flag_num_limit: usize,
 ) -> Result<()> {
     info!("Starting control loop, seed={seed}.\n{NON_DETERMINISM_DISCLAIMER}");
     let mut flags = Vec::new();
@@ -266,19 +269,12 @@ async fn control_loop(
         loop {
             let workload_id = workload_cnt;
             let workload_seed = seed + workload_cnt;
+            let workload_dir = init_workload_dir(workdir_path.clone(), workload_id);
 
-            let res = prepare_workload(
-                workdir_path.clone(),
-                workload_seed,
-                workload_id,
-                resource_alloc.clone(),
-            );
-
-            let workload = match res {
-                Ok(workload) => workload,
-                Err(..) => {
-                    break;
-                }
+            let Ok(workload) =
+                Workload::new(seed, workload_dir, workload_id, resource_alloc.clone())
+            else {
+                break;
             };
 
             workload_cnt += 1;
@@ -310,7 +306,7 @@ async fn control_loop(
         if cancel_token.is_cancelled() {
             break;
         }
-        if flags.len() >= flag_num_limit {
+        if flags.len() >= swarm_params.flag_limit {
             info!("Flag limit reached. Exiting.");
             break;
         }
@@ -324,6 +320,36 @@ async fn control_loop(
     }
 
     for flag in flags {
+        print_flag(&flag);
+    }
+    Ok(())
+}
+
+async fn run_single_workload(
+    cancel_token: CancellationToken,
+    mut run_params: RunParams,
+) -> Result<()> {
+    let workdir_path = if let Some(workdir_path) = run_params.workdir.take() {
+        if !std::path::Path::new(&workdir_path).exists() {
+            anyhow::bail!("The workdir path does not exist");
+        }
+        PathBuf::from_str(&workdir_path).unwrap()
+    } else {
+        std::env::temp_dir()
+    };
+
+    let workload_dir = init_workload_dir(workdir_path.clone(), 0 /* workload_id */);
+
+    let workload = Workload::new_with_resources(
+        run_params.seed,
+        workload_dir,
+        0, /* workload_id */
+        run_params.assigned_disk,
+        run_params.assigned_memory,
+    );
+
+    let maybe_flag = run_workload(cancel_token.clone(), run_params.seed, 0, workload).await?;
+    if let Some(flag) = maybe_flag {
         print_flag(&flag);
     }
     Ok(())

--- a/torture/src/supervisor/resource.rs
+++ b/torture/src/supervisor/resource.rs
@@ -29,13 +29,20 @@ const MAX_ASSIGNED_MEMORY: u64 = 5 * (1 << 30);
 /// which will use only memory.
 const MAX_ASSIGNED_ONLY_MEMORY: u64 = 50 * (1 << 30);
 
+#[derive(Clone, Copy)]
+/// Amount of resources assigned to a workload.
+/// Resources are disk space and memory.
+pub struct AssignedResources {
+    pub disk: u64,
+    pub memory: u64,
+}
+
 /// ResourceAllocator is used to split resources randomly across multiple workloads.
 ///
 /// Resources are Memory and Disk space.
 pub struct ResourceAllocator {
     rng: rand_pcg::Pcg64,
-    // (workload_id, assigned_disk, assigned_mem)
-    assigned: Vec<(u64, u64, u64)>,
+    assigned: Vec<(u64, AssignedResources)>,
     max_disk_avail: u64,
     max_memory_avail: u64,
     total_assigned_disk: u64,
@@ -88,12 +95,17 @@ impl ResourceAllocator {
 
         let assigned_disk_ratio = assigned_disk as f64 / avail_disk as f64;
         avail_memory = std::cmp::min(avail_memory, MAX_ASSIGNED_MEMORY);
-        let assigned_mem = (avail_memory as f64 * assigned_disk_ratio) as u64;
+        let assigned_memory = (avail_memory as f64 * assigned_disk_ratio) as u64;
 
         self.total_assigned_disk += assigned_disk;
-        self.total_assigned_memory += assigned_mem;
-        self.assigned
-            .push((workload_id, assigned_disk, assigned_mem));
+        self.total_assigned_memory += assigned_memory;
+        self.assigned.push((
+            workload_id,
+            AssignedResources {
+                disk: assigned_disk,
+                memory: assigned_memory,
+            },
+        ));
 
         Ok(())
     }
@@ -105,9 +117,15 @@ impl ResourceAllocator {
         }
 
         avail_memory = std::cmp::min(avail_memory, MAX_ASSIGNED_ONLY_MEMORY);
-        let assigned_mem = self.rng.gen_range(MIN_ASSIGNED_MEMORY..avail_memory);
+        let assigned_memory = self.rng.gen_range(MIN_ASSIGNED_MEMORY..avail_memory);
 
-        self.assigned.push((workload_id, 0, assigned_mem));
+        self.assigned.push((
+            workload_id,
+            AssignedResources {
+                disk: 0,
+                memory: assigned_memory,
+            },
+        ));
         Ok(())
     }
 
@@ -121,9 +139,9 @@ impl ResourceAllocator {
             .position(|(id, ..)| *id == workload_id)
             .unwrap();
 
-        let (_, assigned_disk, assigned_mem) = self.assigned.remove(idx);
-        self.total_assigned_memory -= assigned_mem;
-        self.total_assigned_disk -= assigned_disk;
+        let (_, AssignedResources { disk, memory }) = self.assigned.remove(idx);
+        self.total_assigned_disk -= disk;
+        self.total_assigned_memory -= memory;
     }
 
     /// Ensures that the workload_dir does not occupy more disk space than the assigned limit
@@ -139,64 +157,22 @@ impl ResourceAllocator {
         workload_dir_path: &Path,
         process_id: u32,
     ) -> bool {
-        let (_, assigned_disk, assigned_mem) = self
+        let (_, AssignedResources { disk, memory }) = self
             .assigned
             .iter()
             .find(|(id, ..)| *id == workload_id)
             .unwrap();
-
-        let used_mem = process_memory_occupied(process_id);
-        if used_mem >= *assigned_mem {
-            return true;
-        }
-
-        if *assigned_disk == 0 {
-            return false;
-        }
-
-        fn dir_size(path: &Path) -> u64 {
-            std::fs::read_dir(path)
-                .unwrap()
-                .into_iter()
-                .filter_map(|entry| entry.ok())
-                .map(|entry| {
-                    let entry_metadata = entry.metadata().unwrap();
-                    if entry_metadata.is_dir() {
-                        dir_size(&entry.path())
-                    } else {
-                        entry_metadata.size()
-                    }
-                })
-                .sum()
-        }
-
-        let used_disk = dir_size(workload_dir_path);
-        if used_disk >= *assigned_disk {
-            return true;
-        }
-
-        false
+        is_exceeding_resources(*disk, *memory, workload_dir_path, process_id)
     }
 
-    /// Fetch the amount of assigned memory to the specified `workload_id`.
+    /// Fetch the amount of assigned resources to the specified `workload_id`.
     ///
     /// Panics if the specified workload_id is not present in the tracked ones.
-    pub fn assigned_memory(&mut self, workload_id: u64) -> u64 {
+    pub fn assigned_resources(&self, workload_id: u64) -> AssignedResources {
         self.assigned
             .iter()
             .find(|(id, ..)| *id == workload_id)
-            .map(|(_, _, assigned_mem)| *assigned_mem)
-            .unwrap()
-    }
-
-    /// Fetch the amount of assigned disk space to the specified `workload_id`.
-    ///
-    /// Panics if the specified workload_id is not present in the tracked ones.
-    pub fn assigned_disk(&mut self, workload_id: u64) -> u64 {
-        self.assigned
-            .iter()
-            .find(|(id, ..)| *id == workload_id)
-            .map(|(_, assigned_disk, _)| *assigned_disk)
+            .map(|(_, assigned_resources)| *assigned_resources)
             .unwrap()
     }
 }
@@ -269,4 +245,49 @@ fn disk_info(path: &Path) -> (u64, u64) {
     let avail_disk = statvfs.f_bsize * statvfs.f_bavail;
     let total_disk = statvfs.f_bsize * statvfs.f_blocks;
     (avail_disk, total_disk)
+}
+
+/// Ensures that the workload_dir does not occupy more disk space than the assigned limit
+/// and the same applies to the memory utilization of the specified process_id.
+///
+/// Panics if:
+/// 1. workload_dir_path does not exist.
+/// 2. process_id does not refer to an ongoing process.
+pub fn is_exceeding_resources(
+    assigned_disk: u64,
+    assigned_memory: u64,
+    workload_dir_path: &Path,
+    process_id: u32,
+) -> bool {
+    let used_mem = process_memory_occupied(process_id);
+    if used_mem >= assigned_memory {
+        return true;
+    }
+
+    if assigned_disk == 0 {
+        return false;
+    }
+
+    fn dir_size(path: &Path) -> u64 {
+        std::fs::read_dir(path)
+            .unwrap()
+            .into_iter()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| {
+                let entry_metadata = entry.metadata().unwrap();
+                if entry_metadata.is_dir() {
+                    dir_size(&entry.path())
+                } else {
+                    entry_metadata.size()
+                }
+            })
+            .sum()
+    }
+
+    let used_disk = dir_size(workload_dir_path);
+    if used_disk >= assigned_disk {
+        return true;
+    }
+
+    false
 }

--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -3,7 +3,7 @@ use imbl::OrdMap;
 use rand::{distributions::WeightedIndex, prelude::*};
 use std::{
     collections::HashSet,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -19,11 +19,11 @@ use crate::{
         config::WorkloadConfiguration,
         controller::{self, SpawnedAgentController},
         pbt,
-        resource::ResourceAllocator,
+        resource::{self, ResourceAllocator, ResourceExhaustation},
     },
 };
 
-use super::resource::ResourceExhaustation;
+use super::resource::AssignedResources;
 
 /// Represents a snapshot of the state of the database.
 #[derive(Clone)]
@@ -38,6 +38,51 @@ impl Snapshot {
         Self {
             sync_seqn: 0,
             state: OrdMap::new(),
+        }
+    }
+}
+
+enum Resources {
+    /// Resource allocator that is used to assign and check resource usage.
+    Allocator(Arc<Mutex<ResourceAllocator>>),
+    /// Resources are already assigned.
+    Assigned(AssignedResources),
+}
+
+impl Resources {
+    fn free(&self, workload_id: u64) {
+        match self {
+            Resources::Allocator(resource_alloc) => {
+                resource_alloc.lock().unwrap().free(workload_id);
+            }
+            Resources::Assigned(_) => (),
+        }
+    }
+
+    fn is_exceeding_resources(
+        &self,
+        workload_id: u64,
+        workload_dir_path: &Path,
+        process_id: u32,
+    ) -> bool {
+        match self {
+            Resources::Allocator(resource_alloc) => resource_alloc
+                .lock()
+                .unwrap()
+                .is_exceeding_resources(workload_id, workload_dir_path, process_id),
+            Resources::Assigned(AssignedResources { disk, memory }) => {
+                resource::is_exceeding_resources(*disk, *memory, workload_dir_path, process_id)
+            }
+        }
+    }
+
+    fn assigned_resources(&self, workload_id: u64) -> AssignedResources {
+        match self {
+            Resources::Allocator(resource_alloc) => resource_alloc
+                .lock()
+                .unwrap()
+                .assigned_resources(workload_id),
+            Resources::Assigned(assigned_resources) => *assigned_resources,
         }
     }
 }
@@ -90,10 +135,9 @@ pub struct Workload {
     enabled_enospc: bool,
     /// Whether the trickfs is currently configured to inject latency for every operation.
     enabled_latency: bool,
-    /// ResourceAllocator is used to make sure that the workload that is being executed
-    /// does not exceed the assigned disk space and memory and to free the assigned
-    /// resources when it finishes.
-    resource_alloc: Arc<Mutex<ResourceAllocator>>,
+    /// Resources is used to make sure that the workload that is being executed
+    /// does not exceed the assigned disk space and memory.
+    resources: Resources,
 }
 
 /// Contains the information required to apply a rollback.
@@ -115,8 +159,51 @@ impl Workload {
     ) -> Result<Self, ResourceExhaustation> {
         let mut rng = rand_pcg::Pcg64::seed_from_u64(seed);
 
-        let config = WorkloadConfiguration::new(&mut rng, resource_alloc.clone(), workload_id)?;
+        let config = WorkloadConfiguration::new(&mut rng, workload_id, resource_alloc.clone())?;
 
+        Ok(Self::new_inner(
+            rng,
+            seed,
+            workload_dir,
+            workload_id,
+            config,
+            Resources::Allocator(resource_alloc),
+        ))
+    }
+
+    pub fn new_with_resources(
+        seed: u64,
+        workload_dir: TempDir,
+        workload_id: u64,
+        assigned_disk: u64,
+        assigned_memory: u64,
+    ) -> Self {
+        let mut rng = rand_pcg::Pcg64::seed_from_u64(seed);
+
+        let config =
+            WorkloadConfiguration::new_with_resources(&mut rng, assigned_disk, assigned_memory);
+
+        Self::new_inner(
+            rng,
+            seed,
+            workload_dir,
+            workload_id,
+            config,
+            Resources::Assigned(AssignedResources {
+                disk: assigned_disk,
+                memory: assigned_memory,
+            }),
+        )
+    }
+
+    fn new_inner(
+        rng: rand_pcg::Pcg64,
+        seed: u64,
+        workload_dir: TempDir,
+        workload_id: u64,
+        config: WorkloadConfiguration,
+        resources: Resources,
+    ) -> Self {
         #[cfg(target_os = "linux")]
         let trick_handle = if config.trickfs {
             let trickfs_path = workload_dir.path().join("trickfs");
@@ -129,7 +216,7 @@ impl Workload {
         #[cfg(not(target_os = "linux"))]
         let trick_handle = None;
 
-        Ok(Self {
+        Self {
             workload_dir,
             trick_handle,
             agent: None,
@@ -140,11 +227,11 @@ impl Workload {
             scheduled_rollback: None,
             enabled_enospc: false,
             enabled_latency: false,
-            resource_alloc,
+            resources,
             rng,
             committed: Snapshot::empty(),
             config,
-        })
+        }
     }
 
     /// Run the workload.
@@ -167,7 +254,7 @@ impl Workload {
         // Irregardless of the result or if the workload was cancelled, we need to release the
         // resources.
         self.teardown().await;
-        self.resource_alloc.lock().unwrap().free(self.workload_id);
+        self.resources.free(self.workload_id);
         result
     }
 
@@ -177,7 +264,8 @@ impl Workload {
             self.run_iteration()
                 .instrument(trace_span!("iteration", iterno))
                 .await?;
-            if self.resource_alloc.lock().unwrap().is_exceeding_resources(
+
+            if self.resources.is_exceeding_resources(
                 self.workload_id,
                 self.workload_dir.path(),
                 self.agent.as_ref().unwrap().pid().unwrap(),
@@ -770,6 +858,11 @@ impl Workload {
     /// Return the workload directory path.
     pub fn workload_dir_path(&self) -> PathBuf {
         self.workload_dir.path().to_path_buf()
+    }
+
+    /// Return the workload directory path.
+    pub fn assigned_resources(&self) -> AssignedResources {
+        self.resources.assigned_resources(self.workload_id)
     }
 
     fn gen_commit(&mut self) -> (Snapshot, Vec<Key>, Vec<KeyValueChange>) {


### PR DESCRIPTION
Now failed workloads can be re-executed specifying the seed
and optionally limiting resource usage, as in the swarm execution.