### PR TITLE
Add conditional allow for non linux targets

### DIFF
--- a/torture/src/supervisor/config.rs
+++ b/torture/src/supervisor/config.rs
@@ -103,6 +103,7 @@ pub struct WorkloadConfiguration {
     /// Whether trickfs will be used or not.
     ///
     /// If false, enospc_on/off and latency_on/off will all be 0.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub trickfs: bool,
     /// The probability of turning on the `ENOSPC` error.
     pub enospc_on: f64,

--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -206,6 +206,8 @@ impl Workload {
         )
     }
 
+    
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
     fn new_inner(
         rng: rand_pcg::Pcg64,
         seed: u64,

--- a/torture/src/supervisor/workload.rs
+++ b/torture/src/supervisor/workload.rs
@@ -206,7 +206,6 @@ impl Workload {
         )
     }
 
-    
     #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
     fn new_inner(
         rng: rand_pcg::Pcg64,


### PR DESCRIPTION
Removes following warnings, when built on macos:

```
warning: unused variable: `seed`
   --> torture/src/supervisor/workload.rs:211:9
    |
211 |         seed: u64,
    |         ^^^^ help: if this is intentional, prefix it with an underscore: `_seed`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: field `trickfs` is never read
   --> torture/src/supervisor/config.rs:106:9
    |
46  | pub struct WorkloadConfiguration {
    |            --------------------- field in this struct
...
106 |     pub trickfs: bool,
    |         ^^^^^^^
    |
    = note: `WorkloadConfiguration` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
    = note: `#[warn(dead_code)]` on by default
```