### PR TITLE
Expose prev_root() getter for Session

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -572,7 +572,7 @@ impl<T: HashAlgorithm> Session<T> {
         self.store.load_value(path)
     }
 
-    /// Prev root
+    /// Previous root
     pub fn prev_root(&self) -> Root {
         self.prev_root
     }

--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -572,6 +572,11 @@ impl<T: HashAlgorithm> Session<T> {
         self.store.load_value(path)
     }
 
+    /// Prev root
+    pub fn prev_root(&self) -> Root {
+        self.prev_root
+    }
+
     /// Signals that the given key is going to be written to. Relevant only if rollback is enabled.
     ///
     /// This function initiates an I/O load operation to fetch and preserve the prior value of the key.


### PR DESCRIPTION
Sovereign SDK operates on `Session` and `FinishedSession` and it needs access to prev_root to pass it to ZK guest.

I am happy to change location of it, but this method is needed for the integration.

Please let me know if there's any issue of exposing it.