### PR TITLE
feat: count merkle leaves in ht pages

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -639,9 +639,11 @@ impl<T: HashAlgorithm> Session<T> {
             compact_actuals.push((path.clone(), read_write.to_compact::<T>()));
         }
 
-        let merkle_update_handle = self
-            .merkle_updater
-            .update_and_prove::<T>(compact_actuals, self.witness_mode.0)?;
+        let merkle_update_handle = self.merkle_updater.update_and_prove::<T>(
+            compact_actuals,
+            self.witness_mode.0,
+            self.metrics,
+        )?;
 
         let mut tx = self.store.new_value_tx();
         for (path, read_write) in actuals {

--- a/nomt/src/metrics.rs
+++ b/nomt/src/metrics.rs
@@ -20,11 +20,17 @@ pub enum Metric {
     PageFetchTime,
     /// Timer used to record average value fetch time during reads
     ValueFetchTime,
+    /// Counter of created or modified hashtable pages.
+    HashTablePages,
+    /// Count of elided hashtable pages.
+    ElidedHashTablePages,
 }
 
 struct ActiveMetrics {
     page_requests: AtomicU64,
     page_cache_misses: AtomicU64,
+    hashtable_pages: AtomicU64,
+    elided_hashtable_pages: AtomicU64,
     page_fetch_time: Timer,
     value_fetch_time: Timer,
 }
@@ -37,6 +43,8 @@ impl Metrics {
                 Some(Arc::new(ActiveMetrics {
                     page_requests: AtomicU64::new(0),
                     page_cache_misses: AtomicU64::new(0),
+                    elided_hashtable_pages: AtomicU64::new(0),
+                    hashtable_pages: AtomicU64::new(0),
                     page_fetch_time: Timer::new(),
                     value_fetch_time: Timer::new(),
                 }))
@@ -54,6 +62,8 @@ impl Metrics {
             let counter = match metric {
                 Metric::PageRequests => &metrics.page_requests,
                 Metric::PageCacheMisses => &metrics.page_cache_misses,
+                Metric::HashTablePages => &metrics.hashtable_pages,
+                Metric::ElidedHashTablePages => &metrics.elided_hashtable_pages,
                 _ => panic!("Specified metric is not a Counter"),
             };
 
@@ -80,6 +90,12 @@ impl Metrics {
     pub fn print(&self) {
         if let Some(ref metrics) = self.metrics {
             println!("metrics");
+
+            let hashtable_pages = metrics.hashtable_pages.load(Ordering::Relaxed);
+            println!("  ht pages              {}", hashtable_pages);
+
+            let elided_hashtable_pages = metrics.elided_hashtable_pages.load(Ordering::Relaxed);
+            println!("  elided ht pages       {}", elided_hashtable_pages);
 
             let tot_page_requests = metrics.page_requests.load(Ordering::Relaxed);
             println!("  page requests         {}", tot_page_requests);


### PR DESCRIPTION
Add a feature that counts the number of leaves
in each subtree on a bitbox page.

This pr also introduces two new metrics to keep track of how many pages were elided and how many were actually created or modified.