### PR TITLE
feat(nomt): enable `borsh` for `nomt::Root`

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -204,6 +204,10 @@ impl KeyReadWrite {
 
 /// The root of the Merkle Trie.
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct Root([u8; 32]);
 
 impl Root {

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -248,6 +248,18 @@ impl std::fmt::Debug for Root {
     }
 }
 
+impl AsRef<[u8]> for Root {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl From<[u8; 32]> for Root {
+    fn from(value: [u8; 32]) -> Self {
+        Self(value)
+    }
+}
+
 /// An instance of the Nearly-Optimal Merkle Trie Database.
 pub struct Nomt<T: HashAlgorithm> {
     merkle_update_pool: UpdatePool,


### PR DESCRIPTION
As well as handy `AsRef<[u8]>` and `From<[u8;32]>`