### PR TITLE
fix(torture): space usage

### DIFF
--- a/torture/src/agent.rs
+++ b/torture/src/agent.rs
@@ -296,7 +296,7 @@ impl Agent {
         o.page_cache_upper_levels(open_params.page_cache_upper_levels);
         if let Some(n_commits) = open_params.rollback {
             o.rollback(true);
-            o.max_rollback_log_len(n_commits);
+            o.max_rollback_log_len(n_commits as u32);
         } else {
             o.rollback(false);
         }

--- a/torture/src/message.rs
+++ b/torture/src/message.rs
@@ -59,7 +59,7 @@ pub struct OpenPayload {
     pub bitbox_seed: [u8; 16],
     /// Whether the agent is supposed to handle rollbacks.
     /// If `Some`, the maximum number of supported blocks in a single rollback is specified.
-    pub rollback: Option<u32>,
+    pub rollback: Option<usize>,
     /// The number of commit workers.
     pub commit_concurrency: usize,
     /// The number of io_uring instances.

--- a/torture/src/supervisor/comms.rs
+++ b/torture/src/supervisor/comms.rs
@@ -160,7 +160,7 @@ pub fn run(stream: UnixStream) -> (RequestResponse, impl Future<Output = anyhow:
         SymmetricalBincode::default(),
     );
 
-    let timeout = Duration::from_secs(40);
+    let timeout = Duration::from_secs(60);
 
     let shared = Arc::new(Shared {
         reqno: AtomicU64::new(0),


### PR DESCRIPTION
Estimate the number of items that bitbox and beatree can store to avoid reaching Bucket or Resources Exhaustion. 
To have a proper estimation, I had to remove the custom key distribution, otherwise, the number of expected pages was not easily estimable.

Now you can run the torture swarm testing with the following command: `cargo run --release -p torture -- swarm -f 10 --max-disk 70 --max-memory 80`.

If a run workload fails, it can be repeated with `cargo run --release -p torture -- run <SEED>`, and optionally with the flags `--assigned-memory` and `--assigned-disk`. They are optional because the error might or might not depend on the constraints over resources.

Seed and assigned resources are printed in the `InvestigationFlag`.