### PR TITLE
Removes bound from Nomt struct

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -266,7 +266,7 @@ impl From<[u8; 32]> for Root {
 }
 
 /// An instance of the Nearly-Optimal Merkle Trie Database.
-pub struct Nomt<T: HashAlgorithm> {
+pub struct Nomt<T> {
     merkle_update_pool: UpdatePool,
     /// The handle to the page cache.
     page_cache: PageCache,


### PR DESCRIPTION
It simplifies code for structs that only hold Nomt, but don't use it.

Please note that effective boundary remains, but it is only on `impl` blocks