### PR TITLE
refactor/feat(torture): resource usage

### DIFF
--- a/torture/src/supervisor/cli.rs
+++ b/torture/src/supervisor/cli.rs
@@ -27,6 +27,16 @@ pub struct SwarmParams {
     /// It will contain all workload folders.
     #[arg(long = "workdir")]
     pub workdir: Option<String>,
+
+    /// The maximum percentage of total disk space that torture will occupy.
+    #[clap(value_parser=clap::value_parser!(u8).range(1..=100))]
+    #[arg(long, default_value_t = 70)]
+    pub max_disk: u8,
+
+    /// The maximum percentage of total memory that torture will occupy.
+    #[clap(value_parser=clap::value_parser!(u8).range(1..=100))]
+    #[arg(long, default_value_t = 70)]
+    pub max_memory: u8,
 }
 
 #[derive(Clone, Debug, Args)]

--- a/torture/src/supervisor/mod.rs
+++ b/torture/src/supervisor/mod.rs
@@ -255,6 +255,8 @@ async fn control_loop(
     let resource_alloc = Arc::new(Mutex::new(ResourceAllocator::new(
         workdir_path.clone(),
         seed,
+        swarm_params.max_disk,
+        swarm_params.max_memory,
     )?));
 
     loop {


### PR DESCRIPTION
Adds flags to specify the maximum amount of disk and memory that torture can use,
and also forces the workload to use more space instead of selecting uniformly
between 0 and the available amount