### PR TITLE
Fix rollback deadlock caused by occupying all threads

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -478,6 +478,8 @@ pub struct Session<T> {
     rollback_delta: Option<rollback::ReverseDeltaBuilder>,
     overlay: LiveOverlay,
     witness_mode: WitnessMode,
+    // Note: this needs to be after rollback_delta and merkle_updater in declaration order,
+    // so this is dropped after all read transactions are taken, even when the session is dropped.
     access_guard: Option<ArcRwLockReadGuard<parking_lot::RawRwLock, ()>>,
     prev_root: Root,
     _marker: std::marker::PhantomData<T>,


### PR DESCRIPTION
Rollback delta workers each require 2 paired tasks ("run" and "completions") to run on a threadpool which has only 2 threads. Both tasks must be run to prevent deadlock.

When there were multiple sessions (>2), it was possible for the threadpool to fill up and stall such that there were only unpaired "run" and "completions" tasks, which would then never finished.

My fix here is to rewrite the code so we don't need a second task, but run it all on one task.
I also force them to join when dropped.

Still, the behavior isn't ideal when there are many threads running sessions concurrently. I'd recommend increasing the thread-pool size. This shouldn't lead to deadlocks, but maybe suboptimal performance or weird scheduling artifacts.
