### PR TITLE
Use `digest` crate for Blanket implementation of `BinaryHash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "bitvec",
  "blake3",
  "borsh",
+ "digest",
  "hex",
  "ruint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ fuser = { version = "0.15.1", features = ["abi-7-23"] }
 log = "0.4.22"
 rand_distr = "0.4.3"
 env_logger = "0.11.6"
+digest = { version = "0.10.7" }
 
 [profile.release]
 debug = 1

--- a/benchtop/Cargo.lock
+++ b/benchtop/Cargo.lock
@@ -2265,6 +2265,7 @@ dependencies = [
  "bitvec",
  "blake3",
  "borsh 1.5.7",
+ "digest 0.10.7",
  "hex",
  "ruint",
  "serde",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ borsh = { workspace = true, optional = true }
 blake3 = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+digest = { workspace = true }
 
 [dev-dependencies]
 blake3.workspace = true

--- a/core/src/hasher.rs
+++ b/core/src/hasher.rs
@@ -102,6 +102,13 @@ impl<H: BinaryHash> NodeHasher for BinaryHasher<H> {
     }
 }
 
+/// Blanket implementation for all implementations of `Digest`
+impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> BinaryHash for H {
+    fn hash(input: &[u8]) -> [u8; 32] {
+        H::digest(input).into()
+    }
+}
+
 #[cfg(any(feature = "blake3-hasher", test))]
 pub use blake3::Blake3Hasher;
 

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -33,6 +33,7 @@ cfg-if.workspace = true
 borsh = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
+
 [target.'cfg(target_os="linux")'.dependencies]
 io-uring.workspace = true
 

--- a/nomt/Cargo.toml
+++ b/nomt/Cargo.toml
@@ -33,7 +33,6 @@ cfg-if.workspace = true
 borsh = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
-
 [target.'cfg(target_os="linux")'.dependencies]
 io-uring.workspace = true
 


### PR DESCRIPTION

In Sovereign SDK we use `digest` as generic way to reprsent different hashers. So SDK itself does not depend on particular hasher implementation:

```
pub trait CryptoSpec {
    type Hasher: digest::Digest<OutputSize = digest::typenum::U32>;
    // The rest is omitted
}
```

This PR adds blanket implementation of `BinaryHash` for all Digest with matching output size.