### PR TITLE
fix: reconstructed nodes in the recovery process

### DIFF
--- a/nomt/src/merkle/seek.rs
+++ b/nomt/src/merkle/seek.rs
@@ -312,8 +312,12 @@ impl SeekRequest {
             final_leaf_data_collection,
         );
 
-        for (page_id, page, leaves_counter) in pages {
-            page_set.insert(page_id, page, PageOrigin::Reconstructed(leaves_counter));
+        for (page_id, page, diff, leaves_counter) in pages {
+            page_set.insert(
+                page_id,
+                page,
+                PageOrigin::Reconstructed(leaves_counter, diff),
+            );
         }
 
         // Now that all pages are reconstructed, seeking can be resumed.

--- a/nomt/src/page_diff.rs
+++ b/nomt/src/page_diff.rs
@@ -112,6 +112,15 @@ impl PageDiff {
         FastIterOnes(self.changed_nodes[0])
             .chain(FastIterOnes(self.changed_nodes[1]).map(|i| i + 64))
     }
+
+    pub fn join(&self, diff: &PageDiff) -> PageDiff {
+        PageDiff {
+            changed_nodes: [
+                self.changed_nodes[0] | diff.changed_nodes[0],
+                self.changed_nodes[1] | diff.changed_nodes[1],
+            ],
+        }
+    }
 }
 
 struct FastIterOnes(u64);


### PR DESCRIPTION
Pages that get promoted from reconstructed to updated
are written to disk. However, if the process fails, the WAL only
contains the diffs of updated nodes and not all the nodes,
along with the just reconstructed ones.
This adds the reconstructed nodes to the page diffs as well.