### PR TITLE
Fix typos in comments

### DIFF
--- a/torture/src/supervisor/resource.rs
+++ b/torture/src/supervisor/resource.rs
@@ -186,7 +186,7 @@ pub enum ResourceExhaustion {
 }
 
 /// Return the amount of physical memory utilized by the specified pid, or None
-/// if the `statm` file associated with the `pid` is not avaiable.
+/// if the `statm` file associated with the `pid` is not available.
 pub fn process_memory_occupied(pid: u32) -> Option<u64> {
     let file_path = format!("/proc/{}/statm", pid);
     let mut statm_file = std::fs::File::open(&file_path).ok()?;
@@ -202,7 +202,7 @@ pub fn process_memory_occupied(pid: u32) -> Option<u64> {
     Some(occupied_memory)
 }
 
-/// Returns the number of avaiable and total memory in bytes.
+/// Returns the number of available and total memory in bytes.
 ///
 /// Panics if /proc/meminfo does not exist or is not formatted as usual.
 fn mem_info() -> (u64, u64) {

--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -440,7 +440,7 @@ impl Workload {
 
     fn get_crash_delay(&self) -> Duration {
         // The agent should crash after `crash_delay`ns.
-        // If no data avaible crash after 300ms.
+        // If no data available crash after 300ms.
         let mut crash_delay_millis = self
             .tot_commit_time
             .as_millis()


### PR DESCRIPTION


This pull request fixes spelling errors in comments across multiple files:
- In torture/src/supervisor/resource.rs: Fix typo in comments about file availability
- In torture/src/supervisor/workload.rs: Fix typo in crash delay documentation

These changes improve code readability and documentation quality without affecting functionality.