### PR TITLE
refactor/fix: page elision duplication of work

### DIFF
--- a/nomt/src/merkle/page_set.rs
+++ b/nomt/src/merkle/page_set.rs
@@ -62,11 +62,6 @@ impl PageSet {
         }
     }
 
-    /// Checks if a `page_id` is already present.
-    pub fn contains(&self, page_id: &PageId) -> bool {
-        self.map.contains_key(page_id)
-    }
-
     /// Freeze this page-set and make a shareable version of it. This returns a frozen page set
     /// containing all insertions into this map.
     pub fn freeze(self) -> FrozenSharedPageSet {
@@ -85,6 +80,10 @@ impl super::page_walker::PageSet for PageSet {
     fn fresh(&self, page_id: &PageId) -> PageMut {
         let page = PageMut::pristine_empty(&self.page_pool, &page_id);
         page
+    }
+
+    fn contains(&self, page_id: &PageId) -> bool {
+        self.map.contains_key(&page_id)
     }
 
     fn get(&self, page_id: &PageId) -> Option<(Page, PageOrigin)> {


### PR DESCRIPTION
Explicitly describe some duplication of work performed by the page reconstruction process
within the seeker, while simultaneously reducing it by checking if a page has already
been reconstructed before starting the page reconstruction.

A little duplication of work is acceptable because solutions to avoid it have more overhead
than simply performing the task. Benchmarks showed that on a 2^28 database with large commit sizes,
200k, where it is more likely that two requests share the same elided pages),
only 0.1% of elided pages had items collected twice.