### PR TITLE
feat: page elision

### DIFF
--- a/core/src/page_id.rs
+++ b/core/src/page_id.rs
@@ -53,7 +53,7 @@ pub const NUM_CHILDREN: usize = MAX_CHILD_INDEX as usize + 1;
 ///
 /// Each page can be thought of a root-less binary tree. The leaves of that tree are roots of
 /// subtrees stored in subsequent pages. There are 64 (2^[`DEPTH`]) children in each page.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct ChildPageIndex(u8);
 
 impl ChildPageIndex {

--- a/nomt/src/bitbox/mod.rs
+++ b/nomt/src/bitbox/mod.rs
@@ -249,6 +249,7 @@ impl DB {
                     dirty_page
                         .diff
                         .pack_changed_nodes(dirty_page.page.page_data()),
+                    dirty_page.page.elided_children(),
                     bucket,
                 );
 
@@ -459,6 +460,7 @@ fn recover(
                 page_id,
                 page_diff,
                 changed_nodes,
+                elided_children,
                 bucket,
             } => {
                 let hash = hash_raw_page_id(page_id, &seed);
@@ -490,6 +492,9 @@ fn recover(
 
                 // Label the page.
                 page[PAGE_SIZE - 32..].copy_from_slice(&page_id);
+                // Write elided children bitfield.
+                page[PAGE_SIZE - 32 - 8..PAGE_SIZE - 32]
+                    .copy_from_slice(&elided_children.to_le_bytes());
 
                 ht_fd.write_all_at(&page, pn * PAGE_SIZE as u64)?;
             }

--- a/nomt/src/bitbox/wal/read.rs
+++ b/nomt/src/bitbox/wal/read.rs
@@ -19,6 +19,8 @@ pub enum WalEntry {
         /// Nodes that were changed by this update. The length of this array must be consistent with
         /// the number of ones in `page_diff`.
         changed_nodes: Vec<[u8; 32]>,
+        /// Bitfield representing which child page has been elided.
+        elided_children: u64,
         /// The bucket index which is being updated.
         bucket: u64,
     },
@@ -101,12 +103,14 @@ impl WalBlobReader {
                     changed_nodes.push(node);
                 }
 
+                let elided_children = self.read_u64()?;
                 let bucket = self.read_u64()?;
 
                 Ok(Some(WalEntry::Update {
                     page_id,
                     page_diff,
                     changed_nodes,
+                    elided_children,
                     bucket,
                 }))
             }

--- a/nomt/src/bitbox/wal/tests.rs
+++ b/nomt/src/bitbox/wal/tests.rs
@@ -24,6 +24,7 @@ fn test_write_read() {
         .unwrap(),
         vec![].into_iter(),
         0,
+        0,
     );
     builder.write_clear(1);
     builder.write_update(
@@ -33,6 +34,7 @@ fn test_write_read() {
         ))
         .unwrap(),
         vec![[1; 32]].into_iter(),
+        1,
         1,
     );
     builder.write_update(
@@ -45,6 +47,7 @@ fn test_write_read() {
             diff
         },
         (0..126).map(|x| [x; 32]),
+        2,
         2,
     );
     builder.finalize();
@@ -65,6 +68,7 @@ fn test_write_read() {
             page_id: [0; 32],
             page_diff: PageDiff::default(),
             changed_nodes: vec![],
+            elided_children: 0,
             bucket: 0,
         })
     );
@@ -82,6 +86,7 @@ fn test_write_read() {
                 diff
             },
             changed_nodes: vec![[1; 32]],
+            elided_children: 1,
             bucket: 1,
         })
     );
@@ -97,6 +102,7 @@ fn test_write_read() {
                 diff
             },
             changed_nodes: (0..126).map(|x| [x; 32]).collect(),
+            elided_children: 2,
             bucket: 2,
         })
     );

--- a/nomt/src/bitbox/wal/write.rs
+++ b/nomt/src/bitbox/wal/write.rs
@@ -99,6 +99,7 @@ impl WalBlobBuilder {
         page_id: [u8; 32],
         page_diff: &PageDiff,
         changed: impl Iterator<Item = [u8; 32]>,
+        elided_children: u64,
         bucket_index: u64,
     ) {
         unsafe {
@@ -109,6 +110,7 @@ impl WalBlobBuilder {
             for changed in changed {
                 self.write(&changed);
             }
+            self.write(&elided_children.to_le_bytes());
             self.write(&bucket_index.to_le_bytes());
         }
     }


### PR DESCRIPTION
This PR introduces *page elision*, which aims to reduce the space consumption of the hash table. Each HT bucket/page stores a root-less binary tree of depth 6, and page elision means that a page (and its children) is not stored in the hash table if the root-less binary tree contains fewer than a certain number of Merkle leaves. Pages that are elided are then reconstructed on the fly when needed, utilizing the btree to fetch all required values.

The page walker was modified to allow for page reconstruction in a way that minimizes the impact on the codebase and reuses most of the code from the previous PageWalker state. I tried many solutions, but each of them seemed to lead to messy outcomes, with a lot of code duplication. For now, this works, and it was not such an intrusive modification that it still brings a entirely new feature. Suggestions are welcome to find a better way to split the update and reconstruction logic!

Important notes:
+ This feature does not require any migration and will work on already existing db states
+ There are incompatibilities in the WAL format, where a field has been added, thus, this version cannot work on a partially updated db where the WAL needs to be scanned and applied
+ `PAGE_ELISION_THRESHOLD` can be increased between runs but not decreased due to an assumption I made regarding the number of leaves per subtree. TBD: whether this parameter should be user-modifiable (which would necessitate solving the decreasing issue) or if it should be defined as static for everyone