### PR TITLE
feat: introduce a verify_multi_proof_update

### DIFF
--- a/core/src/proof/mod.rs
+++ b/core/src/proof/mod.rs
@@ -9,8 +9,8 @@
 //! of updating a trie with a set of changes ([`verify_update`]).
 
 pub use multi_proof::{
-    verify as verify_multi_proof, MultiPathProof, MultiProof, MultiProofVerificationError,
-    VerifiedMultiProof,
+    verify as verify_multi_proof, verify_update as verify_multi_proof_update, MultiPathProof,
+    MultiProof, MultiProofVerificationError, VerifiedMultiProof,
 };
 pub use path_proof::{
     verify_update, KeyOutOfScope, PathProof, PathProofTerminal, PathProofVerificationError,

--- a/core/src/proof/multi_proof.rs
+++ b/core/src/proof/multi_proof.rs
@@ -8,14 +8,14 @@ use crate::{
         path_proof::{hash_path, shared_bits},
         KeyOutOfScope, PathProof, PathProofTerminal,
     },
-    trie::{InternalData, KeyPath, LeafData, Node, TERMINATOR},
+    trie::{InternalData, KeyPath, LeafData, Node, NodeKind, ValueHash, TERMINATOR},
 };
 
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 
 use bitvec::prelude::*;
-use core::cmp::Ordering;
+use core::{cmp::Ordering, ops::Range};
 
 /// This struct includes the terminal node and its depth
 #[derive(Debug, Clone)]
@@ -277,12 +277,23 @@ pub enum MultiProofVerificationError {
 struct VerifiedMultiPath {
     terminal: PathProofTerminal,
     depth: usize,
+    unique_siblings: Range<usize>,
+}
+
+// indicates a bisection which started at a given depth and covers these common siblings.
+#[derive(Debug, Clone)]
+struct VerifiedBisection {
+    start_depth: usize,
+    common_siblings: Range<usize>,
 }
 
 /// A verified multi-proof.
 #[derive(Debug, Clone)]
 pub struct VerifiedMultiProof {
     inner: Vec<VerifiedMultiPath>,
+    bisections: Vec<VerifiedBisection>,
+    siblings: Vec<Node>,
+    root: Node,
 }
 
 impl VerifiedMultiProof {
@@ -401,13 +412,10 @@ pub fn verify<H: NodeHasher>(
     multi_proof: &MultiProof,
     root: Node,
 ) -> Result<VerifiedMultiProof, MultiProofVerificationError> {
-    let mut new_paths = Vec::with_capacity(multi_proof.paths.len());
+    let mut verified_paths = Vec::with_capacity(multi_proof.paths.len());
+    let mut verified_bisections = Vec::new();
     for i in 0..multi_proof.paths.len() {
         let path = &multi_proof.paths[i];
-        new_paths.push(VerifiedMultiPath {
-            terminal: path.terminal.clone(),
-            depth: path.depth,
-        });
         if i > 0 {
             if path.terminal.path() <= multi_proof.paths[i - 1].terminal.path() {
                 return Err(MultiProofVerificationError::PathsOutOfOrder);
@@ -415,8 +423,14 @@ pub fn verify<H: NodeHasher>(
         }
     }
 
-    let (new_root, siblings_used) =
-        verify_range::<H>(0, &multi_proof.paths, &multi_proof.siblings)?;
+    let (new_root, siblings_used) = verify_range::<H>(
+        0,
+        &multi_proof.paths,
+        &multi_proof.siblings,
+        0,
+        &mut verified_paths,
+        &mut verified_bisections,
+    )?;
 
     if root != new_root {
         return Err(MultiProofVerificationError::RootMismatch);
@@ -426,7 +440,12 @@ pub fn verify<H: NodeHasher>(
         return Err(MultiProofVerificationError::TooManySiblings);
     }
 
-    Ok(VerifiedMultiProof { inner: new_paths })
+    Ok(VerifiedMultiProof {
+        inner: verified_paths,
+        bisections: verified_bisections,
+        siblings: multi_proof.siblings.clone(),
+        root: root,
+    })
 }
 
 // returns the node made by verifying this range along with the number of siblings used.
@@ -434,10 +453,18 @@ fn verify_range<H: NodeHasher>(
     start_depth: usize,
     paths: &[MultiPathProof],
     siblings: &[Node],
+    sibling_offset: usize,
+    verified_paths: &mut Vec<VerifiedMultiPath>,
+    verified_bisections: &mut Vec<VerifiedBisection>,
 ) -> Result<(Node, usize), MultiProofVerificationError> {
     // the range should never be empty except in the first call, if the entire multi-proof is
     // empty.
     if paths.is_empty() {
+        verified_paths.push(VerifiedMultiPath {
+            terminal: PathProofTerminal::Terminator(crate::trie_pos::TriePosition::new()),
+            depth: 0,
+            unique_siblings: Range { start: 0, end: 0 },
+        });
         return Ok((TERMINATOR, 0));
     }
     if paths.len() == 1 {
@@ -451,6 +478,15 @@ fn verify_range<H: NodeHasher>(
             &terminal_path.terminal.path()[start_depth..start_depth + unique_len],
             siblings[..unique_len].iter().rev().copied(),
         );
+
+        verified_paths.push(VerifiedMultiPath {
+            terminal: terminal_path.terminal.clone(),
+            depth: terminal_path.depth,
+            unique_siblings: Range {
+                start: sibling_offset,
+                end: sibling_offset + unique_len,
+            },
+        });
 
         return Ok((node, unique_len));
     }
@@ -483,11 +519,24 @@ fn verify_range<H: NodeHasher>(
     // bisection is based off of them.
     let bisect_idx = search_result.unwrap_err();
 
+    if common_bits > 0 {
+        verified_bisections.push(VerifiedBisection {
+            start_depth,
+            common_siblings: Range {
+                start: sibling_offset,
+                end: sibling_offset + common_bits,
+            },
+        });
+    }
+
     // recurse into the left bisection.
     let (left_node, left_siblings_used) = verify_range::<H>(
         uncommon_start_len,
         &paths[..bisect_idx],
         &siblings[common_bits..],
+        sibling_offset + common_bits,
+        verified_paths,
+        verified_bisections,
     )?;
 
     // now that we know how many siblings were used on the left, we can recurse into the right.
@@ -495,6 +544,9 @@ fn verify_range<H: NodeHasher>(
         uncommon_start_len,
         &paths[bisect_idx..],
         &siblings[common_bits + left_siblings_used..],
+        sibling_offset + common_bits + left_siblings_used,
+        verified_paths,
+        verified_bisections,
     )?;
 
     let total_siblings_used = common_bits + left_siblings_used + right_siblings_used;
@@ -510,16 +562,354 @@ fn verify_range<H: NodeHasher>(
     Ok((node, total_siblings_used))
 }
 
+/// Errors that can occur when verifying an update against a [`VerifiedMultiProof`].
+#[derive(Debug, Clone, Copy)]
+pub enum MultiVerifyUpdateError {
+    /// The operations on the trie were provided out-of-order by [`KeyPath`].
+    OpsOutOfOrder,
+    /// An operation was out of scope for the [`VerifiedMultiProof`]
+    OpOutOfScope,
+    /// Paths were verified against different state-roots.
+    RootMismatch,
+    /// Two terminal paths were provided, where one is a prefix of another.
+    PathPrefixOfAnother,
+}
+
+fn terminal_contains(terminal: &VerifiedMultiPath, key_path: &KeyPath) -> bool {
+    key_path.view_bits::<Msb0>()[..terminal.depth] == terminal.terminal.path()[..terminal.depth]
+}
+
+// walks a multiproof left-to-right and keeps track of a stack of all siblings, based on
+// bisections.
+//
+// when this has ingested all paths up to and including X, the stack will represent all non-unique
+// siblings for X.
+#[derive(Debug)]
+struct CommonSiblings {
+    bisection_stack: Vec<VerifiedBisection>,
+    stack: Vec<(usize, Node)>,
+    taken_siblings: usize,
+    terminal_index: usize,
+    bisection_index: usize,
+}
+
+impl CommonSiblings {
+    fn new() -> Self {
+        CommonSiblings {
+            bisection_stack: Vec::new(),
+            stack: Vec::new(),
+            taken_siblings: 0,
+            terminal_index: 0,
+            bisection_index: 0,
+        }
+    }
+
+    fn advance(&mut self, proof: &VerifiedMultiProof) {
+        let next_terminal = &proof.inner[self.terminal_index];
+
+        let mut prune = true;
+        while next_terminal.unique_siblings.start != self.taken_siblings {
+            let next_bisection = &proof.bisections[self.bisection_index];
+            self.bisection_index += 1;
+
+            assert_eq!(next_bisection.common_siblings.start, self.taken_siblings);
+            if prune {
+                self.pop_to(next_bisection.start_depth);
+                prune = false;
+            }
+
+            // a bisection at depth N involves siblings starting at N+1
+            self.extend(
+                next_bisection.start_depth + 1,
+                next_bisection.common_siblings.end,
+                &proof.siblings,
+                false,
+            );
+            self.bisection_stack.push(next_bisection.clone());
+        }
+
+        let terminal_n = next_terminal.unique_siblings.end - next_terminal.unique_siblings.start;
+        self.extend(
+            next_terminal.depth - terminal_n + 1,
+            next_terminal.unique_siblings.end,
+            &proof.siblings,
+            true,
+        );
+        self.terminal_index += 1;
+    }
+
+    fn pop_to(&mut self, depth: usize) {
+        while self
+            .bisection_stack
+            .last()
+            .map_or(false, |b| b.start_depth >= depth)
+        {
+            let _ = self.bisection_stack.pop();
+        }
+
+        while self.stack.last().map_or(false, |(d, _)| *d >= depth) {
+            let _ = self.stack.pop();
+        }
+    }
+
+    fn extend(&mut self, start_depth: usize, end: usize, siblings: &[Node], reverse: bool) {
+        if reverse {
+            for (i, sibling) in siblings[self.taken_siblings..end].iter().rev().enumerate() {
+                self.stack.push((start_depth + i, *sibling))
+            }
+        } else {
+            for (i, sibling) in siblings[self.taken_siblings..end].iter().enumerate() {
+                self.stack.push((start_depth + i, *sibling))
+            }
+        }
+
+        self.taken_siblings = end;
+    }
+
+    fn pop_if_at_depth(&mut self, depth: usize) -> Option<Node> {
+        if self.stack.last().map_or(false, |(d, _)| *d == depth) {
+            self.stack.pop().map(|(_, n)| n)
+        } else {
+            None
+        }
+    }
+}
+
+/// Verify an update operation against a verified multi-proof. This follows a similar algorithm to
+/// the multi-item update, but without altering any backing storage.
+///
+/// `ops` should contain all updates to be processed. It should be sorted (ascending) by keypath,
+/// without duplicates.
+///
+/// All provided operations should have a key-path which is in scope for the multi proof.
+///
+/// Returns the root of the trie obtained after application of the given updates in the `paths`
+/// vector. In case the `paths` is empty, `prev_root` is returned.
+pub fn verify_update<H: NodeHasher>(
+    proof: &VerifiedMultiProof,
+    ops: Vec<(KeyPath, Option<ValueHash>)>,
+) -> Result<Node, MultiVerifyUpdateError> {
+    // left frontier
+    let mut pending_siblings: Vec<(Node, usize)> = Vec::new();
+
+    let mut last_key = None;
+    let mut last_terminal_index = None;
+    let mut next_pending_terminal_index = None;
+
+    let mut working_ops = Vec::new();
+
+    let mut common_siblings = CommonSiblings::new();
+    let ops_len = ops.len();
+
+    // chain with dummy item for handling the last batch.
+    for (i, (key, op)) in ops.into_iter().chain(Some(([0u8; 32], None))).enumerate() {
+        let is_last = i == ops_len;
+
+        if is_last {
+            let updated_terminal_index = last_terminal_index.unwrap_or(0);
+            let start = next_pending_terminal_index.unwrap_or(0);
+
+            // ingest all terminals from the next one needing an update to the end.
+            for terminal_index in start..proof.inner.len() {
+                let next = if terminal_index == proof.inner.len() - 1 {
+                    None
+                } else {
+                    Some(terminal_index + 1)
+                };
+
+                let terminal = &proof.inner[terminal_index];
+                let next_terminal = next.map(|n| &proof.inner[n]);
+
+                let ops = if terminal_index == updated_terminal_index {
+                    &working_ops[..]
+                } else {
+                    &[]
+                };
+
+                common_siblings.advance(&proof);
+                hash_and_compact_terminal::<H>(
+                    &mut pending_siblings,
+                    terminal,
+                    next_terminal,
+                    &mut common_siblings,
+                    ops,
+                )?;
+            }
+        } else {
+            // enforce key ordering.
+            if let Some(last_key) = last_key {
+                if key <= last_key {
+                    return Err(MultiVerifyUpdateError::OpsOutOfOrder);
+                }
+            }
+            last_key = Some(key);
+
+            // find terminal index for the operation, erroring if out of scope.
+            let mut next_terminal_index = last_terminal_index.unwrap_or(0);
+            if proof.inner.len() <= next_terminal_index {
+                return Err(MultiVerifyUpdateError::OpOutOfScope);
+            }
+
+            while !terminal_contains(&proof.inner[next_terminal_index], &key) {
+                next_terminal_index += 1;
+                if proof.inner.len() <= next_terminal_index {
+                    return Err(MultiVerifyUpdateError::OpOutOfScope);
+                }
+            }
+
+            // if this is either the first op or this has the same terminal as the previous op...
+            if last_terminal_index.map_or(true, |x| x == next_terminal_index) {
+                last_terminal_index = Some(next_terminal_index);
+                working_ops.push((key, op));
+                continue;
+            }
+
+            // UNWRAP: guaranteed by above.
+            let updated_index = last_terminal_index.unwrap();
+            last_terminal_index = Some(next_terminal_index);
+
+            // ingest all terminals up to current.
+            let start = next_pending_terminal_index.unwrap_or(0);
+
+            for terminal_index in start..updated_index {
+                let terminal = &proof.inner[terminal_index];
+                let next_terminal = Some(&proof.inner[terminal_index + 1]);
+
+                common_siblings.advance(&proof);
+                hash_and_compact_terminal::<H>(
+                    &mut pending_siblings,
+                    terminal,
+                    next_terminal,
+                    &mut common_siblings,
+                    &[],
+                )?;
+            }
+
+            // ingest the currently updated terminal.
+            let ops = core::mem::replace(&mut working_ops, Vec::new());
+            working_ops.push((key, op));
+
+            let terminal = &proof.inner[updated_index];
+            let next_terminal = proof.inner.get(updated_index + 1);
+            common_siblings.advance(&proof);
+
+            hash_and_compact_terminal::<H>(
+                &mut pending_siblings,
+                terminal,
+                next_terminal,
+                &mut common_siblings,
+                &ops,
+            )?;
+
+            next_pending_terminal_index = Some(updated_index + 1);
+        };
+    }
+
+    // UNWRAP: This is always full unless the update is empty
+    Ok(pending_siblings.pop().map(|n| n.0).unwrap_or(proof.root))
+}
+
+fn hash_and_compact_terminal<H: NodeHasher>(
+    pending_siblings: &mut Vec<(Node, usize)>,
+    terminal: &VerifiedMultiPath,
+    next_terminal: Option<&VerifiedMultiPath>,
+    common_siblings: &mut CommonSiblings,
+    ops: &[(KeyPath, Option<ValueHash>)],
+) -> Result<(), MultiVerifyUpdateError> {
+    let leaf = terminal.terminal.as_leaf_option();
+    let skip = terminal.depth;
+
+    let up_layers = if let Some(next_terminal) = next_terminal {
+        let n = shared_bits(terminal.terminal.path(), next_terminal.terminal.path());
+
+        // SANITY: this is impossible in a well-formed input but we catch it as an error.
+        // The reason this is impossible is because no terminal should be a prefix of another
+        // terminal (by definition)
+        if n == skip {
+            return Err(MultiVerifyUpdateError::PathPrefixOfAnother);
+        }
+
+        // n always < skip
+        // we want to end at layer n + 1
+        skip - (n + 1)
+    } else {
+        skip // go to root
+    };
+
+    let ops = crate::update::leaf_ops_spliced(leaf, &ops);
+    let sub_root = crate::update::build_trie::<H>(skip, ops, |_| {});
+
+    let mut cur_node = sub_root;
+    let mut cur_layer = skip;
+    let end_layer = skip - up_layers;
+
+    // iterate siblings up to the point of collision with next path, replacing with pending
+    // siblings, and compacting where possible.
+    // push (node, end_layer) to pending siblings when done.
+    for bit in terminal.terminal.path()[..terminal.depth]
+        .iter()
+        .by_vals()
+        .rev()
+        .take(up_layers)
+    {
+        let sibling = if pending_siblings.last().map_or(false, |p| p.1 == cur_layer) {
+            // is this even possible? maybe not. but being extra cautious...
+            let _ = common_siblings.pop_if_at_depth(cur_layer);
+            // UNWRAP: guaranteed to exist.
+            pending_siblings.pop().unwrap().0
+        } else {
+            // UNWRAP: `common_siblings` holds everything which isn't computed dynamically from branch
+            // to branch. basically, it's the inverse of `pending_siblings`. so if the sibling isn't
+            // in pending_siblings, it's in here.
+            common_siblings.pop_if_at_depth(cur_layer).unwrap()
+        };
+
+        match (NodeKind::of::<H>(&cur_node), NodeKind::of::<H>(&sibling)) {
+            (NodeKind::Terminator, NodeKind::Terminator) => {}
+            (NodeKind::Leaf, NodeKind::Terminator) => {}
+            (NodeKind::Terminator, NodeKind::Leaf) => {
+                // relocate sibling upwards.
+                cur_node = sibling;
+            }
+            _ => {
+                // otherwise, internal
+                let node_data = if bit {
+                    InternalData {
+                        left: sibling,
+                        right: cur_node,
+                    }
+                } else {
+                    InternalData {
+                        left: cur_node,
+                        right: sibling,
+                    }
+                };
+                cur_node = H::hash_internal(&node_data);
+            }
+        }
+
+        cur_layer -= 1;
+    }
+
+    pending_siblings.push((cur_node, end_layer));
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{verify, MultiProof};
+    use super::{verify, verify_update, MultiProof};
 
+    use crate::proof::multi_proof::{
+        MultiVerifyUpdateError, VerifiedMultiPath, VerifiedMultiProof,
+    };
     use crate::{
         hasher::{Blake3Hasher, NodeHasher},
         proof::{PathProof, PathProofTerminal},
-        trie::{InternalData, LeafData, TERMINATOR},
+        trie::{InternalData, KeyPath, LeafData, ValueHash, TERMINATOR},
         trie_pos::TriePosition,
+        update::build_trie,
     };
+    use bitvec::prelude::*;
 
     #[test]
     pub fn test_multiproof_creation_single_path_proof() {
@@ -911,6 +1301,51 @@ mod tests {
     }
 
     #[test]
+    fn multi_proof_verify_empty() {
+        let multi_proof = MultiProof::from_path_proofs(Vec::new());
+
+        let verified_multi_proof = verify::<Blake3Hasher>(&multi_proof, TERMINATOR).unwrap();
+
+        assert_eq!(
+            verify_update::<Blake3Hasher>(&verified_multi_proof, Vec::new()).unwrap(),
+            TERMINATOR,
+        );
+    }
+
+    #[test]
+    fn multi_proof_verify_empty_with_provided_updates() {
+        let multi_proof = MultiProof::from_path_proofs(Vec::new());
+
+        let verified_multi_proof = verify::<Blake3Hasher>(&multi_proof, TERMINATOR).unwrap();
+
+        let mut key_path_0 = [0; 32];
+        key_path_0[0] = 0b00001000;
+
+        let mut key_path_1 = [0; 32];
+        key_path_1[0] = 0b00010000;
+
+        let mut key_path_2 = [0; 32];
+        key_path_2[0] = 0b10000000;
+
+        let ops = vec![
+            (key_path_0, Some([1; 32])),
+            (key_path_1, Some([1; 32])),
+            (key_path_2, Some([1; 32])),
+        ];
+
+        let expected_root = build_trie::<Blake3Hasher>(
+            0,
+            ops.clone().into_iter().map(|(k, v)| (k, v.unwrap())),
+            |_| {},
+        );
+
+        assert_eq!(
+            verify_update::<Blake3Hasher>(&verified_multi_proof, ops).unwrap(),
+            expected_root,
+        );
+    }
+
+    #[test]
     pub fn test_verify_multiproof_two_leafs() {
         //     root
         //     /  \
@@ -971,6 +1406,212 @@ mod tests {
 
         assert!(verified.confirm_value(&leaf_0).unwrap());
         assert!(verified.confirm_value(&leaf_1).unwrap());
+    }
+
+    #[test]
+    fn multi_proof_verify_2_leaves_with_provided_updates() {
+        //     root
+        //     /  \
+        //    s3   v1
+        //   / \
+        //  v0  v2
+
+        let mut key_path_0 = [0; 32];
+        key_path_0[0] = 0b00000000;
+
+        let mut key_path_1 = [0; 32];
+        key_path_1[0] = 0b10000000;
+
+        let mut key_path_2 = [0; 32];
+        key_path_2[0] = 0b01000000;
+
+        let leaf_0 = LeafData {
+            key_path: key_path_0,
+            value_hash: [0; 32],
+        };
+
+        let leaf_1 = LeafData {
+            key_path: key_path_1,
+            value_hash: [1; 32],
+        };
+
+        let leaf_2 = LeafData {
+            key_path: key_path_2,
+            value_hash: [2; 32],
+        };
+
+        // this is the
+        let v0 = Blake3Hasher::hash_leaf(&leaf_0);
+        let v1 = Blake3Hasher::hash_leaf(&leaf_1);
+        let v2 = Blake3Hasher::hash_leaf(&leaf_2);
+        let s3 = Blake3Hasher::hash_internal(&InternalData {
+            left: v0.clone(),
+            right: v2,
+        });
+        let root = Blake3Hasher::hash_internal(&InternalData {
+            left: s3,
+            right: v1,
+        });
+
+        let path_proof_0 = PathProof {
+            terminal: PathProofTerminal::Leaf(leaf_0.clone()),
+            siblings: vec![v1, v2],
+        };
+        let path_proof_1 = PathProof {
+            terminal: PathProofTerminal::Leaf(leaf_1.clone()),
+            siblings: vec![s3],
+        };
+
+        let multi_proof =
+            MultiProof::from_path_proofs(vec![path_proof_0.clone(), path_proof_1.clone()]);
+
+        let verified = verify::<Blake3Hasher>(&multi_proof, root).unwrap();
+
+        let mut key_path_3 = key_path_1;
+        key_path_3[0] = 0b10100000;
+
+        let mut key_path_4 = key_path_0;
+        key_path_4[0] = 0b00000100;
+
+        let ops = vec![
+            (key_path_0, Some([2; 32])),
+            (key_path_4, Some([1; 32])),
+            (key_path_1, None),
+            (key_path_3, Some([1; 32])),
+        ];
+
+        let final_state = vec![
+            (key_path_0, [2; 32]),
+            (key_path_4, [1; 32]),
+            (key_path_2, [2; 32]),
+            (key_path_3, [1; 32]),
+        ];
+
+        let expected_root = build_trie::<Blake3Hasher>(0, final_state, |_| {});
+
+        assert_eq!(
+            verify_update::<Blake3Hasher>(&verified, ops).unwrap(),
+            expected_root,
+        );
+    }
+
+    #[test]
+    fn multi_proof_verify_4_leaves_with_long_bisections() {
+        //              R
+        //              i1
+        //              i2
+        //              i3
+        //              i4
+        //           i5a    i5a
+        //           i6a    i6b
+        //           i7a    i7b
+        //         l8a l8b l8c l8d
+
+        let make_leaf = |key_path, value_byte| {
+            let leaf_data = LeafData {
+                key_path,
+                value_hash: [value_byte; 32],
+            };
+
+            let hash = Blake3Hasher::hash_leaf(&leaf_data);
+            (leaf_data, hash)
+        };
+        let internal_hash =
+            |left, right| Blake3Hasher::hash_internal(&InternalData { left, right });
+
+        let mut key_path_0 = [0; 32];
+        key_path_0[0] = 0b00000000;
+
+        let mut key_path_1 = [0; 32];
+        key_path_1[0] = 0b00000001;
+
+        let mut key_path_2 = [0; 32];
+        key_path_2[0] = 0b00001000;
+
+        let mut key_path_3 = [0; 32];
+        key_path_3[0] = 0b00001001;
+
+        let (leaf_a, l8a) = make_leaf(key_path_0, 1);
+        let (leaf_b, l8b) = make_leaf(key_path_1, 1);
+        let (leaf_c, l8c) = make_leaf(key_path_2, 1);
+        let (leaf_d, l8d) = make_leaf(key_path_3, 1);
+
+        let i7a = internal_hash(l8a, l8b);
+        let i7b = internal_hash(l8c, l8d);
+
+        let i6a = internal_hash(i7a, [7; 32]);
+        let i6b = internal_hash(i7b, [7; 32]);
+
+        let i5a = internal_hash(i6a, [6; 32]);
+        let i5b = internal_hash(i6b, [6; 32]);
+
+        let i4 = internal_hash(i5a, i5b);
+        let i3 = internal_hash(i4, [4; 32]);
+        let i2 = internal_hash(i3, [3; 32]);
+        let i1 = internal_hash(i2, [2; 32]);
+        let root = internal_hash(i1, [1; 32]);
+
+        let path_proof_a = PathProof {
+            terminal: PathProofTerminal::Leaf(leaf_a.clone()),
+            siblings: vec![
+                [1; 32], [2; 32], [3; 32], [4; 32], i5b, [6; 32], [7; 32], l8b,
+            ],
+        };
+        let path_proof_b = PathProof {
+            terminal: PathProofTerminal::Leaf(leaf_b.clone()),
+            siblings: vec![
+                [1; 32], [2; 32], [3; 32], [4; 32], i5b, [6; 32], [7; 32], l8a,
+            ],
+        };
+        let path_proof_c = PathProof {
+            terminal: PathProofTerminal::Leaf(leaf_c.clone()),
+            siblings: vec![
+                [1; 32], [2; 32], [3; 32], [4; 32], i5a, [6; 32], [7; 32], l8d,
+            ],
+        };
+        let path_proof_d = PathProof {
+            terminal: PathProofTerminal::Leaf(leaf_d.clone()),
+            siblings: vec![
+                [1; 32], [2; 32], [3; 32], [4; 32], i5a, [6; 32], [7; 32], l8c,
+            ],
+        };
+
+        let multi_proof = MultiProof::from_path_proofs(vec![
+            path_proof_a.clone(),
+            path_proof_b.clone(),
+            path_proof_c.clone(),
+            path_proof_d.clone(),
+        ]);
+
+        let verified = verify::<Blake3Hasher>(&multi_proof, root).unwrap();
+
+        let ops = vec![(key_path_0, Some([69; 32])), (key_path_3, Some([69; 32]))];
+
+        let (_, l8a) = make_leaf(key_path_0, 69);
+        let (_, l8b) = make_leaf(key_path_1, 1);
+        let (_, l8c) = make_leaf(key_path_2, 1);
+        let (_, l8d) = make_leaf(key_path_3, 69);
+
+        let i7a = internal_hash(l8a, l8b);
+        let i7b = internal_hash(l8c, l8d);
+
+        let i6a = internal_hash(i7a, [7; 32]);
+        let i6b = internal_hash(i7b, [7; 32]);
+
+        let i5a = internal_hash(i6a, [6; 32]);
+        let i5b = internal_hash(i6b, [6; 32]);
+
+        let i4 = internal_hash(i5a, i5b);
+
+        let i3 = internal_hash(i4, [4; 32]);
+        let i2 = internal_hash(i3, [3; 32]);
+        let i1 = internal_hash(i2, [2; 32]);
+        let post_root = internal_hash(i1, [1; 32]);
+
+        assert_eq!(
+            verify_update::<Blake3Hasher>(&verified, ops).unwrap(),
+            post_root,
+        );
     }
 
     #[test]
@@ -1146,5 +1787,105 @@ mod tests {
         assert!(verified.confirm_value(&l2).unwrap());
         assert!(verified.confirm_value(&l3).unwrap());
         assert!(verified.confirm_value(&l4).unwrap());
+    }
+
+    #[test]
+
+    fn test_verify_update_underflow_prefix_paths() {
+        // 1. Define paths with prefix relationship
+        let bits_prefix = bitvec![u8, Msb0; 1, 0, 1, 0]; // length 4
+        let bits_longer = bitvec![u8, Msb0; 1, 0, 1, 0, 1, 1]; // length 6 (prefix + 2 bits)
+
+        // Helper to create KeyPath from BitVec (simplified, assumes short paths)
+        let keypath_from_bits = |bits: &BitSlice<u8, Msb0>| -> KeyPath {
+            let mut kp = KeyPath::default();
+
+            for (i, bit) in bits.iter().by_vals().enumerate() {
+                if i >= 256 {
+                    break;
+                }
+
+                if bit {
+                    kp[i / 8] |= 1 << (7 - (i % 8));
+                }
+            }
+
+            kp
+        };
+
+        let kp_prefix = keypath_from_bits(&bits_prefix);
+        let kp_longer = keypath_from_bits(&bits_longer);
+
+        // 2. Create corresponding LeafData and Nodes
+        let leaf_prefix = LeafData {
+            key_path: kp_prefix,
+            value_hash: [1; 32],
+        };
+
+        let leaf_longer = LeafData {
+            key_path: kp_longer,
+            value_hash: [2; 32],
+        };
+
+        let node_prefix = Blake3Hasher::hash_leaf(&leaf_prefix);
+        let node_longer = Blake3Hasher::hash_leaf(&leaf_longer);
+
+        // 3. Construct the VerifiedMultiProof
+        let vmp_prefix = VerifiedMultiPath {
+            terminal: PathProofTerminal::Leaf(leaf_prefix.clone()),
+            depth: bits_prefix.len(),
+            unique_siblings: 0..0, // Minimal example
+        };
+
+        let vmp_longer = VerifiedMultiPath {
+            terminal: PathProofTerminal::Leaf(leaf_longer.clone()),
+            depth: bits_longer.len(),
+            unique_siblings: 0..0, // Minimal example
+        };
+
+        // Create a plausible root for the test setup.
+        // For the purpose of triggering the bug, the exact root structure isn't critical,
+        // as long as the VerifiedMultiProof structure is valid and contains the prefix paths.
+        let plausible_root = Blake3Hasher::hash_internal(&InternalData {
+            left: node_prefix,
+            right: node_longer,
+        });
+
+        let verified_proof = VerifiedMultiProof {
+            inner: vec![vmp_prefix, vmp_longer],
+
+            bisections: Vec::new(), // Minimal example
+
+            siblings: Vec::new(), // Minimal example
+
+            root: plausible_root,
+        };
+
+        // 4. Create operations falling under each path
+        let mut key_op1_bits = bits_prefix.clone();
+
+        key_op1_bits.push(false); // e.g., 10100 (falls under 1010)
+
+        let key_op1 = keypath_from_bits(&key_op1_bits);
+
+        let mut key_op2_bits = bits_longer.clone();
+
+        key_op2_bits.push(true); // e.g., 1010111 (falls under 101011)
+
+        let key_op2 = keypath_from_bits(&key_op2_bits);
+
+        let ops = vec![
+            (key_op1, Some(ValueHash::default())), // Op under prefix path
+            (key_op2, Some(ValueHash::default())), // Op under longer path
+        ];
+
+        // Ensure ops are sorted (should be by construction here)
+        assert!(ops[0].0 < ops[1].0);
+
+        // This should trigger the error.
+        match verify_update::<Blake3Hasher>(&verified_proof, ops).unwrap_err() {
+            MultiVerifyUpdateError::PathPrefixOfAnother => (),
+            _ => panic!(),
+        }
     }
 }

--- a/core/src/proof/path_proof.rs
+++ b/core/src/proof/path_proof.rs
@@ -38,6 +38,14 @@ impl PathProofTerminal {
             Self::Terminator(_key_path) => TERMINATOR,
         }
     }
+
+    /// Transform this into an optional LeafData.
+    pub fn as_leaf_option(&self) -> Option<LeafData> {
+        match self {
+            Self::Leaf(leaf_data) => Some(leaf_data.clone()),
+            Self::Terminator(_) => None,
+        }
+    }
 }
 
 /// A proof of some particular path through the trie.

--- a/core/src/update.rs
+++ b/core/src/update.rs
@@ -212,6 +212,7 @@ pub fn build_trie<H: NodeHasher>(
             .take(hash_up_layers)
         {
             layer -= 1;
+
             let sibling = if pending_siblings.last().map_or(false, |l| l.1 == layer + 1) {
                 // unwrap: just checked
                 pending_siblings.pop().unwrap().0


### PR DESCRIPTION
This turned out more involved than I expected.

The `VerifiedMultiProof` has been extended with a `Vec<VerifiedBisection>` that keeps tracks of all the bisections and upper sibling ranges. This is used to recover all needed siblings.

The core of this operates quite similarly to the existing `verify_update`:
  1. loop through all terminals (ascending)
  2. apply any needed changes to terminals based on `ops` as we go
  
most of the complexity is in gathering the necessary siblings and making sure they are available. for that I've introduced a helper struct `CommonSiblings`.
  
I added a few tests, including one which explicitly loads the bisection logic.
  
Runtime is linear in the number of multiproofs, assuming an average depth per branch. 

This algorithm, as written, does reproduce some of the work from `verify_update`.