### PR TITLE
feat: add Session::prove utility for proving in-session rh-prove-in-session

### DIFF
--- a/nomt/src/lib.rs
+++ b/nomt/src/lib.rs
@@ -548,6 +548,16 @@ impl<T> Session<T> {
 }
 
 impl<T: HashAlgorithm> Session<T> {
+    /// Get a merkle proof for the given key path.
+    ///
+    /// This will block until the proof is fetched from the database.
+    /// Note that this may require multiple round trips to the database to complete.
+    ///
+    /// Fails only if I/O fails. Proves either the existence or non-existence of the key.
+    pub fn prove(&self, path: KeyPath) -> anyhow::Result<PathProof> {
+        Ok(self.merkle_updater.prove::<T>(path)?)
+    }
+
     /// Finish the session. Provide the actual reads and writes (in sorted order) that are to be
     /// considered within the finished session.
     ///

--- a/nomt/tests/common/mod.rs
+++ b/nomt/tests/common/mod.rs
@@ -3,6 +3,7 @@ use nomt::{
     KeyReadWrite, Nomt, Options, Overlay, PanicOnSyncMode, Root, Session, SessionParams, Witness,
     WitnessMode,
 };
+use nomt_core::proof::PathProof;
 use std::{
     collections::{hash_map::Entry, HashMap},
     mem,
@@ -167,6 +168,14 @@ impl Test {
             .overlay(ancestors)
             .unwrap();
         self.session = Some(self.nomt.begin_session(params));
+    }
+
+    pub fn prove(&self, key: KeyPath) -> PathProof {
+        self.session.as_ref().unwrap().prove(key).unwrap()
+    }
+
+    pub fn prove_id(&self, id: u64) -> PathProof {
+        self.prove(account_path(id))
     }
 
     pub fn root(&self) -> Root {

--- a/nomt/tests/prove_in_session.rs
+++ b/nomt/tests/prove_in_session.rs
@@ -1,0 +1,137 @@
+mod common;
+
+use bitvec::prelude::*;
+use common::Test;
+use nomt_core::trie::LeafData;
+
+#[test]
+fn prove_in_session() {
+    let mut accounts = 0;
+    let mut t = Test::new("prove_in_session");
+
+    let _ = t.read_id(0);
+    for _ in 0..100 {
+        common::set_balance(&mut t, accounts, 1000);
+        accounts += 1;
+    }
+    let root = t.commit().0.into_inner();
+
+    for i in 0..100 {
+        let k = common::account_path(i);
+
+        let proof = t.prove_id(i);
+        let expected_leaf = LeafData {
+            key_path: k,
+            value_hash: proof.terminal.as_leaf_option().unwrap().value_hash,
+        };
+        assert!(proof
+            .verify::<nomt::hasher::Blake3Hasher>(k.view_bits::<Msb0>(), root)
+            .expect("verification failed")
+            .confirm_value(&expected_leaf)
+            .unwrap());
+    }
+
+    for i in 100..150 {
+        let k = common::account_path(i);
+        let proof = t.prove_id(i);
+        assert!(proof
+            .verify::<nomt::hasher::Blake3Hasher>(k.view_bits::<Msb0>(), root)
+            .expect("verification failed")
+            .confirm_nonexistence(&k)
+            .unwrap());
+    }
+}
+
+#[test]
+fn prove_in_session_against_overlay() {
+    let mut accounts = 0;
+    let mut t = Test::new("prove_in_session_against_overlay");
+
+    let _ = t.read_id(0);
+    for _ in 0..100 {
+        common::set_balance(&mut t, accounts, 1000);
+        accounts += 1;
+    }
+    let (overlay_a, _) = t.update();
+    let root = overlay_a.root().into_inner();
+    t.start_overlay_session(&[overlay_a]);
+
+    for i in 0..100 {
+        let k = common::account_path(i);
+
+        let proof = t.prove_id(i);
+        let expected_leaf = LeafData {
+            key_path: k,
+            value_hash: proof.terminal.as_leaf_option().unwrap().value_hash,
+        };
+        assert!(proof
+            .verify::<nomt::hasher::Blake3Hasher>(k.view_bits::<Msb0>(), root)
+            .expect("verification failed")
+            .confirm_value(&expected_leaf)
+            .unwrap());
+    }
+
+    for i in 100..150 {
+        let k = common::account_path(i);
+        let proof = t.prove_id(i);
+        assert!(proof
+            .verify::<nomt::hasher::Blake3Hasher>(k.view_bits::<Msb0>(), root)
+            .expect("verification failed")
+            .confirm_nonexistence(&k)
+            .unwrap());
+    }
+}
+
+#[test]
+fn prove_in_session_no_cache() {
+    let mut accounts = 0;
+
+    {
+        let mut t = Test::new("prove_in_session_no_cache");
+
+        let _ = t.read_id(0);
+
+        // Write 5000 accounts to ensure a few I/Os will be needed to read the proofs.
+        for _ in 0..5000 {
+            common::set_balance(&mut t, accounts, 1000);
+            accounts += 1;
+        }
+        t.commit().0.into_inner();
+    }
+
+    // Reopen the DB to clear the cache.
+    let t = Test::new_with_params(
+        "prove_in_session_no_cache",
+        1,      // commit concurrency
+        10_000, // hashtable buckets
+        None,   // panic on sync
+        false,  // cleanup dir
+    );
+
+    let root = t.root().into_inner();
+
+    for i in 0..100 {
+        let k = common::account_path(i);
+
+        let proof = t.prove_id(i);
+        let expected_leaf = LeafData {
+            key_path: k,
+            value_hash: proof.terminal.as_leaf_option().unwrap().value_hash,
+        };
+        assert!(proof
+            .verify::<nomt::hasher::Blake3Hasher>(k.view_bits::<Msb0>(), root)
+            .expect("verification failed")
+            .confirm_value(&expected_leaf)
+            .unwrap());
+    }
+
+    for i in 10000..10050 {
+        let k = common::account_path(i);
+        let proof = t.prove_id(i);
+        assert!(proof
+            .verify::<nomt::hasher::Blake3Hasher>(k.view_bits::<Msb0>(), root)
+            .expect("verification failed")
+            .confirm_nonexistence(&k)
+            .unwrap());
+    }
+}


### PR DESCRIPTION
Closes #903 
Closes #705

This adds a `Session::prove` function which generates a merkle proof for the given key-path while in a session. 

This blocks.

Supports overlays and page elision natively.

There will be no way to get a proof outside of a session - just create a session and drop it afterwards in e.g. RPCs.
