### PR TITLE
No merge: example of failing example of witness verification

### DIFF
--- a/examples/commit_batch/src/lib.rs
+++ b/examples/commit_batch/src/lib.rs
@@ -38,6 +38,7 @@ impl NomtDB {
         //
         // `read` will immediately return the value present in the database
         let value = session.read(key_path_1)?;
+        let value_2 = Some(vec![1, 2, 3]);
 
         // We are going to perform writes on both key-paths, so we have NOMT warm up the on-disk
         // data for both.
@@ -51,7 +52,7 @@ impl NomtDB {
         // performed actions into a vector where items are ordered by the key_path
         let mut actual_access: Vec<_> = vec![
             (key_path_1, KeyReadWrite::ReadThenWrite(value.clone(), None)),
-            (key_path_2, KeyReadWrite::Write(value)),
+            (key_path_2, KeyReadWrite::Write(value_2.clone())),
         ];
         actual_access.sort_by_key(|(k, _)| *k);
 


### PR DESCRIPTION
I've noticed, that example of commit batch does not change database in any way, because nothing is written.

After adding write to a second key, witness verification example starts to fail.

Steps to reproduce:

1. Checkout this branch
2. `cd examples/witness_verification`
3. `cargo run`

## Expected results

Process completes with exit code zero

## Actual results:

```

thread 'main' panicked at examples/witness_verification/src/main.rs:76:5:
assertion `left == right` failed
  left: [158, 25, 120, 36, 49, 185, 135, 224, 110, 46, 165, 242, 248, 7, 135, 130, 125, 124, 112, 6, 69, 61, 175, 103, 47, 147, 217, 142, 17, 94, 96, 251]
 right: [177, 186, 210, 210, 33, 23, 10, 142, 238, 159, 27, 40, 119, 249, 21, 19, 32, 201, 225, 18, 65, 106, 118, 228, 206, 145, 41, 169, 125, 158, 85, 136]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```