### PR TITLE
refactor: remove page elision metrics

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -569,11 +569,9 @@ impl<T: HashAlgorithm> Session<T> {
             compact_actuals.push((path.clone(), read_write.to_compact::<T>()));
         }
 
-        let merkle_update_handle = self.merkle_updater.update_and_prove::<T>(
-            compact_actuals,
-            self.witness_mode.0,
-            self.metrics,
-        )?;
+        let merkle_update_handle = self
+            .merkle_updater
+            .update_and_prove::<T>(compact_actuals, self.witness_mode.0)?;
 
         let mut tx = self.store.new_value_tx();
         for (path, read_write) in actuals {

--- a/nomt/src/merkle/mod.rs
+++ b/nomt/src/merkle/mod.rs
@@ -17,7 +17,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     io::PagePool,
-    metrics::Metrics,
     overlay::LiveOverlay,
     page_cache::{Page, PageCache, ShardIndex},
     rw_pass_cell::WritePassEnvelope,
@@ -266,7 +265,6 @@ impl Updater {
         self,
         read_write: Vec<(KeyPath, KeyReadWrite)>,
         witness: bool,
-        metrics: Metrics,
     ) -> std::io::Result<UpdateHandle> {
         if let Some(ref warm_up) = self.warm_up {
             let _ = warm_up.finish_tx.send(());
@@ -310,7 +308,7 @@ impl Updater {
                 warm_page_set: warm_page_set.clone(),
                 command,
             };
-            spawn_updater::<H>(&self.worker_tp, params, worker_tx.clone(), metrics.clone());
+            spawn_updater::<H>(&self.worker_tp, params, worker_tx.clone());
         }
 
         Ok(UpdateHandle {
@@ -535,13 +533,8 @@ fn spawn_updater<H: HashAlgorithm>(
     worker_tp: &ThreadPool,
     params: worker::UpdateParams,
     output_tx: Sender<TaskResult<std::io::Result<WorkerOutput>>>,
-    metrics: Metrics,
 ) {
-    spawn_task(
-        &worker_tp,
-        || worker::run_update::<H>(params, metrics),
-        output_tx,
-    );
+    spawn_task(&worker_tp, || worker::run_update::<H>(params), output_tx);
 }
 
 fn get_in_memory_page(

--- a/nomt/src/merkle/mod.rs
+++ b/nomt/src/merkle/mod.rs
@@ -41,7 +41,7 @@ use nomt_core::page_id::MAX_CHILD_INDEX;
 
 /// Threshold representing the number of leaves required to be present in the two
 /// subtrees contained in a page to be stored on disk.
-/// If this threshold is not exceeded, the page will not be stored on disk
+/// If this threshold is not reached, the page will not be stored on disk
 /// and will be constructed on the fly when needed.
 pub const PAGE_ELISION_THRESHOLD: u64 = 20;
 
@@ -64,13 +64,12 @@ impl ElidedChildren {
         }
     }
 
+    /// Get raw bytes representing the `ElidedChildren`.
     pub fn to_bytes(&self) -> [u8; 8] {
         self.elided.to_le_bytes()
     }
 
     /// Toggle as elided or not elided a child of the page.
-    ///
-    /// Panics if `child_index` is bigger than [`MAX_CHILD_INDEX`].
     pub fn set_elide(&mut self, child_page_index: ChildPageIndex, elide: bool) {
         let shift = child_page_index.to_u8() as u64;
         if elide {
@@ -81,8 +80,6 @@ impl ElidedChildren {
     }
 
     /// Checks if the child at `child_index` is elided.
-    ///
-    /// Panics if `child_index` is bigger than [`MAX_CHILD_INDEX`].
     pub fn is_elided(&self, child_page_index: ChildPageIndex) -> bool {
         (self.elided >> child_page_index.to_u8() as u64) & 1 == 1
     }

--- a/nomt/src/merkle/page_set.rs
+++ b/nomt/src/merkle/page_set.rs
@@ -22,7 +22,7 @@ pub enum PageOrigin {
 }
 
 impl PageOrigin {
-    /// Extract `BucketInfo` from `PageOrigin::Persisted` variant.
+    /// Extract `BucketInfo` from [`PageOrigin::Persisted`] variant.
     pub fn bucket_info(self) -> Option<BucketInfo> {
         match self {
             PageOrigin::Persisted(bucket_info) => Some(bucket_info),
@@ -30,7 +30,7 @@ impl PageOrigin {
         }
     }
 
-    /// Extract the number of leaves from `PageOrigin::Reconstructed` variant.
+    /// Extract the number of leaves from [`PageOrigin::Reconstructed`] variant.
     pub fn leaves_counter(&self) -> Option<u64> {
         match self {
             PageOrigin::Reconstructed(counter, _) => Some(*counter),
@@ -38,7 +38,7 @@ impl PageOrigin {
         }
     }
 
-    /// Extract the [`PageDiff`] from `PageOrigin::Reconstructed` variant.
+    /// Extract the [`PageDiff`] from [`PageOrigin::Reconstructed`] variant.
     pub fn page_diff(&self) -> Option<&PageDiff> {
         match self {
             PageOrigin::Reconstructed(_, page_diff) => Some(page_diff),

--- a/nomt/src/merkle/page_walker.rs
+++ b/nomt/src/merkle/page_walker.rs
@@ -120,7 +120,6 @@ struct StackPage {
     /// track of it because all parent pages also exceed the threshold.
     leaves_counter: Option<u64>,
     /// Bitfield used to keep track of which child pages have been elided.
-    /// `None` if no child page has been elided.
     elided_children: ElidedChildren,
     /// A compact diff indicating all reconstructed slots in the page if the
     /// page was reconstructed.
@@ -976,8 +975,6 @@ pub fn reconstruct_pages<H: nomt_core::hasher::NodeHasher>(
 
     assert_eq!(root, subtree_root);
 
-    // SAFETY: PageWalker was initialized with the parent_page set to Some thus
-    // no updated page is expected.
     reconstructed_pages.into_iter().map(|reconstructed_page| {
         (
             reconstructed_page.page_id,

--- a/nomt/src/merkle/worker.rs
+++ b/nomt/src/merkle/worker.rs
@@ -33,7 +33,6 @@ use super::{
 
 use crate::{
     io::PagePool,
-    metrics::Metrics,
     page_cache::{PageCache, ShardIndex},
     page_region::PageRegion,
     rw_pass_cell::WritePass,
@@ -84,10 +83,7 @@ pub(super) fn run_warm_up<H: HashAlgorithm>(
     warm_up_phase(page_io_receiver, seeker, page_set, warmup_rx, finish_rx)
 }
 
-pub(super) fn run_update<H: HashAlgorithm>(
-    params: UpdateParams,
-    metrics: Metrics,
-) -> std::io::Result<WorkerOutput> {
+pub(super) fn run_update<H: HashAlgorithm>(params: UpdateParams) -> std::io::Result<WorkerOutput> {
     let UpdateParams {
         page_cache,
         page_pool,
@@ -117,7 +113,6 @@ pub(super) fn run_update<H: HashAlgorithm>(
         command,
         warm_ups,
         warm_page_set,
-        metrics,
     )
 }
 
@@ -210,7 +205,6 @@ fn update<H: HashAlgorithm>(
     command: UpdateCommand,
     warm_ups: Arc<HashMap<KeyPath, Seek>>,
     warm_page_set: Option<FrozenSharedPageSet>,
-    metrics: Metrics,
 ) -> std::io::Result<WorkerOutput> {
     let UpdateCommand { shared, write_pass } = command;
     let write_pass = write_pass.into_inner();
@@ -219,13 +213,7 @@ fn update<H: HashAlgorithm>(
 
     let mut page_set = PageSet::new(page_pool, warm_page_set);
 
-    let updater = RangeUpdater::<H>::new(
-        root,
-        shared.clone(),
-        write_pass,
-        &page_cache,
-        metrics.clone(),
-    );
+    let updater = RangeUpdater::<H>::new(root, shared.clone(), write_pass, &page_cache);
 
     // one lucky thread gets the master write pass.
     match updater.update(&mut seeker, &mut output, &mut page_set, warm_ups)? {
@@ -234,7 +222,7 @@ fn update<H: HashAlgorithm>(
     };
 
     let pending_ops = shared.take_root_pending();
-    let mut root_page_updater = PageWalker::<H>::new(root, None, metrics);
+    let mut root_page_updater = PageWalker::<H>::new(root, None);
 
     // Ensure the root page updater holds the root page. It is possible that this worker did not
     // seek any keys, and therefore the root page would not have been populated yet.
@@ -296,7 +284,6 @@ impl<H: HashAlgorithm> RangeUpdater<H> {
         shared: Arc<UpdateShared>,
         write_pass: WritePass<ShardIndex>,
         page_cache: &PageCache,
-        metrics: Metrics,
     ) -> Self {
         let region = match write_pass.region() {
             ShardIndex::Root => PageRegion::universe(),
@@ -319,7 +306,7 @@ impl<H: HashAlgorithm> RangeUpdater<H> {
             shared,
             write_pass,
             region,
-            page_walker: PageWalker::<H>::new(root, Some(ROOT_PAGE_ID), metrics),
+            page_walker: PageWalker::<H>::new(root, Some(ROOT_PAGE_ID)),
             range_start,
             range_end,
         }

--- a/nomt/src/metrics.rs
+++ b/nomt/src/metrics.rs
@@ -20,17 +20,11 @@ pub enum Metric {
     PageFetchTime,
     /// Timer used to record average value fetch time during reads
     ValueFetchTime,
-    /// Counter of created or modified hashtable pages.
-    HashTablePages,
-    /// Count of elided hashtable pages.
-    ElidedHashTablePages,
 }
 
 struct ActiveMetrics {
     page_requests: AtomicU64,
     page_cache_misses: AtomicU64,
-    hashtable_pages: AtomicU64,
-    elided_hashtable_pages: AtomicU64,
     page_fetch_time: Timer,
     value_fetch_time: Timer,
 }
@@ -43,8 +37,6 @@ impl Metrics {
                 Some(Arc::new(ActiveMetrics {
                     page_requests: AtomicU64::new(0),
                     page_cache_misses: AtomicU64::new(0),
-                    elided_hashtable_pages: AtomicU64::new(0),
-                    hashtable_pages: AtomicU64::new(0),
                     page_fetch_time: Timer::new(),
                     value_fetch_time: Timer::new(),
                 }))
@@ -62,8 +54,6 @@ impl Metrics {
             let counter = match metric {
                 Metric::PageRequests => &metrics.page_requests,
                 Metric::PageCacheMisses => &metrics.page_cache_misses,
-                Metric::HashTablePages => &metrics.hashtable_pages,
-                Metric::ElidedHashTablePages => &metrics.elided_hashtable_pages,
                 _ => panic!("Specified metric is not a Counter"),
             };
 
@@ -90,12 +80,6 @@ impl Metrics {
     pub fn print(&self) {
         if let Some(ref metrics) = self.metrics {
             println!("metrics");
-
-            let hashtable_pages = metrics.hashtable_pages.load(Ordering::Relaxed);
-            println!("  ht pages              {}", hashtable_pages);
-
-            let elided_hashtable_pages = metrics.elided_hashtable_pages.load(Ordering::Relaxed);
-            println!("  elided ht pages       {}", elided_hashtable_pages);
 
             let tot_page_requests = metrics.page_requests.load(Ordering::Relaxed);
             println!("  page requests         {}", tot_page_requests);

--- a/nomt/src/page_diff.rs
+++ b/nomt/src/page_diff.rs
@@ -113,6 +113,8 @@ impl PageDiff {
             .chain(FastIterOnes(self.changed_nodes[1]).map(|i| i + 64))
     }
 
+    /// Join two `PageDiff` together into one, it results in a `PageDiff` that contains
+    /// all the changed nodes present in the two operand `PageDiff`s.
     pub fn join(&self, diff: &PageDiff) -> PageDiff {
         PageDiff {
             changed_nodes: [


### PR DESCRIPTION
As mentioned here https://github.com/thrumdev/nomt/pull/859#discussion_r2035107366, the page elision metrics are not particularly helpful. Understanding whether the feature was effectively eliding pages was only important initially to understand the correctness of the feature.